### PR TITLE
feat: zero new --json envelope with order-independent args

### DIFF
--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -3272,14 +3272,13 @@ static bool parse_command(int argc, char **argv, Command *command) {
   command->target = "host";
   command->profile = "release";
   if (strcmp(command->command, "new") == 0) {
-    if (argc >= 3) {
-      if (strcmp(argv[2], "--help") == 0 || strcmp(argv[2], "-h") == 0) command->kind = "help";
-      else command->kind = argv[2];
-    }
-    for (int i = 3; i < argc; i++) {
-      if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) return true;
-      else if (!command->input) command->input = argv[i];
-      else return false;
+    for (int i = 2; i < argc; i++) {
+      if (strcmp(argv[i], "--help") == 0 || strcmp(argv[i], "-h") == 0) { command->kind = "help"; continue; }
+      if (strcmp(argv[i], "--json") == 0) { command->json = true; continue; }
+      if (!command->kind) { command->kind = argv[i]; continue; }
+      if (!command->input) { command->input = argv[i]; continue; }
+      command->unknown_flag = argv[i];
+      return true;
     }
     return true;
   }
@@ -5554,9 +5553,48 @@ static int new_command(const Command *command) {
     return 1;
   }
 
-  printf("created %s project %s\n", command->kind, command->input);
-  if (strcmp(command->kind, "lib") == 0) printf("next: cd %s && zero check . && zero test .\n", command->input);
-  else printf("next: cd %s && zero check . && zero test . && zero run .\n", command->input);
+  if (command->json) {
+    ZBuf buf;
+    zbuf_init(&buf);
+    zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"ok\": true,\n  \"kind\": ");
+    append_json_string(&buf, command->kind);
+    zbuf_append(&buf, ",\n  \"name\": ");
+    append_json_string(&buf, command->input);
+    zbuf_append(&buf, ",\n  \"path\": ");
+    append_json_string(&buf, command->input);
+    zbuf_append(&buf, ",\n  \"manifest\": ");
+    ZBuf manifest_path;
+    zbuf_init(&manifest_path);
+    zbuf_append(&manifest_path, command->input);
+    zbuf_append(&manifest_path, "/zero.json");
+    append_json_string(&buf, manifest_path.data);
+    zbuf_free(&manifest_path);
+    zbuf_append(&buf, ",\n  \"entry\": ");
+    ZBuf entry_path;
+    zbuf_init(&entry_path);
+    zbuf_append(&entry_path, command->input);
+    zbuf_append(&entry_path, "/src/main.0");
+    append_json_string(&buf, entry_path.data);
+    zbuf_free(&entry_path);
+    zbuf_append(&buf, ",\n  \"nextSteps\": [");
+    zbuf_append(&buf, "\"zero check ");
+    zbuf_append(&buf, command->input);
+    zbuf_append(&buf, "\", \"zero test ");
+    zbuf_append(&buf, command->input);
+    zbuf_append(&buf, "\"");
+    if (strcmp(command->kind, "lib") != 0) {
+      zbuf_append(&buf, ", \"zero run ");
+      zbuf_append(&buf, command->input);
+      zbuf_append(&buf, "\"");
+    }
+    zbuf_append(&buf, "]\n}\n");
+    fputs(buf.data, stdout);
+    zbuf_free(&buf);
+  } else {
+    printf("created %s project %s\n", command->kind, command->input);
+    if (strcmp(command->kind, "lib") == 0) printf("next: cd %s && zero check . && zero test .\n", command->input);
+    else printf("next: cd %s && zero check . && zero test . && zero run .\n", command->input);
+  }
   return 0;
 }
 

--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
 import { access, mkdtemp, mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { mkdirSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, relative, sep } from "node:path";
 import { describe, it } from "node:test";
@@ -253,5 +254,77 @@ describe("native zero CLI", () => {
     assert.notEqual(result.code, 0);
     assert.match(result.stderr, /FLD001/);
     assert.match(result.stderr, /explain: zero explain FLD001/);
+  });
+
+  it("covers target capability facts in zero targets", async () => {
+    const targets = JSON.parse((await runZero(["targets"])).stdout);
+    assert.equal(targets.schemaVersion, 1);
+    assert.ok(targets.host.length > 0);
+
+    // Find the host target
+    const hostTarget = targets.targets.find((t: { hosted: boolean }) => t.hosted);
+    assert.ok(hostTarget, "host target should exist");
+    assert.equal(hostTarget.hosted, true);
+
+    // Host target should have process/runtime capabilities
+    assert.ok(hostTarget.capabilities.includes("proc"), "host target should have proc capability");
+    assert.ok(hostTarget.capabilities.includes("fs"), "host target should have fs capability");
+    assert.ok(hostTarget.capabilities.includes("net"), "host target should have net capability");
+
+    // Host target should have hosted process/runtime surface facts
+    const hostCapabilityNames = hostTarget.capabilityFacts.map((f: { name: string }) => f.name);
+    assert.ok(hostCapabilityNames.includes("proc"), "host target capabilityFacts should include proc");
+    assert.ok(hostCapabilityNames.includes("fs"), "host target capabilityFacts should include fs");
+
+    // Unavailable capabilities should appear with available: false
+    const webFact = hostTarget.capabilityFacts.find((f: { name: string }) => f.name === "web");
+    if (webFact) {
+      assert.equal(webFact.available, false, "web capability should be unavailable on host target");
+    }
+
+    // Find a non-host target (e.g., wasm32-wasi)
+    const wasmTarget = targets.targets.find((t: { name: string }) => t.name === "wasm32-wasi");
+    if (wasmTarget) {
+      assert.equal(wasmTarget.hosted, false, "wasm32-wasi should not be hosted");
+      assert.ok(!wasmTarget.capabilities.includes("proc"), "wasm should not have proc");
+    }
+  });
+
+  it("covers zero new --json envelope with order-independent args", async () => {
+    const tmpDir = join(tmpdir(), `zero-new-test-${Date.now()}`);
+    mkdirSync(tmpDir, { recursive: true });
+
+    try {
+      // Test --json before positional args
+      const result1 = JSON.parse((await runZero(["new", "--json", "cli", "mycli"], { cwd: tmpDir })).stdout);
+      assert.equal(result1.schemaVersion, 1);
+      assert.equal(result1.ok, true);
+      assert.equal(result1.kind, "cli");
+      assert.equal(result1.name, "mycli");
+      assert.equal(result1.path, "mycli");
+      assert.equal(result1.manifest, "mycli/zero.json");
+      assert.equal(result1.entry, "mycli/src/main.0");
+      assert.ok(Array.isArray(result1.nextSteps));
+      assert.ok(result1.nextSteps.includes("zero run mycli"), "cli should have run in nextSteps");
+
+      // Clean up for next test
+      rmSync(join(tmpDir, "mycli"), { force: true, recursive: true });
+
+      // Test --json after positional args
+      const result2 = JSON.parse((await runZero(["new", "lib", "mylib", "--json"], { cwd: tmpDir })).stdout);
+      assert.equal(result2.kind, "lib");
+      assert.equal(result2.name, "mylib");
+      assert.ok(!result2.nextSteps.includes("zero run mylib"), "lib should not have run in nextSteps");
+      assert.ok(result2.nextSteps.includes("zero check mylib"));
+      assert.ok(result2.nextSteps.includes("zero test mylib"));
+
+      // Test plain-text output is unchanged
+      rmSync(join(tmpDir, "mylib"), { force: true, recursive: true });
+      const result3 = (await runZero(["new", "cli", "plaincli"], { cwd: tmpDir })).stdout;
+      assert.match(result3, /created cli project plaincli/);
+      assert.match(result3, /next: cd plaincli && zero check . && zero test . && zero run ./);
+    } finally {
+      rmSync(tmpDir, { force: true, recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

Adds `--json` flag to `zero new`, outputting structured JSON with:
- `schemaVersion`, `ok`, `kind`, `name`, `path`
- `manifest`, `entry` paths
- `nextSteps` (lib omits `zero run`)

Arg parser rewritten to be order-independent:
- `--json` can appear before or after positional args
- `--json` can appear between kind and name

Plain-text output unchanged.

## Testing

- `zero new --json cli mycli` → correct JSON envelope
- `zero new lib mylib --json` → lib omits run from nextSteps
- `zero new --json package test-pkg` → package includes run
- Plain text output unchanged
- All 11 CLI tests pass

Closes #22