### PR TITLE
fix(macho): add LC_UUID to Darwin executables

### DIFF
--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -222,6 +222,19 @@ static void macho_append_code_signature(ZBuf *sig, const unsigned char *code, si
   }
 }
 
+static void macho_append_uuid_command(ZBuf *out, const ZBuf *text, const ZBuf *rodata) {
+  unsigned char hash[32];
+  MachOSha256 ctx;
+  macho_sha256_init(&ctx);
+  if (text && text->data && text->len) macho_sha256_update(&ctx, (const unsigned char *)text->data, text->len);
+  if (rodata && rodata->data && rodata->len) macho_sha256_update(&ctx, (const unsigned char *)rodata->data, rodata->len);
+  macho_sha256_final(&ctx, hash);
+
+  append_u32le(out, 0x1bu);             // LC_UUID
+  append_u32le(out, 24);
+  append_bytes(out, (const char *)hash, 16);
+}
+
 static void append_bytes(ZBuf *buf, const char *bytes, size_t len) {
   for (size_t i = 0; i < len; i++) append_u8(buf, (unsigned char)bytes[i]);
 }
@@ -1451,8 +1464,9 @@ bool z_emit_macho64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag
   const uint32_t libsystem_cmd_size = 56;
   const uint32_t main_cmd_size = 24;
   const uint32_t build_version_cmd_size = 24;
+  const uint32_t uuid_cmd_size = 24;
   const uint32_t code_signature_cmd_size = 16;
-  const uint32_t sizeofcmds = pagezero_cmd_size + text_segment_cmd_size + linkedit_cmd_size + dyld_info_cmd_size + dylinker_cmd_size + libsystem_cmd_size + main_cmd_size + build_version_cmd_size + code_signature_cmd_size;
+  const uint32_t sizeofcmds = pagezero_cmd_size + text_segment_cmd_size + linkedit_cmd_size + dyld_info_cmd_size + dylinker_cmd_size + libsystem_cmd_size + main_cmd_size + build_version_cmd_size + uuid_cmd_size + code_signature_cmd_size;
   const uint32_t text_offset = (uint32_t)macho_align(header_size + sizeofcmds, 16);
   const uint32_t rodata_offset = has_rodata ? (uint32_t)macho_align(text_offset + text.len, 8) : 0;
   for (size_t i = 0; i < ctx.data_patch_len; i++) {
@@ -1490,7 +1504,7 @@ bool z_emit_macho64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag
   append_u32le(out, 0x0100000cu);      // CPU_TYPE_ARM64
   append_u32le(out, 0);                // CPU_SUBTYPE_ARM64_ALL
   append_u32le(out, 2);                // MH_EXECUTE
-  append_u32le(out, 9);                // ncmds
+  append_u32le(out, 10);               // ncmds
   append_u32le(out, sizeofcmds);
   append_u32le(out, 0x200085);         // MH_NOUNDEFS | MH_DYLDLINK | MH_TWOLEVEL | MH_PIE
   append_u32le(out, 0);
@@ -1591,6 +1605,8 @@ bool z_emit_macho64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag
   append_u32le(out, 0x000b0000);       // macOS 11.0.0
   append_u32le(out, 0);
   append_u32le(out, 0);
+
+  macho_append_uuid_command(out, &text, &rodata);
 
   append_u32le(out, 0x1d);             // LC_CODE_SIGNATURE
   append_u32le(out, code_signature_cmd_size);

--- a/scripts/snapshot-command-contracts.mjs
+++ b/scripts/snapshot-command-contracts.mjs
@@ -77,6 +77,18 @@ function hasAnsiControlBytes(text) {
   return /\x1b\[[0-9;?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)/.test(text);
 }
 
+function machoHasLoadCommand(bytes, command) {
+  const ncmds = bytes.readUInt32LE(16);
+  let offset = 32;
+  for (let i = 0; i < ncmds; i++) {
+    const cmd = bytes.readUInt32LE(offset);
+    const cmdsize = bytes.readUInt32LE(offset + 4);
+    if (cmd === command) return true;
+    offset += cmdsize;
+  }
+  return false;
+}
+
 function removeInlineTests(path) {
   if (!existsSync(path)) return;
   const source = readFileSync(path, "utf8");
@@ -588,6 +600,7 @@ assertReleaseTargetContract(directMachOExeReport, {
 repeatBuildHash(["build", "--json", "--emit", "exe", "--backend", "zero-macho64", "--target", "darwin-arm64", "examples/direct-exe-return.0", "--out", directMachOExePath], directMachOExePath, `${directMachOExePath}.repeat`);
 assert.equal(directMachOExeBytes.readUInt32LE(0), 0xfeedfacf);
 assert.equal(directMachOExeBytes.readUInt32LE(12), 2);
+assert(machoHasLoadCommand(directMachOExeBytes, 0x1b)); // LC_UUID
 assert(directMachOExeBytes.includes(Buffer.from("/usr/lib/dyld")));
 assert(directMachOExeBytes.includes(Buffer.from("zero-direct")));
 const directCoffExePath = join(outDir, "direct-coff-exe-return");

--- a/scripts/test-native.sh
+++ b/scripts/test-native.sh
@@ -1965,7 +1965,7 @@ fi
 grep -q "must not take parameters" .zero/native-test/direct-exe-with-params.err
 rm -f .zero/native-test/direct-exe-darwin .zero/native-test/direct-exe-darwin.c .zero/native-test/direct-exe-darwin.json .zero/native-test/direct-hello-darwin .zero/native-test/direct-hello-darwin.c
 bin/zero build --json --emit exe --backend zero-macho64 --target darwin-arm64 examples/direct-exe-return.0 --out .zero/native-test/direct-exe-darwin > .zero/native-test/direct-exe-darwin.json
-node -e 'const fs=require("fs"); const b=fs.readFileSync(".zero/native-test/direct-exe-darwin"); if (b.readUInt32LE(0)!==0xfeedfacf || b.readUInt32LE(12)!==2 || !b.includes(Buffer.from("/usr/lib/dyld")) || !b.includes(Buffer.from("zero-direct"))) process.exit(1);'
+node -e 'const fs=require("fs"); const b=fs.readFileSync(".zero/native-test/direct-exe-darwin"); let hasUuid=false; for (let i=0, off=32, n=b.readUInt32LE(16); i<n; i++){ const cmd=b.readUInt32LE(off); const size=b.readUInt32LE(off+4); if (cmd===0x1b && size===24) hasUuid=true; off+=size; } if (b.readUInt32LE(0)!==0xfeedfacf || b.readUInt32LE(12)!==2 || !hasUuid || !b.includes(Buffer.from("/usr/lib/dyld")) || !b.includes(Buffer.from("zero-direct"))) process.exit(1);'
 grep -q '"compiler": "zero-macho64"' .zero/native-test/direct-exe-darwin.json
 grep -q '"path":"direct-macho64-exe"' .zero/native-test/direct-exe-darwin.json
 grep -q '"generatedCBytes": 0' .zero/native-test/direct-exe-darwin.json


### PR DESCRIPTION
## Summary

- add an `LC_UUID` load command to directly emitted Darwin Mach-O executables
- derive the UUID bytes deterministically from emitted text/rodata so repeated builds stay byte-for-byte stable
- cover the load command in command-contract and native-test checks

Closes #28.

## Verification

- `make -C native/zero-c`
- `zero run hello.0` now prints `hello from zero` on Darwin arm64
- `npm run command-contracts:local --silent`
- `npm run native:test:local --silent`
