### PR TITLE
feat: zero fmt --write and --check --json envelope

### DIFF
--- a/docs-site/articles/cli-reference.md
+++ b/docs-site/articles/cli-reference.md
@@ -1,0 +1,37 @@
+## CLI Reference
+
+`zero` is the product shell for checking, formatting, building, testing, inspecting, and repairing Zero projects.
+
+Core commands:
+
+```sh
+zero --version [--json]
+zero skills [list|get|path] [--json]
+zero new cli|lib|package <path>
+zero doctor [--json]
+zero check [--json] [--target <target>] <input>
+zero dev [--json] [--trace] [--target <target>] <input>
+zero build [--emit exe|obj|wasm] [--target <target>] [--profile dev|release] [--out <file>] <input>
+zero ship [--json] [--target <target>] [--profile release-small|tiny|audit] [--out <file>] <input>
+zero test [--json] [--filter <name>] [--target <target>] [--cc <path>] [--out <file>] <input>
+zero fmt [--check | --write] [--json] <input>
+zero graph [--json] [--target <target>] <input>
+zero doc [--json] [--target <target>] <input>
+zero size [--json] [--target <target>] [--out <artifact>] <input>
+zero explain [--json] <diagnostic-code>
+zero fix --plan --json [--target <target>] <input>
+zero targets
+zero clean [--all]
+```
+
+`<input>` may be a `.0` source file, a package directory, or a `zero.json` manifest. JSON modes are stable enough for agents and tests. `zero check --json` and `zero graph --json` include `compileTime` for deterministic bounded `meta` evaluation, sandbox denials, cache key inputs, typed reflection facts, integer/Bool/enum static values, and limited typed builder metadata. `zero dev --json --trace` emits the current watch plan, source/manifest/package-lock/generated-binding inputs, affected checks/tests/examples, restart behavior for runnable CLI targets, interface fingerprints, cache hit/miss facts, phase timing, and diagnostics passthrough metadata. `zero time --json` reports the same `interfaceFingerprints` and `incrementalInvalidation` cache facts for editor and CI timing audits. `zero build --json` includes a `toolchain` object with the selected compiler, selection source, target triple, linker flavor, and sysroot status. Build and ship JSON also expose `releaseTargetContract`, which records the artifact kind, object format, direct linker flavor, target libc mode, sysroot requirement/status, emitter readiness, target capability facts, and repeat-build hash policy. `zero ship --json` produces a release preview with the binary, stripped binary copy, checksum file, deterministic archive manifest, debug-symbol metadata, size report, SBOM placeholder, artifact names, sizes, hashes, target facts, and the same `releaseTargetContract` nested under `releasePreview.targetContract`. Use `--emit wasm` for WebAssembly artifacts and `--emit obj` for native objects. Removed backend flags report `BLD003`. `zero doctor --json` includes checks for the host target, PATH health, target SDK/sysroot readiness, workspace writes, bundled targets, docs, examples, and a `targetToolchains` array with per-target readiness facts. `zero fix` is plan-only and does not apply edits.
+
+`zero fmt --check` exits non-zero when the input would be reformatted, matching the shape of `gofmt -l` and `rustfmt --check`. `zero fmt --write` overwrites the source file in place. Both modes accept `--json` for a structured envelope: `{ "schemaVersion": 1, "command": "fmt", "mode": "check"|"write", "sourceFile": path, "ok": bool, "unformatted"|"written": [paths] }`. `--check` and `--write` are mutually exclusive; bare `zero fmt` continues to print formatted output to stdout.
+
+`zero skills` serves bundled skill content for agents. Use `zero skills list` to discover available skills, `zero skills get zero` to print the current Zero workflow, `zero skills get zero --full` to include references and templates, and `zero skills path zero` to print the local skill directory. `--json` returns `{ "success": true, "data": ... }` payloads for automation. Set `ZERO_SKILLS_DIR` to point the command at an alternate skill directory.
+
+`zero test --json` reports package and fixture discovery for CI and editor integrations. The payload includes `testDiscovery`, `fixtures`, `targetFacts`, `results`, `discoveredTests`, `selectedTests`, `passedTests`, `failedTests`, `expectedFailures`, `unexpectedPasses`, `durationMs`, `stdout`, and `stderr`. `fixtures.snapshotKey` identifies the test snapshot contract, and each result includes a source location plus a failure span when available. Expected-fail tests use `xfail:`, `expected fail:`, or `[xfail]` in the test name; an unexpected pass fails the command.
+
+Profile-aware build and size JSON include `profileSemantics`, `profileCatalog`, and `profileBudget` for `debug`, `fast`, `small`, and `tiny`. `zero size --json` also emits `sizeBreakdown`, `retentionReasons`, and `optimizationHints` so optimization agents can explain retained functions, sections, literals, stdlib helpers, imports, runtime shims, and debug metadata.
+
+`npm run zls -- --self-test` exercises the language-server smoke path: diagnostics, hover docs with target/capability/generated-binding facts, completions, go-to definition, document symbols, and quick-fix code actions surfaced from `zero fix` for `TAR002`, `TYP009`, `ERR002`, `ERR003`, and `PUB001`.

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -130,6 +130,7 @@ typedef struct {
   bool patch;
   bool all;
   bool fmt_check;
+  bool fmt_write;
   bool legacy_backend;
   bool trace;
   bool graph_patch_command;
@@ -4785,6 +4786,24 @@ static bool cli_arg_is(const char *arg, const char *expected) {
   return strcmp(arg ? arg : "", expected) == 0;
 }
 
+static void print_help_with_fmt_modes(void) {
+  z_cli_print_help();
+  printf("\nFormatting modes:\n");
+  printf("  zero fmt [--check | --write] [--json] <file.0|project|zero.toml|zero.json>\n");
+}
+
+static void print_command_help_with_fmt_modes(const char *command) {
+  if (!cli_arg_is(command, "fmt")) {
+    z_cli_print_command_help(command);
+    return;
+  }
+  printf("Usage: zero fmt [--check | --write] [--json] <file.0|project|zero.toml|zero.json>\n\n");
+  printf("Print deterministic bootstrap formatting for Zero source.\n");
+  printf("With --check, exit non-zero if input would be reformatted.\n");
+  printf("With --write, overwrite the input file in place.\n");
+  printf("With --json, emit a structured envelope for --check or --write.\n");
+}
+
 static bool is_program_graph_root_command(const char *command) {
   static const char *const commands[] = {"init", "dump", "import", "export", "query", "inspect", "validate", "view", "diff", "source-map", "reconcile", "status", "verify-projection", "merge", "roundtrip", "patch"};
   for (size_t i = 0; i < sizeof(commands) / sizeof(commands[0]); i++) {
@@ -4994,6 +5013,9 @@ static bool parse_common_option(int argc, char **argv, int *index, Command *comm
     return true;
   } else if (strcmp(arg, "--check") == 0) {
     command->fmt_check = true;
+    return true;
+  } else if (strcmp(arg, "--write") == 0) {
+    command->fmt_write = true;
     return true;
   } else if (strcmp(arg, "--trace") == 0) {
     command->trace = true;
@@ -16129,19 +16151,19 @@ static EarlyCachedRunResult try_run_manifest_graph_cached_executable_before_reso
 
 int main(int argc, char **argv) {
   if (argc >= 2 && (strcmp(argv[1], "--help") == 0 || strcmp(argv[1], "-h") == 0 || strcmp(argv[1], "help") == 0)) {
-    z_cli_print_help();
+    print_help_with_fmt_modes();
     return 0;
   }
   Command command = {0};
   if (!parse_command(argc, argv, &command)) {
-    z_cli_print_help();
+    print_help_with_fmt_modes();
     return 1;
   }
   if (command.retired_graph_subcommand || strcmp(command.command, "graph") == 0) {
     return reject_retired_graph_subcommand(&command);
   }
   if (command.kind && strcmp(command.kind, "help") == 0) {
-    z_cli_print_command_help(command.command);
+    print_command_help_with_fmt_modes(command.command);
     return 0;
   }
   if (command.unknown_flag) return reject_unknown_flag(&command);
@@ -16199,7 +16221,7 @@ int main(int argc, char **argv) {
   command_apply_query_bare_argument(&command);
   command_apply_current_directory_default(&command);
   if (!command.input) {
-    z_cli_print_command_help(command.command);
+    print_command_help_with_fmt_modes(command.command);
     return 1;
   }
 
@@ -16330,6 +16352,11 @@ int main(int argc, char **argv) {
   }
 
   if (strcmp(command.command, "fmt") == 0) {
+    if (command.fmt_check && command.fmt_write) {
+      fprintf(stderr, "zero fmt: --check and --write are mutually exclusive\n");
+      fprintf(stderr, "  help: pass --check OR --write, not both\n");
+      return 1;
+    }
     SourceInput fmt_input = {0};
     if (!load_format_source(command.input, &fmt_input, &diag)) {
       if (command.json) print_command_diag_json(&command, command.input, &diag);
@@ -16359,16 +16386,80 @@ int main(int argc, char **argv) {
       z_free_source(&fmt_input);
       return 1;
     }
+    const char *path_for_output = fmt_input.source_file ? fmt_input.source_file : command.input;
+    bool matches = strcmp(formatted, fmt_input.source) == 0;
     if (command.fmt_check) {
-      bool matches = strcmp(formatted, fmt_input.source) == 0;
-      if (matches) {
+      if (command.json) {
+        ZBuf buf;
+        zbuf_init(&buf);
+        zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"command\": \"fmt\",\n  \"mode\": \"check\",\n  \"sourceFile\": ");
+        append_json_string(&buf, path_for_output);
+        zbuf_append(&buf, ",\n  \"ok\": ");
+        zbuf_append(&buf, matches ? "true" : "false");
+        zbuf_append(&buf, ",\n  \"unformatted\": [");
+        if (!matches) {
+          append_json_string(&buf, path_for_output);
+        }
+        zbuf_append(&buf, "]\n}\n");
+        fputs(buf.data, stdout);
+        zbuf_free(&buf);
+      } else if (matches) {
         printf("fmt ok\n");
       } else {
-        fprintf(stderr, "format differs: %s\n", fmt_input.source_file ? fmt_input.source_file : command.input);
+        fprintf(stderr, "format differs: %s\n", path_for_output);
       }
       free(formatted);
       z_free_source(&fmt_input);
       return matches ? 0 : 1;
+    }
+    if (command.fmt_write) {
+      if (!fmt_input.source_file) {
+        fprintf(stderr, "zero fmt: --write requires a source file path on disk\n");
+        fprintf(stderr, "  help: pass a .0 file or a project/zero.json that resolves to one\n");
+        free(formatted);
+        z_free_source(&fmt_input);
+        return 1;
+      }
+      bool wrote = false;
+      if (!matches) {
+        FILE *out = fopen(fmt_input.source_file, "wb");
+        if (!out) {
+          fprintf(stderr, "zero fmt: could not open %s for writing\n", fmt_input.source_file);
+          free(formatted);
+          z_free_source(&fmt_input);
+          return 1;
+        }
+        size_t len = strlen(formatted);
+        size_t written = fwrite(formatted, 1, len, out);
+        fclose(out);
+        if (written != len) {
+          fprintf(stderr, "zero fmt: short write to %s (%zu of %zu bytes)\n", fmt_input.source_file, written, len);
+          free(formatted);
+          z_free_source(&fmt_input);
+          return 1;
+        }
+        wrote = true;
+      }
+      if (command.json) {
+        ZBuf buf;
+        zbuf_init(&buf);
+        zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"command\": \"fmt\",\n  \"mode\": \"write\",\n  \"sourceFile\": ");
+        append_json_string(&buf, path_for_output);
+        zbuf_append(&buf, ",\n  \"ok\": true,\n  \"written\": [");
+        if (wrote) {
+          append_json_string(&buf, path_for_output);
+        }
+        zbuf_append(&buf, "]\n}\n");
+        fputs(buf.data, stdout);
+        zbuf_free(&buf);
+      } else if (wrote) {
+        printf("formatted: %s\n", path_for_output);
+      } else {
+        printf("unchanged: %s\n", path_for_output);
+      }
+      free(formatted);
+      z_free_source(&fmt_input);
+      return 0;
     }
     fputs(formatted, stdout);
     free(formatted);


### PR DESCRIPTION
## Summary
`zero fmt --write` overwrites the source file in place; `zero fmt --check --json` now emits a structured envelope (today `--json` is ignored on `--check` and output stays text-only).

## Why this matters
`zero fmt --check` shipped earlier today and `--json` envelopes are the contract for every other Zero command. CI pipelines and pre-commit hooks expect the gofmt -l / -w shape: `--check` for exit-code-on-diff, `--write` for in-place. With neither, integrations end up shelling `diff <(zero fmt file) file` (quoting risk on paths) or `zero fmt file | tee file` (races on large files).

## Demo

![demo](https://vhs.charm.sh/vhs-3Vrv91kWoAogGtVIGUQaSb.gif)

## Changes
- `--write` flag overwrites the input file in place. Backward compat preserved: bare `zero fmt` still prints to stdout.
- `--check --json` now emits `{ schemaVersion, command, mode, sourceFile, ok, unformatted: [...] }`. `--check` text mode unchanged.
- `--write --json` mirrors the same shape with `written: [...]`.
- `--check` and `--write` are mutually exclusive.

## Testing
- `bin/zero fmt --check examples/hello.0` exits 0
- `bin/zero fmt --check /tmp/messy.0` exits 1 with `format differs: ...`
- `bin/zero fmt --check --json /tmp/messy.0` emits the envelope with `ok: false`, exits 1
- `bin/zero fmt --write /tmp/messy.0` rewrites the file, prints `formatted: <path>`
- `bin/zero fmt --check --write file.0` exits with the mutually-exclusive error
- `bin/zero fmt /tmp/messy.0` (bare) still prints to stdout

Local conformance and native:test exercise pre-existing upstream code paths that already fail on darwin-arm64 (the macho64 emitter is missing LC_UUID; binaries are rejected by dyld). The fmt code path I touched does not go through executable emission, so this PR does not change those failure modes. CI runs in the Vercel sandbox and should be green there.

AI was used for assistance.
