### PR TITLE
fix: zero fix --apply writes combined-source buffer to original file

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1453,15 +1453,18 @@ const fixPatchBody = JSON.parse(fixPatchJson.stdout);
 assert.equal(fixPatchBody.mode, "patch");
 assert.equal(fixPatchBody.appliesEdits, false);
 assert.equal(fixPatchBody.fixes[0].appliesEdits, true);
+assert.equal(fixPatchBody.patches[0].line, 2);
 assert.match(fixPatchBody.patches[0].new, /let mut dst/);
 
 const fixApplyFixture = `${outDir}/fix-apply-mutable.0`;
-await writeFile(fixApplyFixture, await readFile("conformance/native/fail/mem-copy-immutable-dst.0", "utf8"));
+const fixApplyOriginal = await readFile("conformance/native/fail/mem-copy-immutable-dst.0", "utf8");
+await writeFile(fixApplyFixture, fixApplyOriginal);
 const fixApplyJson = await execFileAsync(zero, ["fix", "--apply", "--json", fixApplyFixture]);
 const fixApplyBody = JSON.parse(fixApplyJson.stdout);
 assert.equal(fixApplyBody.mode, "apply");
 assert.equal(fixApplyBody.applied, true);
-assert.match(await readFile(fixApplyFixture, "utf8"), /let mut dst/);
+const fixApplyResult = await readFile(fixApplyFixture, "utf8");
+assert.equal(fixApplyResult, fixApplyOriginal.replace("let dst:", "let mut dst:"));
 await execFileAsync(zero, ["check", fixApplyFixture]);
 
 const importGraph = await execFileAsync(zero, ["graph", "--json", "conformance/check/pass/imports"]);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2825,14 +2825,20 @@ static int print_or_apply_fix_json(const char *path, SourceInput *input, const Z
   int edit_line = 0;
   char *old_line = NULL;
   char *new_line = NULL;
-  bool has_edit = can_apply && find_make_binding_mutable_edit(input ? input->source : NULL, &edit_line, &old_line, &new_line);
+  char *original = NULL;
+  if (can_apply && input && input->source_file) {
+    ZDiag read_diag = {0};
+    original = z_read_file(input->source_file, &read_diag);
+  }
+  bool has_edit = original && find_make_binding_mutable_edit(original, &edit_line, &old_line, &new_line);
   bool applied = false;
   if (apply && has_edit) {
-    char *updated = apply_single_line_edit(input->source, edit_line, new_line);
+    char *updated = apply_single_line_edit(original, edit_line, new_line);
     ZDiag write_diag = {0};
     applied = z_write_file(input->source_file, updated, &write_diag);
     free(updated);
   }
+  free(original);
 
   ZBuf buf;
   zbuf_init(&buf);


### PR DESCRIPTION
print_or_apply_fix_json was scanning and writing `input->source` — the import-resolved combined buffer that `fs.c::append_source_without_imports` prefixes each file with `// file: <path>`. For `--apply` this injected the prefix as the first line of the user's file; for `--patch` it shifted reported line numbers by one. Re-read `input->source_file` from disk before applying the line edit.

Repro on the existing fixture:

```
cp conformance/native/fail/mem-copy-immutable-dst.0 /tmp/x.0
bin/zero fix --apply /tmp/x.0
head -1 /tmp/x.0   # before: "// file: /tmp/x.0"
```

The conformance assertion for `--apply` was a regex match (`/let mut dst/`) which the injected header passed through; tightened to full-content equality, and added an explicit `patches[0].line` check for `--patch`.