### PR TITLE
Add explain catalog entry for NAM003

### DIFF
--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2357,6 +2357,16 @@ static const ExplainInfo explain_infos[] = {
     "let mut dst: [4]u8 = [0, 0, 0, 0]\nlet _ = std.mem.copy(dst, src)",
   },
   {
+    "NAM003",
+    "name-resolution",
+    "Unknown identifier",
+    "An expression references a name that is not visible at that source location.",
+    "Zero keeps name resolution explicit so agents can distinguish missing declarations, missing imports, and spelling mistakes from type errors.",
+    "Declare the referenced symbol, import the module that provides it, or correct the identifier spelling.",
+    "return 40 + missing",
+    "const missing: i32 = 2\nreturn 40 + missing",
+  },
+  {
     "ERR002",
     "fallibility",
     "Error set mismatch",
@@ -2604,6 +2614,7 @@ static void print_explain_json(const ExplainInfo *info) {
   append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
                                          strcmp(info->code, "TAR002") == 0 ? 6002 :
                                          strcmp(info->code, "BLD003") == 0 ? 2003 :
+                                         strcmp(info->code, "NAM003") == 0 ? 3003 :
                                          strcmp(info->code, "TYP009") == 0 ? 3010 :
                                          strcmp(info->code, "TYP023") == 0 ? 3032 :
                                          strcmp(info->code, "TYP024") == 0 ? 3033 :

--- a/scripts/snapshot-command-contracts.mjs
+++ b/scripts/snapshot-command-contracts.mjs
@@ -1433,6 +1433,11 @@ assert.equal(explainJson.schemaVersion, 1);
 assert.equal(explainJson.code, "TAR002");
 assert.equal(explainJson.repair.id, "remove-hosted-fs-or-use-host-target");
 
+const explainNameJson = json(["explain", "--json", "NAM003"]).body;
+assert.equal(explainNameJson.schemaVersion, 1);
+assert.equal(explainNameJson.code, "NAM003");
+assert.equal(explainNameJson.repair.id, "declare-missing-symbol");
+
 const fixPlan = json(["fix", "--plan", "--json", "--target", "wasm32-web", "conformance/native/fail/std-fs-target-unsupported.0"]).body;
 assert.equal(fixPlan.schemaVersion, 1);
 assert.equal(fixPlan.mode, "plan");


### PR DESCRIPTION
 ## Summary

   - Add a `NAM003` entry to the native compiler explain catalog.
   - Map `NAM003` explain JSON repair metadata to diagnostic code `3003`.
   - Add command-contract coverage for `zero explain --json NAM003`.

   ## Why

   `zero check` can emit `NAM003` for unknown identifiers, and `zero fix --plan`
   already maps it to `declare-missing-symbol`, but `zero explain --json NAM003`
   reported the code as unknown.

   ## Validation

   Focused local validation with a rebuilt native compiler:

   - `zero explain --json NAM003` returns `code: "NAM003"` and `repair.id: "declare-missing-symbol"`.
   - `zero check --json conformance/check/fail/unknown-name.0` still emits `NAM003`.
   - `zero fix --plan --json conformance/check/fail/unknown-name.0` still reports `declare-missing-symbol`.

   Also ran:

   - `git diff --check`

   Note: full `make -C native/zero-c` / `npm run command-contracts:local` should be run in CI or a local environment with `make` available.