### PR TITLE
test(cli): cover target capability facts

### DIFF
--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -129,6 +129,22 @@ describe("native zero CLI", () => {
     );
     assert.equal(targets.targets.find((target: { name: string }) => target.name === "linux-musl-x64")?.compilerTarget, "x86_64-linux-musl");
     assert.equal(targets.targets.find((target: { name: string }) => target.name === "win32-x64.exe")?.exeSuffix, ".exe");
+
+    const hostTarget = targets.targets.find((target: { name: string }) => target.name === targets.host);
+    assert.ok(hostTarget, "host target should be in the target table");
+    for (const capability of ["memory", "stdio", "args", "env", "fs", "net", "proc", "time", "rand"]) {
+      assert.ok(hostTarget.capabilities.includes(capability), `host target should expose ${capability}`);
+      assert.equal(
+        hostTarget.capabilityFacts.find((fact: { name: string }) => fact.name === capability)?.available,
+        true,
+        `${capability} should have an available capability fact`,
+      );
+    }
+    assert.equal(
+      hostTarget.capabilityFacts.find((fact: { name: string }) => fact.name === "web")?.available,
+      false,
+      "host target should report web as unavailable",
+    );
   });
 
   it("lists and retrieves bundled skills", async () => {


### PR DESCRIPTION
## Summary
- add CLI coverage for host target capability facts in `zero targets`
- assert host capabilities include the hosted process/runtime surface
- assert unavailable capabilities still appear in `capabilityFacts` with `available: false`

## Validation
- `npm run build:test --silent`
- `node --test .zero/test-js/*.test.js` *(fails on two existing executable-run tests in this macOS environment: dyld missing LC_UUID; updated targets test passes)*
- `git diff --check`
