### PR TITLE
fix: portable signalExitCode via os.constants.signals

### DIFF
--- a/scripts/zero-cli.mjs
+++ b/scripts/zero-cli.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { constants as osConstants } from "node:os";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -72,22 +73,7 @@ function runNative() {
 }
 
 function signalExitCode(signal) {
-  const signalNumbers = {
-    SIGHUP: 1,
-    SIGINT: 2,
-    SIGQUIT: 3,
-    SIGILL: 4,
-    SIGTRAP: 5,
-    SIGABRT: 6,
-    SIGBUS: 7,
-    SIGFPE: 8,
-    SIGKILL: 9,
-    SIGSEGV: 11,
-    SIGPIPE: 13,
-    SIGALRM: 14,
-    SIGTERM: 15,
-  };
-  return 128 + (signalNumbers[signal] ?? 1);
+  return 128 + (osConstants.signals?.[signal] ?? 1);
 }
 
 function trySkillsCommand(argv) {


### PR DESCRIPTION
## Summary

`signalExitCode` in `scripts/zero-cli.mjs` hardcoded a signal-number map using Linux values (e.g. `SIGBUS: 7`). On Darwin those numbers differ — `SIGBUS` is `10`, not `7` — so a native compiler crash terminated by signal reports the wrong exit code on macOS.

Node already exposes the correct per-platform values via `os.constants.signals`. This swap removes the hardcoded table and gets each host's actual numbers.

## Test plan

- [x] `node -e "console.log(128 + require('os').constants.signals.SIGBUS)"` returns `138` on Darwin (was `135` with old table)
- [x] `node -e "console.log(128 + require('os').constants.signals.SIGSEGV)"` returns `139` on both platforms
- [x] `npm run docs:test` passes
- [x] Unknown-signal fallback (`?? 1`) preserved