### PR TITLE
Add agent-surface baseline fixtures

### DIFF
--- a/conformance/agent-surface/classification.json
+++ b/conformance/agent-surface/classification.json
@@ -1,0 +1,46 @@
+{
+  "schema": 1,
+  "purpose": "Track minimized agent-surface repros without preserving report source context.",
+  "fixtures": [
+    {
+      "id": "generic-type-shadowing-current",
+      "path": "conformance/agent-surface/fixtures/generic-type-shadowing-current.0",
+      "classification": "compiler-gap",
+      "currentBehavior": "check-pass",
+      "followUp": "Define and enforce or expose an agent-deterministic binding rule for generic type parameters that reuse visible concrete type names.",
+      "runner": "assert-current-behavior"
+    },
+    {
+      "id": "borrow-lexical-lifetime",
+      "path": "conformance/agent-surface/fixtures/borrow-lexical-lifetime.0",
+      "classification": "intended-behavior-with-insufficient-diagnostic-detail",
+      "currentBehavior": "check-fail-BOR001",
+      "followUp": "Keep lexical borrow semantics unless deliberately changed, but expose active borrow root, path, binding, and repair facts in JSON diagnostics.",
+      "runner": "assert-diagnostic-code"
+    },
+    {
+      "id": "unresolved-package-import",
+      "path": "conformance/agent-surface/fixtures/unresolved-package-import",
+      "classification": "diagnostic-surface-gap",
+      "currentBehavior": "check-fail-IMP001",
+      "followUp": "Parse use declarations into first-class import nodes and tie resolver diagnostics to their source ranges.",
+      "runner": "assert-diagnostic-code"
+    },
+    {
+      "id": "malformed-use-current",
+      "path": "conformance/agent-surface/fixtures/malformed-use-current.0",
+      "classification": "parser-surface-gap",
+      "currentBehavior": "check-pass",
+      "followUp": "Parse use declarations as syntax-bearing nodes so malformed import paths produce parser diagnostics instead of being skipped.",
+      "runner": "assert-current-behavior"
+    },
+    {
+      "id": "owned-drop-direct-backend-unsupported",
+      "path": "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0",
+      "classification": "backend-limitation-reported-late",
+      "currentBehavior": "check-pass-build-fail-CGEN004",
+      "followUp": "Report target-aware backend blockers before emission and keep backend diagnostics target-correct.",
+      "runner": "assert-diagnostic-code"
+    }
+  ]
+}

--- a/conformance/agent-surface/fixtures/borrow-lexical-lifetime.0
+++ b/conformance/agent-surface/fixtures/borrow-lexical-lifetime.0
@@ -1,0 +1,17 @@
+shape Data {
+    value: i32,
+}
+
+fun update(target: mutref<Data>) -> Void {
+    target.value = target.value + 1
+}
+
+pub fun main(world: World) -> Void raises {
+    let mut data: Data = Data { value: 0 }
+    let shared = &data
+    let observed = shared.value
+    update(&mut data)
+    if observed == 0 {
+        check world.out.write("borrow lexical lifetime current ok\n")
+    }
+}

--- a/conformance/agent-surface/fixtures/generic-type-shadowing-current.0
+++ b/conformance/agent-surface/fixtures/generic-type-shadowing-current.0
@@ -1,0 +1,17 @@
+shape T {
+    value: i32,
+}
+
+fun identity<T>(value: T) -> T {
+    return value
+}
+
+pub fun main(world: World) -> Void raises {
+    let concrete: T = T { value: 42 }
+    let result: T = identity<T>(concrete)
+    if result.value == 42 {
+        check world.out.write("generic type shadowing current ok\n")
+    } else {
+        check world.out.write("generic type shadowing current broke\n")
+    }
+}

--- a/conformance/agent-surface/fixtures/malformed-use-current.0
+++ b/conformance/agent-surface/fixtures/malformed-use-current.0
@@ -1,0 +1,5 @@
+use std.
+
+pub fun main(world: World) -> Void raises {
+    check world.out.write("malformed use current ok\n")
+}

--- a/conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0
+++ b/conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0
@@ -1,0 +1,14 @@
+shape Tracked {
+    value: i32,
+
+    fun drop(self: mutref<Self>) -> Void {
+        self.value = 0
+    }
+}
+
+pub fun main(world: World) -> Void raises {
+    let tracked: owned<Tracked> = Tracked { value: 42 }
+    if tracked.value == 42 {
+        check world.out.write("owned drop backend unsupported current ok\n")
+    }
+}

--- a/conformance/agent-surface/fixtures/unresolved-package-import/src/main.0
+++ b/conformance/agent-surface/fixtures/unresolved-package-import/src/main.0
@@ -1,0 +1,5 @@
+use missing.utility
+
+pub fun main(world: World) -> Void raises {
+    check world.out.write("unresolved import current\n")
+}

--- a/conformance/agent-surface/fixtures/unresolved-package-import/zero.json
+++ b/conformance/agent-surface/fixtures/unresolved-package-import/zero.json
@@ -1,0 +1,4 @@
+{
+  "package": { "name": "agent-surface-unresolved-import", "version": "0.1.0" },
+  "targets": { "cli": { "kind": "exe", "main": "src/main.0" } }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -430,6 +430,58 @@ assert.ok(checkJsonSuccessBody.incrementalInvalidation.targetDependency);
 assert.equal(checkJsonSuccessBody.incrementalInvalidation.profileDependency, "release");
 assert.equal(checkJsonSuccessBody.incrementalInvalidation.recheckStrategy, "fingerprint changed modules and dependent bodies");
 
+const agentSurfaceClassification = JSON.parse(await readFile("conformance/agent-surface/classification.json", "utf8"));
+assert.equal(agentSurfaceClassification.schema, 1);
+assert.deepEqual(agentSurfaceClassification.fixtures.map((item) => item.id), [
+  "generic-type-shadowing-current",
+  "borrow-lexical-lifetime",
+  "unresolved-package-import",
+  "malformed-use-current",
+  "owned-drop-direct-backend-unsupported",
+]);
+
+const agentSurfaceGenericShadowing = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/generic-type-shadowing-current.0"]);
+const agentSurfaceGenericShadowingBody = JSON.parse(agentSurfaceGenericShadowing.stdout);
+assert.equal(agentSurfaceGenericShadowingBody.ok, true);
+assert.equal(agentSurfaceGenericShadowingBody.diagnostics.length, 0);
+
+const agentSurfaceBorrowLifetime = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/borrow-lexical-lifetime.0"]).catch((error) => error);
+assert.notEqual(agentSurfaceBorrowLifetime.code, 0);
+const agentSurfaceBorrowLifetimeBody = JSON.parse(agentSurfaceBorrowLifetime.stdout);
+assert.equal(agentSurfaceBorrowLifetimeBody.diagnostics[0].code, "BOR001");
+assert.match(agentSurfaceBorrowLifetimeBody.diagnostics[0].actual, /data already has shared borrow/);
+
+const agentSurfaceUnresolvedImport = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/unresolved-package-import"]).catch((error) => error);
+assert.notEqual(agentSurfaceUnresolvedImport.code, 0);
+const agentSurfaceUnresolvedImportBody = JSON.parse(agentSurfaceUnresolvedImport.stdout);
+assert.equal(agentSurfaceUnresolvedImportBody.diagnostics[0].code, "IMP001");
+assert.match(agentSurfaceUnresolvedImportBody.diagnostics[0].expected, /src\/missing\.utility\.0/);
+
+const agentSurfaceMalformedUse = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/malformed-use-current.0"]);
+const agentSurfaceMalformedUseBody = JSON.parse(agentSurfaceMalformedUse.stdout);
+assert.equal(agentSurfaceMalformedUseBody.ok, true);
+assert.equal(agentSurfaceMalformedUseBody.diagnostics.length, 0);
+
+const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0"]);
+const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
+assert.equal(agentSurfaceOwnedDropCheckBody.ok, true);
+const agentSurfaceOwnedDropBuild = await execFileAsync(zero, [
+  "build",
+  "--json",
+  "--emit",
+  "obj",
+  "--target",
+  "win32-x64.exe",
+  "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0",
+  "--out",
+  `${outDir}/agent-surface-owned-drop.obj`,
+]).catch((error) => error);
+assert.notEqual(agentSurfaceOwnedDropBuild.code, 0);
+const agentSurfaceOwnedDropBuildBody = JSON.parse(agentSurfaceOwnedDropBuild.stdout);
+assert.equal(agentSurfaceOwnedDropBuildBody.diagnostics[0].code, "CGEN004");
+assert.match(agentSurfaceOwnedDropBuildBody.diagnostics[0].expected, /COFF/);
+assert.equal(agentSurfaceOwnedDropBuildBody.diagnostics[0].actual, "owned<Tracked>");
+
 const compileTimeJson = await execFileAsync(zero, ["check", "--json", "conformance/native/pass/compile-time-v1.0"]);
 const compileTimeBody = JSON.parse(compileTimeJson.stdout);
 assert.equal(compileTimeBody.ok, true);


### PR DESCRIPTION
- Capture current behavior for key agent-surface gaps
- Add neutral classification metadata for follow-up PRs
- Assert baselines in conformance