### PR TITLE
feat: zero explain --json --all diagnostic catalog

### DIFF
--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2647,6 +2647,64 @@ static void print_explain_text(const ExplainInfo *info) {
 }
 
 static int explain_command(const Command *command) {
+  if (command->all) {
+    if (command->json) {
+      ZBuf buf;
+      zbuf_init(&buf);
+      zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"command\": \"explain\",\n  \"mode\": \"all\",\n  \"count\": ");
+      int count = 0;
+      for (size_t i = 0; explain_infos[i].code; i++) count++;
+      zbuf_appendf(&buf, "%d", count);
+      zbuf_append(&buf, ",\n  \"diagnostics\": [\n");
+      for (size_t i = 0; explain_infos[i].code; i++) {
+        const ExplainInfo *info = &explain_infos[i];
+        if (i > 0) zbuf_append(&buf, ",\n");
+        zbuf_append(&buf, "    {\n      \"code\": ");
+        append_json_string(&buf, info->code);
+        zbuf_append(&buf, ",\n      \"category\": ");
+        append_json_string(&buf, info->category);
+        zbuf_append(&buf, ",\n      \"title\": ");
+        append_json_string(&buf, info->title);
+        zbuf_append(&buf, ",\n      \"summary\": ");
+        append_json_string(&buf, info->summary);
+        zbuf_append(&buf, ",\n      \"why\": ");
+        append_json_string(&buf, info->why);
+        zbuf_append(&buf, ",\n      \"repair\": {\"id\": ");
+        append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
+                                             strcmp(info->code, "TAR002") == 0 ? 6002 :
+                                             strcmp(info->code, "BLD003") == 0 ? 2003 :
+                                             strcmp(info->code, "TYP009") == 0 ? 3010 :
+                                             strcmp(info->code, "TYP023") == 0 ? 3032 :
+                                             strcmp(info->code, "TYP024") == 0 ? 3033 :
+                                             strcmp(info->code, "ERR002") == 0 ? 3034 :
+                                             strcmp(info->code, "ERR003") == 0 ? 3035 :
+                                             strcmp(info->code, "STD003") == 0 ? 3036 :
+                                             strcmp(info->code, "NAM003") == 0 ? 3003 :
+                                             strcmp(info->code, "CGEN004") == 0 ? 3037 :
+                                             strcmp(info->code, "MET001") == 0 ? 3038 : 0));
+        zbuf_append(&buf, ",\n        \"summary\": ");
+        append_json_string(&buf, info->canonical_repair);
+        zbuf_append(&buf, "},\n      \"examples\": {\"bad\": ");
+        append_json_string(&buf, info->bad_example);
+        zbuf_append(&buf, ", \"good\": ");
+        append_json_string(&buf, info->good_example);
+        zbuf_append(&buf, "}\n    }");
+      }
+      zbuf_append(&buf, "\n  ]\n}\n");
+      fputs(buf.data, stdout);
+      zbuf_free(&buf);
+    } else {
+      int count = 0;
+      for (size_t i = 0; explain_infos[i].code; i++) count++;
+      printf("Diagnostic catalog (%d codes):\n\n", count);
+      for (size_t i = 0; explain_infos[i].code; i++) {
+        const ExplainInfo *info = &explain_infos[i];
+        printf("  %s  %-12s  %s\n", info->code, info->category, info->title);
+      }
+      printf("\nUse `zero explain <code>` for details.\n");
+    }
+    return 0;
+  }
   const ExplainInfo *info = find_explain_info(command->input);
   if (!info) {
     ZDiag diag = {0};
@@ -2989,8 +3047,11 @@ static void print_command_help(const char *command) {
     printf("Usage: zero time --json [--target <target>] <file.0|project|zero.json>\n\n");
     printf("Emit compiler phase, cache, and invalidation timing facts.\n");
   } else if (strcmp(command, "explain") == 0) {
-    printf("Usage: zero explain [--json] <diagnostic-code>\n\n");
+    printf("Usage: zero explain [--json] <diagnostic-code>\n");
+    printf("       zero explain --json --all\n\n");
     printf("Explain a diagnostic and its repair metadata.\n");
+    printf("  --all    List all known diagnostic codes.\n");
+    printf("  --json   Structured envelope for single code or catalog.\n");
   } else if (strcmp(command, "fix") == 0) {
     printf("Usage: zero fix (--plan|--patch|--apply) --json [--target <target>] <file.0|project|zero.json>\n\n");
     printf("Print repair plans, reviewable patches, or apply behavior-preserving edits.\n");
@@ -8190,7 +8251,7 @@ int main(int argc, char **argv) {
     }
     return 1;
   }
-  if (!command.input) {
+  if (!command.input && !(strcmp(command.command, "explain") == 0 && command.all)) {
     print_command_help(command.command);
     return 1;
   }


### PR DESCRIPTION
## Summary

Adds `--all` flag to `zero explain`, emitting the full diagnostic catalog
as a structured JSON envelope. Text mode lists all codes with category
and title. Single-code explain is unchanged.

## JSON envelope shape

```json
{
  "schemaVersion": 1,
  "command": "explain",
  "mode": "all",
  "count": 26,
  "diagnostics": [
    {
      "code": "TAR001",
      "category": "target",
      "title": "Unknown target",
      "summary": "...",
      "why": "...",
      "repair": {"id": "...", "summary": "..."},
      "examples": {"bad": "...", "good": "..."}
    },
    ...
  ]
}
```

## Text mode

```
Diagnostic catalog (26 codes):

  TAR001  target        Unknown target
  TAR002  target        Hosted filesystem unavailable
  ...

Use `zero explain <code>` for details.
```

## Changes

- `explain_command` now checks `command->all` first
- JSON mode: outputs all diagnostics with full details (code, category, title, summary, why, repair, examples)
- Text mode: outputs compact table of all codes
- Allows `explain` to proceed without `command.input` when `--all` is set
- Updated help text

## Testing

- All 9 CLI tests pass
- All 8 docs tests pass
- Command contracts pass
- Manual verification of --all --json, --all, single-code, and no-args modes

Closes #2