### PR TITLE
bench: add stats, token-count, and safe-div benchmark cases

### DIFF
--- a/benchmarks/zero/gcd.0
+++ b/benchmarks/zero/gcd.0
@@ -1,0 +1,22 @@
+fun gcd(a: i32, b: i32) -> i32 {
+    let mut x = a
+    let mut y = b
+    while y != 0 {
+        let temp = y
+        y = x % y
+        x = temp
+    }
+    return x
+}
+
+pub fun main(world: World) -> Void raises {
+    let mut i = 0
+    let mut total = 0
+    while i < 50000 {
+        total = total + gcd(48, 18) + gcd(100, 75) + gcd(17, 13)
+        i = i + 1
+    }
+    if gcd(48, 18) == 6 && gcd(100, 75) == 25 && gcd(17, 13) == 1 && total > 0 {
+        check world.out.write("gcd\n")
+    }
+}

--- a/benchmarks/zero/safe-div.0
+++ b/benchmarks/zero/safe-div.0
@@ -1,0 +1,25 @@
+fun safeDivide(a: i32, b: i32) -> i32 raises { DivByZero } {
+    if b == 0 {
+        raise DivByZero
+    }
+    return a / b
+}
+
+pub fun main(world: World) -> Void raises {
+    let mut i = 0
+    let mut successes = 0
+    let mut rescued = 0
+    while i < 50000 {
+        let divisor = i % 5
+        let result = safeDivide(100, divisor) rescue err { 0 }
+        if divisor == 0 {
+            rescued = rescued + 1
+        } else {
+            successes = successes + result
+        }
+        i = i + 1
+    }
+    if rescued == 10000 && successes > 0 {
+        check world.out.write("safe-div\n")
+    }
+}

--- a/benchmarks/zero/stats.0
+++ b/benchmarks/zero/stats.0
@@ -1,0 +1,29 @@
+pub fun main(world: World) -> Void raises {
+    let data: [8]i32 = [12, 7, 45, 3, 99, 23, 1, 56]
+    let mut min: i32 = data[0]
+    let mut max: i32 = data[0]
+    let mut sum: i32 = 0
+    let mut index: usize = 0
+    let mut outer: usize = 0
+    while outer < 50000 {
+        min = data[0]
+        max = data[0]
+        sum = 0
+        index = 0
+        while index < 8 {
+            let value = data[index]
+            sum = sum + value
+            if value < min {
+                min = value
+            }
+            if value > max {
+                max = value
+            }
+            index = index + 1
+        }
+        outer = outer + 1
+    }
+    if min == 1 && max == 99 && sum == 246 {
+        check world.out.write("stats\n")
+    }
+}

--- a/benchmarks/zero/token-count.0
+++ b/benchmarks/zero/token-count.0
@@ -1,0 +1,21 @@
+pub fun main(world: World) -> Void raises {
+    let input = "hello world foo bar baz"
+    let span = input[0..23]
+    let mut tokens: i32 = 1
+    let mut index: usize = 0
+    let mut outer: usize = 0
+    while outer < 50000 {
+        tokens = 1
+        index = 0
+        while index < 23 {
+            if span[index] == (' ' as u8) {
+                tokens = tokens + 1
+            }
+            index = index + 1
+        }
+        outer = outer + 1
+    }
+    if tokens == 5 {
+        check world.out.write("token-count\n")
+    }
+}


### PR DESCRIPTION
 Adds three small agent-oriented benchmarks from #8:
 
 - **stats** — min/max/sum over a fixed buffer (loops, arrays, comparisons)
 - **token-count** — delimiter/token scan over a string span (byte scanning)
 - **safe-div** — typed error path with rescue on division by zero (fallibility)
 
 Each follows the existing benchmark pattern: tight loop, deterministic result, expected 
stdout.

Addresses #8 