### PR TITLE
fix: check self-host target support before browser-compiler artifact

### DIFF
--- a/scripts/zero-cli.mjs
+++ b/scripts/zero-cli.mjs
@@ -471,13 +471,14 @@ function trySelfHostedDriver(argv) {
 
   const loaded = loadSelfHostDriverInput(input);
   if (!loaded) return false;
+
+  if (!selfHostDriverSupportsTarget({ command, target, normalizedInput })) return false;
+
   if (!existsSync(publicCompiler)) {
     console.error("zero: browser compiler artifact is missing");
     console.error("run: npm run docs:compiler");
     process.exit(127);
   }
-
-  if (!selfHostDriverSupportsTarget({ command, target, normalizedInput })) return false;
 
   const emit = optionValue(argv, "--emit") ?? (command === "build" ? "exe" : null);
   if (command === "build" && emit !== "wasm") return false;


### PR DESCRIPTION
## Summary

`trySelfHostedDriver` in `scripts/zero-cli.mjs` exits 127 with `browser compiler artifact is missing` even when the requested `(command, input, target)` combo would have fallen through to the native compiler — e.g. on a fresh checkout where the playground wasm has not been built yet:

```sh
$ zero check examples/hello.0 --target linux-musl-x64
zero: browser compiler artifact is missing
run: npm run docs:compiler
# exit 127
```

`examples/hello.0` is in `selfHostDriverInputs` so `loaded` is non-null, but the driver only handles `wasm32-web` for that input — `selfHostDriverSupportsTarget` would return `false` and we should fall through to native. The artifact check fires first and aborts.

## Fix

Move the `selfHostDriverSupportsTarget` check ahead of the `existsSync(publicCompiler)` check so the wasm-missing error only fires when the driver is actually going to read the wasm.

## Test plan

- [x] `zero check examples/hello.0 --target linux-musl-x64` (wasm missing, native missing) now falls through and reports the native-missing error instead of the wasm-missing one
- [x] `zero check examples/hello.0` (default `wasm32-web`, wasm missing) still reports the wasm-missing error — behavior preserved for the supported path
- [x] `npm run docs:test` passes