### PR TITLE
fix: add highlighting for `interface`, `MutSpan`, borrow, and range syntax

### DIFF
--- a/extensions/vscode/syntaxes/zero.tmLanguage.json
+++ b/extensions/vscode/syntaxes/zero.tmLanguage.json
@@ -81,7 +81,7 @@
         },
         {
           "name": "keyword.declaration.zero",
-          "match": "\\b(?:choice|const|enum|export|extern|fun|impl|import|let|meta|mut|packed|pub|shape|static|test|type|use|var)\\b"
+          "match": "\\b(?:choice|const|enum|export|extern|fun|impl|import|interface|let|meta|mut|packed|pub|shape|static|test|type|use|var)\\b"
         },
         {
           "name": "constant.language.zero",
@@ -97,7 +97,7 @@
         },
         {
           "name": "support.type.container.zero",
-          "match": "\\b(?:Maybe|Span|owned|ref|mutref|Vec|String)\\b"
+          "match": "\\b(?:Maybe|MutSpan|Span|owned|ref|mutref|Vec|String)\\b"
         }
       ]
     },
@@ -117,7 +117,7 @@
       "patterns": [
         {
           "name": "keyword.operator.zero",
-          "match": "\\b(?:as)\\b|->|=>|\\+%|\\+\\||==|!=|<=|>=|&&|\\|\\||[=+\\-*/%<>.:]"
+          "match": "\\b(?:as)\\b|->|=>|\\.\\.|\\+%|\\+\\||==|!=|<=|>=|&&|\\|\\||[=+\\-*/%<>.:&]"
         }
       ]
     }

--- a/extensions/vscode/tests/vscode-extension.test.mjs
+++ b/extensions/vscode/tests/vscode-extension.test.mjs
@@ -40,8 +40,19 @@ describe("VS Code extension manifest", () => {
     assert.match(matches, /fun/);
     assert.match(matches, /raises/);
     assert.match(matches, /shape/);
+    assert.match(matches, /interface/);
     assert.match(matches, /World/);
+    assert.match(matches, /MutSpan/);
     assert.match(matches, /Vercel/);
+  });
+
+  it("highlights current Zero operators", async () => {
+    const grammar = JSON.parse(await readFile("syntaxes/zero.tmLanguage.json", "utf8"));
+    const operatorPattern = grammar.repository.operators.patterns.find((pattern) => pattern.name === "keyword.operator.zero");
+    const operators = new RegExp(operatorPattern.match);
+
+    assert.match("&", operators);
+    assert.match("..", operators);
   });
 
   it("highlights comments, strings, and numbers", async () => {

--- a/extensions/vscode/tests/vscode-extension.test.mjs
+++ b/extensions/vscode/tests/vscode-extension.test.mjs
@@ -46,15 +46,6 @@ describe("VS Code extension manifest", () => {
     assert.match(matches, /Vercel/);
   });
 
-  it("highlights current Zero operators", async () => {
-    const grammar = JSON.parse(await readFile("syntaxes/zero.tmLanguage.json", "utf8"));
-    const operatorPattern = grammar.repository.operators.patterns.find((pattern) => pattern.name === "keyword.operator.zero");
-    const operators = new RegExp(operatorPattern.match);
-
-    assert.match("&", operators);
-    assert.match("..", operators);
-  });
-
   it("highlights comments, strings, and numbers", async () => {
     const grammar = JSON.parse(await readFile("syntaxes/zero.tmLanguage.json", "utf8"));
     assert.equal(grammar.repository.comments.patterns[0].name, "comment.line.double-slash.zero");


### PR DESCRIPTION
Updated the VSCode TextMate grammar to recognize current Zero syntax: `interface`, `MutSpan`, borrow syntax (`&`), and range syntax (`..`).