### PR TITLE
feat: zero new --json envelope

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 if (process.env.ZERO_NATIVE_TEST_SANDBOX !== "1" && process.env.ZERO_NATIVE_TEST_ALLOW_LOCAL !== "1") {
@@ -1463,6 +1463,35 @@ assert.equal(fixApplyBody.mode, "apply");
 assert.equal(fixApplyBody.applied, true);
 assert.match(await readFile(fixApplyFixture, "utf8"), /let mut dst/);
 await execFileAsync(zero, ["check", fixApplyFixture]);
+
+const newCliPath = `${outDir}/new-cli-json-fixture`;
+await rm(newCliPath, { recursive: true, force: true });
+const newCliJson = await execFileAsync(zero, ["new", "--json", "cli", newCliPath]);
+const newCliBody = JSON.parse(newCliJson.stdout);
+assert.equal(newCliBody.schemaVersion, 1);
+assert.equal(newCliBody.ok, true);
+assert.equal(newCliBody.kind, "cli");
+assert.equal(newCliBody.name, newCliPath);
+assert.equal(newCliBody.path, newCliPath);
+assert.equal(newCliBody.manifest, `${newCliPath}/zero.json`);
+assert.equal(newCliBody.entry, `${newCliPath}/src/main.0`);
+assert.deepEqual(newCliBody.nextSteps, [`zero check ${newCliPath}`, `zero test ${newCliPath}`, `zero run ${newCliPath}`]);
+await execFileAsync(zero, ["check", newCliPath]);
+
+const newLibPath = `${outDir}/new-lib-json-fixture`;
+await rm(newLibPath, { recursive: true, force: true });
+const newLibJson = await execFileAsync(zero, ["new", "--json", "lib", newLibPath]);
+const newLibBody = JSON.parse(newLibJson.stdout);
+assert.equal(newLibBody.kind, "lib");
+assert.equal(newLibBody.entry, `${newLibPath}/src/lib.0`);
+assert.deepEqual(newLibBody.nextSteps, [`zero check ${newLibPath}`, `zero test ${newLibPath}`]);
+
+const newPackagePath = `${outDir}/new-package-json-fixture`;
+await rm(newPackagePath, { recursive: true, force: true });
+const newPackageJson = await execFileAsync(zero, ["new", "--json", "package", newPackagePath]);
+const newPackageBody = JSON.parse(newPackageJson.stdout);
+assert.equal(newPackageBody.kind, "package");
+assert.equal(newPackageBody.entry, `${newPackagePath}/src/main.0`);
 
 const importGraph = await execFileAsync(zero, ["graph", "--json", "conformance/check/pass/imports"]);
 const importGraphBody = JSON.parse(importGraph.stdout);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -3080,12 +3080,13 @@ static bool parse_command(int argc, char **argv, Command *command) {
   command->target = "host";
   command->profile = "release";
   if (strcmp(command->command, "new") == 0) {
-    if (argc >= 3) {
-      if (strcmp(argv[2], "--help") == 0 || strcmp(argv[2], "-h") == 0) command->kind = "help";
-      else command->kind = argv[2];
-    }
-    for (int i = 3; i < argc; i++) {
-      if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) return true;
+    for (int i = 2; i < argc; i++) {
+      if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) {
+        if (!command->kind) command->kind = "help";
+        return true;
+      }
+      else if (strcmp(argv[i], "--json") == 0) command->json = true;
+      else if (!command->kind) command->kind = argv[i];
       else if (!command->input) command->input = argv[i];
       else return false;
     }
@@ -5151,8 +5152,51 @@ static int new_command(const Command *command) {
     return 1;
   }
 
+  bool is_lib = strcmp(command->kind, "lib") == 0;
+  const char *entry = is_lib ? "src/lib.0" : "src/main.0";
+
+  if (command->json) {
+    ZBuf buf;
+    ZBuf scratch;
+    zbuf_init(&buf);
+    zbuf_init(&scratch);
+    zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"ok\": true,\n  \"kind\": ");
+    append_json_string(&buf, command->kind);
+    zbuf_append(&buf, ",\n  \"name\": ");
+    append_json_string(&buf, command->input);
+    zbuf_append(&buf, ",\n  \"path\": ");
+    append_json_string(&buf, command->input);
+    zbuf_append(&buf, ",\n  \"manifest\": ");
+    scratch.len = 0;
+    zbuf_appendf(&scratch, "%s/zero.json", command->input);
+    append_json_string(&buf, scratch.data);
+    zbuf_append(&buf, ",\n  \"entry\": ");
+    scratch.len = 0;
+    zbuf_appendf(&scratch, "%s/%s", command->input, entry);
+    append_json_string(&buf, scratch.data);
+    zbuf_append(&buf, ",\n  \"nextSteps\": [");
+    scratch.len = 0;
+    zbuf_appendf(&scratch, "zero check %s", command->input);
+    append_json_string(&buf, scratch.data);
+    zbuf_append(&buf, ", ");
+    scratch.len = 0;
+    zbuf_appendf(&scratch, "zero test %s", command->input);
+    append_json_string(&buf, scratch.data);
+    if (!is_lib) {
+      zbuf_append(&buf, ", ");
+      scratch.len = 0;
+      zbuf_appendf(&scratch, "zero run %s", command->input);
+      append_json_string(&buf, scratch.data);
+    }
+    zbuf_append(&buf, "]\n}\n");
+    fputs(buf.data, stdout);
+    zbuf_free(&buf);
+    zbuf_free(&scratch);
+    return 0;
+  }
+
   printf("created %s project %s\n", command->kind, command->input);
-  if (strcmp(command->kind, "lib") == 0) printf("next: cd %s && zero check . && zero test .\n", command->input);
+  if (is_lib) printf("next: cd %s && zero check . && zero test .\n", command->input);
   else printf("next: cd %s && zero check . && zero test . && zero run .\n", command->input);
   return 0;
 }


### PR DESCRIPTION
`zero new` is the only project-scaffolding entry point without a JSON envelope. Adds `--json` with `kind`, `name`, `path`, `manifest`, `entry`, and `nextSteps` so scaffold output can be consumed structurally.

```
$ bin/zero new --json cli mycli
{
  "schemaVersion": 1,
  "ok": true,
  "kind": "cli",
  "name": "mycli",
  "path": "mycli",
  "manifest": "mycli/zero.json",
  "entry": "mycli/src/main.0",
  "nextSteps": ["zero check mycli", "zero test mycli", "zero run mycli"]
}
```

Plain-text output is unchanged. `lib` omits `zero run` in `nextSteps`. The `new` arg parser is rewritten to be order-independent so `--json` can appear before or after the positional args.