### PR TITLE
fix: add NAM003 explain entry and guard catalog driftFix/nam003 explain coverage guard

### DIFF
--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2357,6 +2357,16 @@ static const ExplainInfo explain_infos[] = {
     "let mut dst: [4]u8 = [0, 0, 0, 0]\nlet _ = std.mem.copy(dst, src)",
   },
   {
+    "NAM003",
+    "name-resolution",
+    "Unknown identifier",
+    "An expression references a name that is not visible at that source location.",
+    "Zero keeps name resolution explicit so agents can distinguish missing declarations, missing imports, and spelling mistakes from type errors.",
+    "Declare the referenced symbol, import the module that provides it, or correct the identifier spelling.",
+    "return 40 + missing",
+    "const missing: i32 = 2\nreturn 40 + missing",
+  },
+  {
     "ERR002",
     "fallibility",
     "Error set mismatch",
@@ -2604,6 +2614,7 @@ static void print_explain_json(const ExplainInfo *info) {
   append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
                                          strcmp(info->code, "TAR002") == 0 ? 6002 :
                                          strcmp(info->code, "BLD003") == 0 ? 2003 :
+                                         strcmp(info->code, "NAM003") == 0 ? 3003 :
                                          strcmp(info->code, "TYP009") == 0 ? 3010 :
                                          strcmp(info->code, "TYP023") == 0 ? 3032 :
                                          strcmp(info->code, "TYP024") == 0 ? 3033 :

--- a/scripts/snapshot-command-contracts.mjs
+++ b/scripts/snapshot-command-contracts.mjs
@@ -1438,6 +1438,36 @@ assert.equal(explainNameJson.schemaVersion, 1);
 assert.equal(explainNameJson.code, "NAM003");
 assert.equal(explainNameJson.repair.id, "declare-missing-symbol");
 
+// --- explain coverage guard: prevent future NAM003-style drift ---
+const mainC = readFileSync("native/zero-c/src/main.c", "utf8");
+const emitCodes = new Set(
+  [...mainC.matchAll(/\s+case \d+: return "([A-Z]{3,}\d{3})"/g)].map(m => m[1])
+);
+emitCodes.delete("PAR100");
+const explainCodes = new Set(
+  [...mainC.matchAll(/^\s{2,}"([A-Z]{3,}\d{3})",$/gm)].map(m => m[1])
+);
+const KNOWN_MISSING = new Set([
+  "ABI001", "APP001", "BLD002", "BOR001", "BOR002",
+  "CIMP001", "CIMP002", "CIMP003", "ERR001", "FLD001", "FLD002",
+  "IMP001", "IMP002", "IMP003", "MAT001", "MAT002", "MAT003",
+  "MAT004", "MAT005", "MEM001", "NAM002", "NAM004", "OWN001",
+  "OWN002", "PKG001", "PKG002", "PKG003", "PKG004", "STD002",
+  "TYP001", "TYP002", "TYP003", "TYP005", "TYP010", "TYP011",
+  "TYP012", "TYP013", "TYP014", "TYP015", "TYP016", "TYP017",
+  "TYP018", "TYP019", "TYP020", "TYP021", "TYP022", "VAR001",
+  "VAR002", "VAR003", "VAR004", "WEB001",
+]);
+for (const code of emitCodes) {
+  if (explainCodes.has(code)) continue;
+  if (KNOWN_MISSING.has(code)) continue;
+  assert.fail(`diagnostic code ${code} is emitted by diag_code() but has no explain entry and is not in the known-missing allowlist`);
+}
+const remainingMissing = [...emitCodes].filter(c => !explainCodes.has(c)).sort();
+const coveredCount = [...emitCodes].filter(c => explainCodes.has(c)).length;
+const knownMissingCount = remainingMissing.filter(c => KNOWN_MISSING.has(c)).length;
+// --- end explain coverage guard ---
+
 const fixPlan = json(["fix", "--plan", "--json", "--target", "wasm32-web", "conformance/native/fail/std-fs-target-unsupported.0"]).body;
 assert.equal(fixPlan.schemaVersion, 1);
 assert.equal(fixPlan.mode, "plan");
@@ -1808,6 +1838,12 @@ const report = {
   targets: {
     host: targets.host,
     count: targets.targets.length,
+  },
+  diagnosticExplainCoverage: {
+    totalEmitted: emitCodes.size,
+    totalCovered: coveredCount,
+    totalKnownMissing: knownMissingCount,
+    missingCodes: remainingMissing,
   },
   generatedCAudit: null,
 };

--- a/scripts/snapshot-command-contracts.mjs
+++ b/scripts/snapshot-command-contracts.mjs
@@ -1433,6 +1433,11 @@ assert.equal(explainJson.schemaVersion, 1);
 assert.equal(explainJson.code, "TAR002");
 assert.equal(explainJson.repair.id, "remove-hosted-fs-or-use-host-target");
 
+const explainNameJson = json(["explain", "--json", "NAM003"]).body;
+assert.equal(explainNameJson.schemaVersion, 1);
+assert.equal(explainNameJson.code, "NAM003");
+assert.equal(explainNameJson.repair.id, "declare-missing-symbol");
+
 const fixPlan = json(["fix", "--plan", "--json", "--target", "wasm32-web", "conformance/native/fail/std-fs-target-unsupported.0"]).body;
 assert.equal(fixPlan.schemaVersion, 1);
 assert.equal(fixPlan.mode, "plan");


### PR DESCRIPTION
 ## Summary

   Supersedes #40.

   This PR includes the NAM003 explain catalog fix and adds a command-contract
   guard to prevent the same class of drift from growing.

   ## Why

   `zero check` can emit diagnostic codes that `zero explain <code>` does not
   recognize. NAM003 was one example of that drift.

   This PR fixes NAM003 directly and adds a coverage guard so future diagnostic
   codes added to `diag_code()` must either:

   - have an `explain_infos[]` entry, or
   - be explicitly listed as known missing explain coverage.

   The existing missing explain entries are allowlisted so this does not require
   filling the entire historical catalog gap in one PR.

   ## Changes

   - Add `NAM003` to `explain_infos[]`.
   - Map `NAM003` to repair id `declare-missing-symbol` in explain JSON.
   - Add `explain --json NAM003` command-contract assertions.
   - Add a static coverage guard comparing emitted diagnostic codes with explain catalog codes.
   - Add `diagnosticExplainCoverage` to the command-contract summary.

   ## Validation

   Focused local validation:

   - `.zero/bin/zero.exe explain --json NAM003`
     - returns `code: "NAM003"`
     - returns `repair.id: "declare-missing-symbol"`
   - `.zero/bin/zero.exe check --json conformance/check/fail/unknown-name.0`
     - still emits `NAM003`
   - `.zero/bin/zero.exe fix --plan --json conformance/check/fail/unknown-name.0`
     - still maps to `declare-missing-symbol`
   - Static guard dry-run:
     - emitted: 78
     - covered: 27
     - known missing: 51
     - NAM003 covered: true
   - `git diff --check upstream/main..HEAD` passed

   Local caveat:

   - Full `node scripts/snapshot-command-contracts.mjs` is blocked in this Windows
     environment because Node `execFileSync("bin/zero")` cannot spawn the bash
     wrapper directly (`ENOENT`). Upstream CI/Linux should be authoritative for
     the full snapshot.