### PR TITLE
docs: add expected output and PATH persistence to install guide

### DIFF
--- a/docs-site/articles/install.md
+++ b/docs-site/articles/install.md
@@ -8,6 +8,22 @@ export PATH="$HOME/.zero/bin:$PATH"
 zero --version
 ```
 
+To keep `zero` on your PATH permanently, add the export line to your shell
+profile (`~/.zshrc`, `~/.bashrc`, or equivalent).
+
+Expected output:
+
+```text
+zero <version>
+commit: <hash>
+host: <platform>
+backend: zero-c
+targets: ["darwin-arm64","darwin-x64","linux-musl-x64",...]
+target compiler: available <toolchain>
+```
+
+The values vary depending on your release and local toolchain.
+
 The installer downloads the latest matching binary from
 `github.com/vercel-labs/zero`, verifies it against the release checksum file,
 and writes it to `$HOME/.zero/bin/zero`. Set `ZERO_INSTALL_DIR` to choose a


### PR DESCRIPTION
## Summary
- Adds representative `zero --version` output so new users know what success looks like
- Adds a one-line note on making the PATH export permanent via shell profile

## Context
The install guide tells users to run `zero --version` as a verification step but doesn't show expected output. The multi-line report (version, commit, host, backend, targets, toolchain) can be confusing without a reference. The PATH export is also session-only with no mention of persistence.

## Test plan
- [ ] `npm run docs:test` passes
- [ ] Output block matches the shape of actual `zero --version` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)