### PR TITLE
chore: sync package-lock.json with Apache-2.0 license

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "zero-lang-workspace",
       "version": "0.1.1",
+      "license": "Apache-2.0",
       "workspaces": [
         "extensions/*"
       ],


### PR DESCRIPTION
The license commit (https://github.com/vercel-labs/zero/pull/37) added "license": "Apache-2.0" to `package.json` but did not regenerate `package-lock.json`. As a result, every fresh `npm install` produces an uncommitted one-line diff populating the field in packages[""]. Sync the lockfile so checkouts stay clean.