### PR TITLE
bench: add token-count benchmark

### DIFF
--- a/benchmarks/zero/token-count.0
+++ b/benchmarks/zero/token-count.0
@@ -1,0 +1,18 @@
+pub fun main(world: World) -> Void raises {
+    let input: Span<u8> = std.mem.span("the quick brown fox")
+    let len: usize = std.mem.len(input)
+    let space: u8 = 32_u8
+    let mut count: usize = 0
+    let mut prev: u8 = 32_u8
+    let mut i: usize = 0
+    while i < len {
+        if input[i] != space && prev == space {
+            count = count + 1
+        }
+        prev = input[i]
+        i = i + 1
+    }
+    if count == 4 {
+        check world.out.write("token-count\n")
+    }
+}

--- a/docs-site/articles/benchmarks.md
+++ b/docs-site/articles/benchmarks.md
@@ -37,6 +37,7 @@ The current cases include:
 - `slices`, `arena`, `fallibility`, `branches`: memory views, fixed-buffer allocation style, explicit fallible branching, and branch-heavy loops
 - `module-package`, `rescue`: package graph overhead and local rescue lowering
 - `fs-resource`, `mem-copy-fill`, `zero-hash`: focused Zero cases for file-resource metadata, memory helpers, and deterministic byte payload processing
+- `token-count`: space-delimited token scan over a fixed byte span
 
 The Zero sources for these cases live under `benchmarks/zero`.
 Host targets that do not support a direct executable runner for a case report it

--- a/scripts/bench.mjs
+++ b/scripts/bench.mjs
@@ -46,6 +46,7 @@ const cases = [
   { name: "zero-hash", expectedStdout: "zero-hash ok", languages: ["zero"] },
   { name: "json", expectedStdout: "json", languages: ["zero"] },
   { name: "networking", expectedStdout: "networking", languages: ["zero"], skipLanguages: ["zero"] },
+  { name: "token-count", expectedStdout: "token-count", languages: ["zero"] },
 ];
 
 const languages = [
@@ -428,6 +429,7 @@ function buildMeasurementCoverage(results) {
       measurementFact(results, "rescue", "fallible-rescue"),
       measurementFact(results, "networking", "networking"),
       measurementFact(results, "json", "json"),
+      measurementFact(results, "token-count", "token-scan"),
     ],
   };
 }


### PR DESCRIPTION
## Summary

- add a `token-count` Zero benchmark case
- register the case in the benchmark harness
- document the new benchmark in the public benchmark docs

Closes #8

## Validation

- `make -C native/zero-c`
- `bin/zero check --json benchmarks/zero/token-count.0`
- `npm run docs:test`
- `bin/zero build --json --emit exe --target linux-musl-x64 benchmarks/zero/token-count.0 --out .zero/bench/zero-token-count-linux`

`check` returns `ok: true` with zero diagnostics. The Linux direct executable build produces a 529-byte ELF64 artifact with `generatedCBytes: 0` and `cBridgeFallback: false`. Note: `ZERO_BENCH_RUNS=1 npm run bench` was not attempted on macOS arm64 due to the Darwin `dyld: missing LC_UUID load command` issue tracked in #28.