### PR TITLE
docs: add MutSpan<T> to primitives type table

### DIFF
--- a/docs-site/articles/primitives.md
+++ b/docs-site/articles/primitives.md
@@ -71,7 +71,8 @@ Zero makes memory shape visible in types. These forms are primitive type constru
 | Primitive | Purpose |
 | --- | --- |
 | `[N]T` | Fixed-size array with `N` elements of `T`. |
-| `Span<T>` | Non-owning pointer plus length. |
+| `Span<T>` | Non-owning read-only pointer plus length. |
+| `MutSpan<T>` | Non-owning mutable pointer plus length. |
 | `ref<T>` | Non-owning shared reference. |
 | `mutref<T>` | Non-owning mutable reference. |
 | `owned<T>` | Move-only value that owns cleanup responsibility. |


### PR DESCRIPTION
## Summary
- Adds `MutSpan<T>` to the Memory And Ownership table in `primitives.md`
- Clarifies `Span<T>` as "read-only" to contrast with the mutable variant

## Context
`MutSpan<T>` is used throughout the docs (`learn-zero.md`, `language-reference.md`, `modules/mem.md`, `modules/fs.md`) and in examples on the primitives page itself, but was missing from the canonical type table. This makes it harder for new users to find its definition when scanning the reference.

## Test plan
- [ ] `npm run docs:test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)