### PR TITLE
test(cli): cover fix-plan repair safety metadata

### DIFF
--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -187,6 +187,32 @@ describe("native zero CLI", () => {
     }
   });
 
+  it("reports fix-plan repair safety metadata without applying edits", async () => {
+    const plan = JSON.parse((await runZero(["fix", "--plan", "--json", "examples/agent-repair-demo/broken.0"])).stdout);
+
+    assert.equal(plan.schemaVersion, 1);
+    assert.equal(plan.mode, "plan");
+    assert.equal(plan.appliesEdits, false);
+    assert.deepEqual(plan.safetyLevels, [
+      "format-only",
+      "behavior-preserving",
+      "api-changing",
+      "target-changing",
+      "requires-human-review",
+    ]);
+
+    const diagnostic = plan.diagnostics[0];
+    assert.equal(diagnostic.code, "TYP009");
+    assert.equal(diagnostic.fixSafety, "behavior-preserving");
+    assert.equal(diagnostic.repair.id, "make-binding-mutable");
+
+    const fix = plan.fixes[0];
+    assert.equal(fix.diagnosticCode, "TYP009");
+    assert.equal(fix.safety, "behavior-preserving");
+    assert.equal(fix.id, "make-binding-mutable");
+    assert.equal(fix.appliesEdits, false);
+  });
+
   it("emits native diagnostic codes", async () => {
     const result = await runZero(["check", "conformance/native/fail/unknown-field.0"]).catch((error) => error);
     assert.notEqual(result.code, 0);


### PR DESCRIPTION
## Summary
- add CLI coverage for fix-plan safety metadata
- assert the plan remains non-applying while preserving repair id and safety fields
- cover the agent-facing TYP009 repair contract

## Validation
- npm run build:test --silent
- node --test .zero/test-js/*.test.js *(fails on two existing executable-run tests in this macOS environment: dyld missing LC_UUID; new fix-plan test passes)*
- git diff --check