### PR TITLE
Parse use imports into graph facts

### DIFF
--- a/conformance/agent-surface/classification.json
+++ b/conformance/agent-surface/classification.json
@@ -71,16 +71,16 @@
       "path": "conformance/agent-surface/fixtures/unresolved-package-import",
       "classification": "diagnostic-surface-gap",
       "currentBehavior": "check-fail-IMP001",
-      "followUp": "Parse use declarations into first-class import nodes and tie resolver diagnostics to their source ranges.",
+      "followUp": "Tie resolver diagnostics to parsed import source ranges.",
       "runner": "assert-diagnostic-code"
     },
     {
       "id": "malformed-use-current",
       "path": "conformance/agent-surface/fixtures/malformed-use-current.0",
-      "classification": "parser-surface-gap",
-      "currentBehavior": "check-pass",
-      "followUp": "Parse use declarations as syntax-bearing nodes so malformed import paths produce parser diagnostics instead of being skipped.",
-      "runner": "assert-current-behavior"
+      "classification": "parser-surface-rule",
+      "currentBehavior": "check-fail-PAR100",
+      "followUp": "Keep malformed import paths syntax-bearing so parser diagnostics point at the bad import span.",
+      "runner": "assert-diagnostic-code"
     },
     {
       "id": "owned-drop-direct-backend-unsupported",

--- a/conformance/agent-surface/fixtures/malformed-use-current.0
+++ b/conformance/agent-surface/fixtures/malformed-use-current.0
@@ -1,5 +1,5 @@
 use std.
 
 pub fun main(world: World) -> Void raises {
-    check world.out.write("malformed use current ok\n")
+    check world.out.write("malformed use parser fixture\n")
 }

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1782,6 +1782,26 @@ assert(importGraphBody.useImports.every((item) => item.sourceRange.columnUnit ==
 assert(importGraphBody.symbols.some((item) => item.module === "math" && item.name === "add_one"));
 assert(importGraphBody.functions.some((item) => item.name === "main" && item.returnType === "Void" && item.effects.includes("world")));
 
+const whitespaceUsePackage = `${outDir}/use-whitespace-package`;
+await mkdir(`${whitespaceUsePackage}/src`, { recursive: true });
+await writeFile(`${whitespaceUsePackage}/zero.json`, JSON.stringify({
+  package: { name: "use-whitespace-package", version: "0.1.0" },
+  targets: { cli: { kind: "exe", main: "src/main.0" } },
+  deps: {},
+}, null, 2));
+await writeFile(`${whitespaceUsePackage}/src/math.0`, 'fun add_one(value: i32) -> i32 {\n    return value + 1\n}\n');
+await writeFile(`${whitespaceUsePackage}/src/types.0`, 'shape Point {\n    value: i32,\n}\n');
+await writeFile(`${whitespaceUsePackage}/src/main.0`, 'use\tmath\nuse   types   as   model\n\npub fun main(world: World) -> Void raises {\n    let point = Point { value: add_one(41) }\n    if point.value == 42 {\n        check world.out.write("whitespace imports pass\\n")\n    }\n}\n');
+const whitespaceUseCheck = await execFileAsync(zero, ["check", "--json", whitespaceUsePackage]);
+assert.equal(JSON.parse(whitespaceUseCheck.stdout).ok, true);
+const whitespaceUseGraph = await execFileAsync(zero, ["graph", "--json", whitespaceUsePackage]);
+const whitespaceUseGraphBody = JSON.parse(whitespaceUseGraph.stdout);
+assert.deepEqual(whitespaceUseGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.alias ?? "null"}:${item.sourceRange.end.column}`), [
+  "main->math:package-local:null:9",
+  "main->types:package-local:model:25",
+]);
+assert.deepEqual(whitespaceUseGraphBody.importEdges.map((item) => `${item.from}->${item.to}`), ["main->math", "main->types"]);
+
 const packageUseGraph = await execFileAsync(zero, ["graph", "--json", "conformance/check/pass/package"]);
 const packageUseGraphBody = JSON.parse(packageUseGraph.stdout);
 assert.deepEqual(packageUseGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.resolvedPath ?? "null"}`), [

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -507,6 +507,26 @@ assert.match(agentSurfaceMalformedUseBody.diagnostics[0].message, /expected impo
 assert.equal(agentSurfaceMalformedUseBody.diagnostics[0].line, 1);
 assert.equal(agentSurfaceMalformedUseBody.diagnostics[0].column, 8);
 
+const agentSurfaceMalformedLocalUseFixture = `${outDir}/malformed-local-use.0`;
+await writeFile(agentSurfaceMalformedLocalUseFixture, 'use local.\n\npub fun main(world: World) -> Void raises {\n    check world.out.write("malformed local use parser fixture\\n")\n}\n');
+const agentSurfaceMalformedLocalUse = await execFileAsync(zero, ["check", "--json", agentSurfaceMalformedLocalUseFixture]).catch((error) => error);
+assert.notEqual(agentSurfaceMalformedLocalUse.code, 0);
+const agentSurfaceMalformedLocalUseBody = JSON.parse(agentSurfaceMalformedLocalUse.stdout);
+assert.equal(agentSurfaceMalformedLocalUseBody.diagnostics[0].code, "PAR100");
+assert.match(agentSurfaceMalformedLocalUseBody.diagnostics[0].message, /expected import module segment/);
+assert.equal(agentSurfaceMalformedLocalUseBody.diagnostics[0].line, 1);
+assert.equal(agentSurfaceMalformedLocalUseBody.diagnostics[0].column, 10);
+
+const agentSurfaceSplitUseFixture = `${outDir}/split-use-path.0`;
+await writeFile(agentSurfaceSplitUseFixture, 'use std.\ncodec\n\npub fun main(world: World) -> Void raises {\n    check world.out.write("split use parser fixture\\n")\n}\n');
+const agentSurfaceSplitUse = await execFileAsync(zero, ["check", "--json", agentSurfaceSplitUseFixture]).catch((error) => error);
+assert.notEqual(agentSurfaceSplitUse.code, 0);
+const agentSurfaceSplitUseBody = JSON.parse(agentSurfaceSplitUse.stdout);
+assert.equal(agentSurfaceSplitUseBody.diagnostics[0].code, "PAR100");
+assert.match(agentSurfaceSplitUseBody.diagnostics[0].message, /expected import module segment/);
+assert.equal(agentSurfaceSplitUseBody.diagnostics[0].line, 1);
+assert.equal(agentSurfaceSplitUseBody.diagnostics[0].column, 8);
+
 const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0"]);
 const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
 assert.equal(agentSurfaceOwnedDropCheckBody.ok, true);

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -527,6 +527,16 @@ assert.match(agentSurfaceSplitUseBody.diagnostics[0].message, /expected import m
 assert.equal(agentSurfaceSplitUseBody.diagnostics[0].line, 1);
 assert.equal(agentSurfaceSplitUseBody.diagnostics[0].column, 8);
 
+const agentSurfaceKeywordUseFixture = `${outDir}/keyword-use.0`;
+await writeFile(agentSurfaceKeywordUseFixture, 'use pub\n\npub fun main(world: World) -> Void raises {\n    check world.out.write("keyword use parser fixture\\n")\n}\n');
+const agentSurfaceKeywordUse = await execFileAsync(zero, ["check", "--json", agentSurfaceKeywordUseFixture]).catch((error) => error);
+assert.notEqual(agentSurfaceKeywordUse.code, 0);
+const agentSurfaceKeywordUseBody = JSON.parse(agentSurfaceKeywordUse.stdout);
+assert.equal(agentSurfaceKeywordUseBody.diagnostics[0].code, "PAR100");
+assert.match(agentSurfaceKeywordUseBody.diagnostics[0].message, /expected import module name/);
+assert.equal(agentSurfaceKeywordUseBody.diagnostics[0].line, 1);
+assert.equal(agentSurfaceKeywordUseBody.diagnostics[0].column, 5);
+
 const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0"]);
 const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
 assert.equal(agentSurfaceOwnedDropCheckBody.ok, true);

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -499,10 +499,13 @@ const agentSurfaceUnresolvedImportBody = JSON.parse(agentSurfaceUnresolvedImport
 assert.equal(agentSurfaceUnresolvedImportBody.diagnostics[0].code, "IMP001");
 assert.match(agentSurfaceUnresolvedImportBody.diagnostics[0].expected, /src\/missing\.utility\.0/);
 
-const agentSurfaceMalformedUse = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/malformed-use-current.0"]);
+const agentSurfaceMalformedUse = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/malformed-use-current.0"]).catch((error) => error);
+assert.notEqual(agentSurfaceMalformedUse.code, 0);
 const agentSurfaceMalformedUseBody = JSON.parse(agentSurfaceMalformedUse.stdout);
-assert.equal(agentSurfaceMalformedUseBody.ok, true);
-assert.equal(agentSurfaceMalformedUseBody.diagnostics.length, 0);
+assert.equal(agentSurfaceMalformedUseBody.diagnostics[0].code, "PAR100");
+assert.match(agentSurfaceMalformedUseBody.diagnostics[0].message, /expected import module segment/);
+assert.equal(agentSurfaceMalformedUseBody.diagnostics[0].line, 1);
+assert.equal(agentSurfaceMalformedUseBody.diagnostics[0].column, 8);
 
 const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0"]);
 const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
@@ -1737,8 +1740,26 @@ assert(importGraphBody.sourceMaps.every((item) => item.columnUnit === "utf8-byte
 assert.deepEqual(importGraphBody.targets.map((item) => item.name), ["cli"]);
 assert.deepEqual(importGraphBody.modules.map((item) => item.name), ["math", "types", "main"]);
 assert.deepEqual(importGraphBody.importEdges.map((item) => `${item.from}->${item.to}`), ["main->math", "main->types"]);
+assert.deepEqual(importGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.line}:${item.column}`), [
+  "main->math:package-local:1:1",
+  "main->types:package-local:2:1",
+]);
+assert.deepEqual(importGraphBody.useImports.map((item) => item.resolvedPath), [
+  "conformance/check/pass/imports/src/math.0",
+  "conformance/check/pass/imports/src/types.0",
+]);
+assert(importGraphBody.useImports.every((item) => item.sourceRange.columnUnit === "utf8-byte"));
 assert(importGraphBody.symbols.some((item) => item.module === "math" && item.name === "add_one"));
 assert(importGraphBody.functions.some((item) => item.name === "main" && item.returnType === "Void" && item.effects.includes("world")));
+
+const packageUseGraph = await execFileAsync(zero, ["graph", "--json", "conformance/check/pass/package"]);
+const packageUseGraphBody = JSON.parse(packageUseGraph.stdout);
+assert.deepEqual(packageUseGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.resolvedPath ?? "null"}`), [
+  "main->std.codec:stdlib:null",
+  "main->std.parse:stdlib:null",
+  "main->std.time:stdlib:null",
+  "main->types:package-local:conformance/check/pass/package/src/types.0",
+]);
 
 const resourceGraph = await execFileAsync(zero, ["graph", "--json", "examples/resource-cli"]);
 const resourceGraphBody = JSON.parse(resourceGraph.stdout);

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1789,18 +1789,21 @@ await writeFile(`${whitespaceUsePackage}/zero.json`, JSON.stringify({
   targets: { cli: { kind: "exe", main: "src/main.0" } },
   deps: {},
 }, null, 2));
+await mkdir(`${whitespaceUsePackage}/src/math`, { recursive: true });
 await writeFile(`${whitespaceUsePackage}/src/math.0`, 'fun add_one(value: i32) -> i32 {\n    return value + 1\n}\n');
+await writeFile(`${whitespaceUsePackage}/src/math/util.0`, 'fun add_two(value: i32) -> i32 {\n    return value + 2\n}\n');
 await writeFile(`${whitespaceUsePackage}/src/types.0`, 'shape Point {\n    value: i32,\n}\n');
-await writeFile(`${whitespaceUsePackage}/src/main.0`, 'use\tmath\nuse   types   as   model\n\npub fun main(world: World) -> Void raises {\n    let point = Point { value: add_one(41) }\n    if point.value == 42 {\n        check world.out.write("whitespace imports pass\\n")\n    }\n}\n');
+await writeFile(`${whitespaceUsePackage}/src/main.0`, 'use\tmath\nuse math . util\nuse   types   as   model\n\npub fun main(world: World) -> Void raises {\n    let point = Point { value: add_two(40) }\n    if point.value == add_one(41) {\n        check world.out.write("whitespace imports pass\\n")\n    }\n}\n');
 const whitespaceUseCheck = await execFileAsync(zero, ["check", "--json", whitespaceUsePackage]);
 assert.equal(JSON.parse(whitespaceUseCheck.stdout).ok, true);
 const whitespaceUseGraph = await execFileAsync(zero, ["graph", "--json", whitespaceUsePackage]);
 const whitespaceUseGraphBody = JSON.parse(whitespaceUseGraph.stdout);
 assert.deepEqual(whitespaceUseGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.alias ?? "null"}:${item.sourceRange.end.column}`), [
   "main->math:package-local:null:9",
+  "main->math.util:package-local:null:16",
   "main->types:package-local:model:25",
 ]);
-assert.deepEqual(whitespaceUseGraphBody.importEdges.map((item) => `${item.from}->${item.to}`), ["main->math", "main->types"]);
+assert.deepEqual(whitespaceUseGraphBody.importEdges.map((item) => `${item.from}->${item.to}`), ["main->math", "main->math.util", "main->types"]);
 
 const packageUseGraph = await execFileAsync(zero, ["graph", "--json", "conformance/check/pass/package"]);
 const packageUseGraphBody = JSON.parse(packageUseGraph.stdout);

--- a/docs-site/articles/language-reference.md
+++ b/docs-site/articles/language-reference.md
@@ -772,9 +772,9 @@ imports, direct import cycles, bad manifests, and duplicate public exports are
 reported before parsing the combined package source.
 
 `zero graph --json <package>` lists module names, source paths, import edges,
-public/private symbol counts, target metadata, function effects, required
-capabilities, and whether the selected target provides hosted filesystem
-support.
+parsed `useImports` with source ranges, public/private symbol counts, target
+metadata, function effects, required capabilities, and whether the selected
+target provides hosted filesystem support.
 
 There is no published package registry or semantic version solver in the
 current compiler.

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -337,6 +337,7 @@ typedef struct {
   char *alias;
   int line;
   int column;
+  int end_column;
 } UseImport;
 
 typedef struct {

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -333,6 +333,20 @@ typedef struct {
 } CImportVec;
 
 typedef struct {
+  char *module;
+  char *alias;
+  int line;
+  int column;
+} UseImport;
+
+typedef struct {
+  UseImport *items;
+  size_t len;
+  size_t cap;
+} UseImportVec;
+
+typedef struct {
+  UseImportVec use_imports;
   CImportVec c_imports;
   ConstVec consts;
   TypeAliasVec aliases;

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -580,8 +580,8 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
     }
     const char *module = NULL;
     size_t module_len = 0;
-    if (len >= 4 && strncmp(start, "use ", 4) == 0) {
-      parse_use_import_line_module(start + 4, len - 4, &module, &module_len);
+    if (len > 3 && strncmp(start, "use", 3) == 0 && isspace((unsigned char)start[3])) {
+      parse_use_import_line_module(start + 3, len - 3, &module, &module_len);
     } else if (len >= 7 && strncmp(start, "import ", 7) == 0) {
       module = start + 7;
       module_len = len - 7;

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -501,6 +501,58 @@ static void format_cycle_chain(const char *src_root, char **stack, size_t stack_
   free(module);
 }
 
+static bool import_ident_start(char ch) {
+  return isalpha((unsigned char)ch) || ch == '_';
+}
+
+static bool import_ident_continue(char ch) {
+  return isalnum((unsigned char)ch) || ch == '_';
+}
+
+static bool import_line_comment_at(const char *text, size_t pos, size_t len) {
+  return pos + 1 < len && text[pos] == '/' && text[pos + 1] == '/';
+}
+
+static void import_line_skip_ws(const char *text, size_t len, size_t *pos) {
+  while (*pos < len && isspace((unsigned char)text[*pos])) (*pos)++;
+}
+
+static bool parse_use_import_line_module(const char *text, size_t len, const char **module_out, size_t *module_len_out) {
+  size_t pos = 0;
+  import_line_skip_ws(text, len, &pos);
+  if (pos >= len || !import_ident_start(text[pos])) return false;
+  size_t module_start = pos;
+  for (;;) {
+    if (pos >= len || !import_ident_start(text[pos])) return false;
+    pos++;
+    while (pos < len && import_ident_continue(text[pos])) pos++;
+    if (pos < len && text[pos] == '.') {
+      pos++;
+      if (pos >= len || !import_ident_start(text[pos])) return false;
+      continue;
+    }
+    break;
+  }
+  size_t module_end = pos;
+  import_line_skip_ws(text, len, &pos);
+  if (import_line_comment_at(text, pos, len)) pos = len;
+  if (pos < len) {
+    if (pos + 2 > len || strncmp(text + pos, "as", 2) != 0) return false;
+    pos += 2;
+    if (pos >= len || !isspace((unsigned char)text[pos])) return false;
+    import_line_skip_ws(text, len, &pos);
+    if (pos >= len || !import_ident_start(text[pos])) return false;
+    pos++;
+    while (pos < len && import_ident_continue(text[pos])) pos++;
+    import_line_skip_ws(text, len, &pos);
+    if (import_line_comment_at(text, pos, len)) pos = len;
+    if (pos < len) return false;
+  }
+  *module_out = text + module_start;
+  *module_len_out = module_end - module_start;
+  return true;
+}
+
 static bool scan_imports_and_append_dependencies(const char *source, const char *src_root, const char *current_module, SourceInput *input, ZBuf *combined, ZDiag *diag, char ***stack, size_t *stack_len) {
   const char *line = source;
   while (*line && diag->code == 0) {
@@ -512,16 +564,12 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
       len--;
     }
     const char *module = NULL;
-    size_t prefix_len = 0;
+    size_t module_len = 0;
     if (len >= 4 && strncmp(start, "use ", 4) == 0) {
-      module = start + 4;
-      prefix_len = 4;
+      parse_use_import_line_module(start + 4, len - 4, &module, &module_len);
     } else if (len >= 7 && strncmp(start, "import ", 7) == 0) {
       module = start + 7;
-      prefix_len = 7;
-    }
-    if (module) {
-      size_t module_len = len - prefix_len;
+      module_len = len - 7;
       while (module_len > 0 && isspace((unsigned char)module[module_len - 1])) module_len--;
       const char *as_kw = NULL;
       for (size_t i = 0; i + 4 <= module_len; i++) {
@@ -531,6 +579,8 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
         }
       }
       if (as_kw) module_len = (size_t)(as_kw - module);
+    }
+    if (module) {
       if (module_len >= 4 && strncmp(module, "std.", 4) == 0) {
         if (!end) break;
         line = end + 1;

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -509,6 +509,27 @@ static bool import_ident_continue(char ch) {
   return isalnum((unsigned char)ch) || ch == '_';
 }
 
+static bool import_ident_is_keyword(const char *text, size_t len) {
+  const char *keywords[] = {
+    "as", "break", "check", "choice", "const", "continue", "defer", "else", "enum", "export", "extern", "false", "for", "fun",
+    "if", "import", "in", "let", "match", "meta", "mut", "null", "packed", "pub",
+    "raise", "raises", "rescue", "return", "shape", "static", "test", "true", "type",
+    "use", "var", "while", NULL
+  };
+  for (int i = 0; keywords[i]; i++) {
+    if (strlen(keywords[i]) == len && strncmp(text, keywords[i], len) == 0) return true;
+  }
+  return false;
+}
+
+static bool parse_use_import_ident_segment(const char *text, size_t len, size_t *pos) {
+  if (*pos >= len || !import_ident_start(text[*pos])) return false;
+  size_t start = *pos;
+  (*pos)++;
+  while (*pos < len && import_ident_continue(text[*pos])) (*pos)++;
+  return !import_ident_is_keyword(text + start, *pos - start);
+}
+
 static bool import_line_comment_at(const char *text, size_t pos, size_t len) {
   return pos + 1 < len && text[pos] == '/' && text[pos + 1] == '/';
 }
@@ -520,15 +541,11 @@ static void import_line_skip_ws(const char *text, size_t len, size_t *pos) {
 static bool parse_use_import_line_module(const char *text, size_t len, const char **module_out, size_t *module_len_out) {
   size_t pos = 0;
   import_line_skip_ws(text, len, &pos);
-  if (pos >= len || !import_ident_start(text[pos])) return false;
   size_t module_start = pos;
   for (;;) {
-    if (pos >= len || !import_ident_start(text[pos])) return false;
-    pos++;
-    while (pos < len && import_ident_continue(text[pos])) pos++;
+    if (!parse_use_import_ident_segment(text, len, &pos)) return false;
     if (pos < len && text[pos] == '.') {
       pos++;
-      if (pos >= len || !import_ident_start(text[pos])) return false;
       continue;
     }
     break;
@@ -541,9 +558,7 @@ static bool parse_use_import_line_module(const char *text, size_t len, const cha
     pos += 2;
     if (pos >= len || !isspace((unsigned char)text[pos])) return false;
     import_line_skip_ws(text, len, &pos);
-    if (pos >= len || !import_ident_start(text[pos])) return false;
-    pos++;
-    while (pos < len && import_ident_continue(text[pos])) pos++;
+    if (!parse_use_import_ident_segment(text, len, &pos)) return false;
     import_line_skip_ws(text, len, &pos);
     if (import_line_comment_at(text, pos, len)) pos = len;
     if (pos < len) return false;

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -407,8 +407,8 @@ static void append_source_without_imports(SourceInput *input, ZBuf *buf, const c
       start++;
       len--;
     }
-    bool is_import = (len >= 4 && strncmp(start, "use ", 4) == 0) || (len >= 7 && strncmp(start, "import ", 7) == 0);
-    if (!is_import) {
+    bool is_legacy_import = len >= 7 && strncmp(start, "import ", 7) == 0;
+    if (!is_legacy_import) {
       zbuf_appendf(buf, "%.*s\n", (int)(end ? (size_t)(end - line) : strlen(line)), line);
       source_input_push_source_line(input, path, original_line);
     }

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -522,12 +522,15 @@ static bool import_ident_is_keyword(const char *text, size_t len) {
   return false;
 }
 
-static bool parse_use_import_ident_segment(const char *text, size_t len, size_t *pos) {
+static bool parse_use_import_ident_segment(const char *text, size_t len, size_t *pos, const char **segment_out, size_t *segment_len_out) {
   if (*pos >= len || !import_ident_start(text[*pos])) return false;
   size_t start = *pos;
   (*pos)++;
   while (*pos < len && import_ident_continue(text[*pos])) (*pos)++;
-  return !import_ident_is_keyword(text + start, *pos - start);
+  if (import_ident_is_keyword(text + start, *pos - start)) return false;
+  if (segment_out) *segment_out = text + start;
+  if (segment_len_out) *segment_len_out = *pos - start;
+  return true;
 }
 
 static bool import_line_comment_at(const char *text, size_t pos, size_t len) {
@@ -538,33 +541,59 @@ static void import_line_skip_ws(const char *text, size_t len, size_t *pos) {
   while (*pos < len && isspace((unsigned char)text[*pos])) (*pos)++;
 }
 
-static bool parse_use_import_line_module(const char *text, size_t len, const char **module_out, size_t *module_len_out) {
+static void import_line_append_span(ZBuf *buf, const char *text, size_t len) {
+  for (size_t i = 0; i < len; i++) zbuf_append_char(buf, text[i]);
+}
+
+static bool parse_use_import_line_module(const char *text, size_t len, char **module_out) {
   size_t pos = 0;
   import_line_skip_ws(text, len, &pos);
-  size_t module_start = pos;
+  ZBuf module;
+  zbuf_init(&module);
+  bool wrote_segment = false;
   for (;;) {
-    if (!parse_use_import_ident_segment(text, len, &pos)) return false;
+    const char *segment = NULL;
+    size_t segment_len = 0;
+    if (!parse_use_import_ident_segment(text, len, &pos, &segment, &segment_len)) {
+      zbuf_free(&module);
+      return false;
+    }
+    if (wrote_segment) zbuf_append_char(&module, '.');
+    import_line_append_span(&module, segment, segment_len);
+    wrote_segment = true;
+    import_line_skip_ws(text, len, &pos);
     if (pos < len && text[pos] == '.') {
       pos++;
+      import_line_skip_ws(text, len, &pos);
       continue;
     }
     break;
   }
-  size_t module_end = pos;
   import_line_skip_ws(text, len, &pos);
   if (import_line_comment_at(text, pos, len)) pos = len;
   if (pos < len) {
-    if (pos + 2 > len || strncmp(text + pos, "as", 2) != 0) return false;
+    if (pos + 2 > len || strncmp(text + pos, "as", 2) != 0) {
+      zbuf_free(&module);
+      return false;
+    }
     pos += 2;
-    if (pos >= len || !isspace((unsigned char)text[pos])) return false;
+    if (pos >= len || !isspace((unsigned char)text[pos])) {
+      zbuf_free(&module);
+      return false;
+    }
     import_line_skip_ws(text, len, &pos);
-    if (!parse_use_import_ident_segment(text, len, &pos)) return false;
+    if (!parse_use_import_ident_segment(text, len, &pos, NULL, NULL)) {
+      zbuf_free(&module);
+      return false;
+    }
     import_line_skip_ws(text, len, &pos);
     if (import_line_comment_at(text, pos, len)) pos = len;
-    if (pos < len) return false;
+    if (pos < len) {
+      zbuf_free(&module);
+      return false;
+    }
   }
-  *module_out = text + module_start;
-  *module_len_out = module_end - module_start;
+  *module_out = module.data ? module.data : z_strdup("");
   return true;
 }
 
@@ -578,13 +607,12 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
       start++;
       len--;
     }
-    const char *module = NULL;
-    size_t module_len = 0;
+    char *module_name = NULL;
     if (len > 3 && strncmp(start, "use", 3) == 0 && isspace((unsigned char)start[3])) {
-      parse_use_import_line_module(start + 3, len - 3, &module, &module_len);
+      parse_use_import_line_module(start + 3, len - 3, &module_name);
     } else if (len >= 7 && strncmp(start, "import ", 7) == 0) {
-      module = start + 7;
-      module_len = len - 7;
+      const char *module = start + 7;
+      size_t module_len = len - 7;
       while (module_len > 0 && isspace((unsigned char)module[module_len - 1])) module_len--;
       const char *as_kw = NULL;
       for (size_t i = 0; i + 4 <= module_len; i++) {
@@ -594,14 +622,15 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
         }
       }
       if (as_kw) module_len = (size_t)(as_kw - module);
+      module_name = z_strndup(module, module_len);
     }
-    if (module) {
-      if (module_len >= 4 && strncmp(module, "std.", 4) == 0) {
+    if (module_name) {
+      if (strncmp(module_name, "std.", 4) == 0) {
+        free(module_name);
         if (!end) break;
         line = end + 1;
         continue;
       }
-      char *module_name = z_strndup(module, module_len);
       source_input_push_import(input, module_name);
       char *module_path = module_path_to_source(src_root, module_name);
       if (!module_path) {

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -8293,12 +8293,6 @@ static const char *resolved_path_for_import(const SourceInput *input, const char
   return NULL;
 }
 
-static int use_import_end_column(const UseImport *item) {
-  size_t end = (size_t)(item->column > 0 ? item->column : 1) + strlen("use ") + strlen(item->module ? item->module : "");
-  if (item->alias && item->alias[0]) end += strlen(" as ") + strlen(item->alias);
-  return (int)end;
-}
-
 static void append_use_imports_json(ZBuf *buf, const SourceInput *input, const Program *program) {
   zbuf_append(buf, "[");
   for (size_t i = 0; program && i < program->use_imports.len; i++) {
@@ -8326,7 +8320,7 @@ static void append_use_imports_json(ZBuf *buf, const SourceInput *input, const P
                  line,
                  item->column,
                  line,
-                 use_import_end_column(item));
+                 item->end_column > 0 ? item->end_column : item->column);
     zbuf_append(buf, ",\"resolvedPath\":");
     append_json_string_or_null(buf, resolved_path);
     zbuf_append(buf, "}");

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -8257,6 +8257,83 @@ static size_t source_line_count(const char *source) {
   return lines;
 }
 
+static const char *source_path_for_parser_line(const SourceInput *input, int parser_line) {
+  if (!input || parser_line <= 0) return NULL;
+  size_t index = (size_t)parser_line - 1;
+  if (index >= input->source_line_count) return NULL;
+  return input->source_line_paths[index];
+}
+
+static int source_original_line_for_parser_line(const SourceInput *input, int parser_line) {
+  if (!input || parser_line <= 0) return parser_line > 0 ? parser_line : 1;
+  size_t index = (size_t)parser_line - 1;
+  if (index >= input->source_line_count) return parser_line;
+  return input->source_line_numbers[index] > 0 ? input->source_line_numbers[index] : parser_line;
+}
+
+static const char *module_name_for_source_path(const SourceInput *input, const char *path) {
+  if (!input || !path) return (input && input->module_count == 1) ? input->module_names[0] : "main";
+  for (size_t i = 0; i < input->module_count; i++) {
+    if (strcmp(input->module_paths[i], path) == 0) return input->module_names[i];
+  }
+  return input->module_count == 1 ? input->module_names[0] : "main";
+}
+
+static bool import_module_is_stdlib(const char *module) {
+  return module && strncmp(module, "std.", 4) == 0;
+}
+
+static const char *resolved_path_for_import(const SourceInput *input, const char *from, const char *to) {
+  if (!input || !from || !to) return NULL;
+  for (size_t i = 0; i < input->import_edge_count; i++) {
+    if (strcmp(input->import_from[i], from) == 0 && strcmp(input->import_to[i], to) == 0) {
+      return input->import_paths[i];
+    }
+  }
+  return NULL;
+}
+
+static int use_import_end_column(const UseImport *item) {
+  size_t end = (size_t)(item->column > 0 ? item->column : 1) + strlen("use ") + strlen(item->module ? item->module : "");
+  if (item->alias && item->alias[0]) end += strlen(" as ") + strlen(item->alias);
+  return (int)end;
+}
+
+static void append_use_imports_json(ZBuf *buf, const SourceInput *input, const Program *program) {
+  zbuf_append(buf, "[");
+  for (size_t i = 0; program && i < program->use_imports.len; i++) {
+    if (i > 0) zbuf_append(buf, ", ");
+    UseImport *item = &program->use_imports.items[i];
+    const char *path = source_path_for_parser_line(input, item->line);
+    const char *from = module_name_for_source_path(input, path);
+    int line = source_original_line_for_parser_line(input, item->line);
+    const char *kind = import_module_is_stdlib(item->module) ? "stdlib" : "package-local";
+    const char *resolved_path = import_module_is_stdlib(item->module) ? NULL : resolved_path_for_import(input, from, item->module);
+    zbuf_append(buf, "{\"from\":");
+    append_json_string(buf, from);
+    zbuf_append(buf, ",\"to\":");
+    append_json_string(buf, item->module);
+    zbuf_append(buf, ",\"alias\":");
+    append_json_string_or_null(buf, item->alias);
+    zbuf_append(buf, ",\"kind\":");
+    append_json_string(buf, kind);
+    zbuf_append(buf, ",\"path\":");
+    append_json_string(buf, path ? path : "");
+    zbuf_appendf(buf, ",\"line\":%d,\"column\":%d", line, item->column);
+    zbuf_append(buf, ",\"sourceRange\":{\"path\":");
+    append_json_string(buf, path ? path : "");
+    zbuf_appendf(buf, ",\"start\":{\"line\":%d,\"column\":%d},\"end\":{\"line\":%d,\"column\":%d},\"columnUnit\":\"utf8-byte\"}",
+                 line,
+                 item->column,
+                 line,
+                 use_import_end_column(item));
+    zbuf_append(buf, ",\"resolvedPath\":");
+    append_json_string_or_null(buf, resolved_path);
+    zbuf_append(buf, "}");
+  }
+  zbuf_append(buf, "]");
+}
+
 static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program *program, const ZTargetInfo *target) {
   CapabilitySummary caps = program_capabilities(program);
   size_t public_count = 0;
@@ -8342,7 +8419,9 @@ static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program
     if (i > 0) zbuf_append(buf, ", ");
     append_json_string(buf, input->imports[i]);
   }
-  zbuf_append(buf, "],\n  \"modules\": [");
+  zbuf_append(buf, "],\n  \"useImports\": ");
+  append_use_imports_json(buf, input, program);
+  zbuf_append(buf, ",\n  \"modules\": [");
   for (size_t i = 0; i < input->module_count; i++) {
     if (i > 0) zbuf_append(buf, ", ");
     zbuf_append(buf, "{\"name\":");

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -178,6 +178,11 @@ static bool token_on_line(Token *token, int line) {
   return token && token->kind != TOK_EOF && token->line == line;
 }
 
+static int token_end_column(Token *token) {
+  if (!token) return 1;
+  return token->column + (int)token->length;
+}
+
 static Token *expect(Parser *parser, const char *text, const char *message) {
   if (match(parser, text)) return previous(parser);
   fail(parser, message);
@@ -975,6 +980,7 @@ static UseImport parse_use_import(Parser *parser) {
     fail_at(parser, current(parser), "expected import module name");
   }
   Token *segment = parser->diag->code == 0 ? expect_ident(parser, "expected import module name") : NULL;
+  Token *end_token = segment;
   if (segment) zbuf_append(&module, segment->text);
   while (parser->diag->code == 0 && token_on_line(current(parser), start->line) && match(parser, ".")) {
     Token *dot = previous(parser);
@@ -986,6 +992,7 @@ static UseImport parse_use_import(Parser *parser) {
     if (segment) {
       zbuf_append_char(&module, '.');
       zbuf_append(&module, segment->text);
+      end_token = segment;
     }
   }
   if (parser->diag->code == 0 && check(parser, "as") && !token_on_line(current(parser), start->line)) {
@@ -996,12 +1003,16 @@ static UseImport parse_use_import(Parser *parser) {
       fail_at(parser, current(parser), "expected import alias");
     }
     Token *alias = parser->diag->code == 0 ? expect_ident(parser, "expected import alias") : NULL;
-    if (alias) item.alias = z_strdup(alias->text);
+    if (alias) {
+      item.alias = z_strdup(alias->text);
+      end_token = alias;
+    }
   }
   if (parser->diag->code == 0 && token_on_line(current(parser), start->line)) {
     fail_at(parser, current(parser), "expected end of line after use declaration");
   }
   item.module = module.data ? module.data : z_strdup("");
+  item.end_column = token_end_column(end_token);
   return item;
 }
 

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -174,6 +174,10 @@ static bool fail_at(Parser *parser, Token *token, const char *message) {
   return false;
 }
 
+static bool token_on_line(Token *token, int line) {
+  return token && token->kind != TOK_EOF && token->line == line;
+}
+
 static Token *expect(Parser *parser, const char *text, const char *message) {
   if (match(parser, text)) return previous(parser);
   fail(parser, message);
@@ -967,11 +971,14 @@ static UseImport parse_use_import(Parser *parser) {
 
   ZBuf module;
   zbuf_init(&module);
-  Token *segment = expect_ident(parser, "expected import module name");
+  if (!token_on_line(current(parser), start->line) || current(parser)->kind != TOK_IDENT) {
+    fail_at(parser, current(parser), "expected import module name");
+  }
+  Token *segment = parser->diag->code == 0 ? expect_ident(parser, "expected import module name") : NULL;
   if (segment) zbuf_append(&module, segment->text);
-  while (parser->diag->code == 0 && match(parser, ".")) {
+  while (parser->diag->code == 0 && token_on_line(current(parser), start->line) && match(parser, ".")) {
     Token *dot = previous(parser);
-    if (current(parser)->kind != TOK_IDENT) {
+    if (!token_on_line(current(parser), start->line) || current(parser)->kind != TOK_IDENT) {
       fail_at(parser, dot, "expected import module segment after '.'");
       break;
     }
@@ -981,9 +988,18 @@ static UseImport parse_use_import(Parser *parser) {
       zbuf_append(&module, segment->text);
     }
   }
-  if (parser->diag->code == 0 && match(parser, "as")) {
-    Token *alias = expect_ident(parser, "expected import alias");
+  if (parser->diag->code == 0 && check(parser, "as") && !token_on_line(current(parser), start->line)) {
+    fail_at(parser, current(parser), "expected import alias on same line");
+  }
+  if (parser->diag->code == 0 && token_on_line(current(parser), start->line) && match(parser, "as")) {
+    if (!token_on_line(current(parser), start->line) || current(parser)->kind != TOK_IDENT) {
+      fail_at(parser, current(parser), "expected import alias");
+    }
+    Token *alias = parser->diag->code == 0 ? expect_ident(parser, "expected import alias") : NULL;
     if (alias) item.alias = z_strdup(alias->text);
+  }
+  if (parser->diag->code == 0 && token_on_line(current(parser), start->line)) {
+    fail_at(parser, current(parser), "expected end of line after use declaration");
   }
   item.module = module.data ? module.data : z_strdup("");
   return item;

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -86,6 +86,14 @@ static void push_c_import(CImportVec *vec, CImport item) {
   vec->items[vec->len++] = item;
 }
 
+static void push_use_import(UseImportVec *vec, UseImport item) {
+  if (vec->len + 1 > vec->cap) {
+    vec->cap = vec->cap == 0 ? 4 : vec->cap * 2;
+    vec->items = realloc(vec->items, vec->cap * sizeof(UseImport));
+  }
+  vec->items[vec->len++] = item;
+}
+
 static void push_choice(ChoiceVec *vec, Choice item) {
   if (vec->len + 1 > vec->cap) {
     vec->cap = vec->cap == 0 ? 4 : vec->cap * 2;
@@ -154,6 +162,14 @@ static bool fail(Parser *parser, const char *message) {
   parser->diag->code = 100;
   parser->diag->line = current(parser)->line;
   parser->diag->column = current(parser)->column;
+  snprintf(parser->diag->message, sizeof(parser->diag->message), "%s", message);
+  return false;
+}
+
+static bool fail_at(Parser *parser, Token *token, const char *message) {
+  parser->diag->code = 100;
+  parser->diag->line = token ? token->line : current(parser)->line;
+  parser->diag->column = token ? token->column : current(parser)->column;
   snprintf(parser->diag->message, sizeof(parser->diag->message), "%s", message);
   return false;
 }
@@ -942,24 +958,48 @@ static Choice parse_choice(Parser *parser) {
   return item;
 }
 
+static UseImport parse_use_import(Parser *parser) {
+  Token *start = current(parser);
+  UseImport item = {0};
+  expect(parser, "use", "expected use declaration");
+  item.line = start->line;
+  item.column = start->column;
+
+  ZBuf module;
+  zbuf_init(&module);
+  Token *segment = expect_ident(parser, "expected import module name");
+  if (segment) zbuf_append(&module, segment->text);
+  while (parser->diag->code == 0 && match(parser, ".")) {
+    Token *dot = previous(parser);
+    if (current(parser)->kind != TOK_IDENT) {
+      fail_at(parser, dot, "expected import module segment after '.'");
+      break;
+    }
+    segment = expect_ident(parser, "expected import module segment");
+    if (segment) {
+      zbuf_append_char(&module, '.');
+      zbuf_append(&module, segment->text);
+    }
+  }
+  if (parser->diag->code == 0 && match(parser, "as")) {
+    Token *alias = expect_ident(parser, "expected import alias");
+    if (alias) item.alias = z_strdup(alias->text);
+  }
+  item.module = module.data ? module.data : z_strdup("");
+  return item;
+}
+
 Program z_parse(TokenVec *tokens, ZDiag *diag) {
   Parser parser = {tokens, 0, diag};
   Program program = {0};
   while (current(&parser)->kind != TOK_EOF && diag->code == 0) {
-    if (match(&parser, "use")) {
-      while (current(&parser)->kind != TOK_EOF &&
-             !check(&parser, "pub") &&
-             !check(&parser, "const") &&
-             !check(&parser, "type") &&
-             !check(&parser, "interface") &&
-             !check(&parser, "fun") &&
-             !check(&parser, "shape") &&
-             !check(&parser, "enum") &&
-             !check(&parser, "choice") &&
-             !check(&parser, "test") &&
-             !check(&parser, "export") &&
-             !check(&parser, "extern") &&
-             !check(&parser, "packed")) parser.index++;
+    if (check(&parser, "use")) {
+      UseImport item = parse_use_import(&parser);
+      if (diag->code == 0) push_use_import(&program.use_imports, item);
+      else {
+        free(item.module);
+        free(item.alias);
+      }
       continue;
     }
     if (check(&parser, "extern") && parser.tokens->items[parser.index + 1].text && strcmp(parser.tokens->items[parser.index + 1].text, "c") == 0) {
@@ -1058,6 +1098,11 @@ static void free_stmt_vec(StmtVec *vec) {
 }
 
 void z_free_program(Program *program) {
+  for (size_t i = 0; i < program->use_imports.len; i++) {
+    free(program->use_imports.items[i].module);
+    free(program->use_imports.items[i].alias);
+  }
+  free(program->use_imports.items);
   for (size_t i = 0; i < program->consts.len; i++) {
     ConstDecl *item = &program->consts.items[i];
     free(item->name);


### PR DESCRIPTION
- Parse use declarations into syntax nodes instead of skipping them.

- Preserve import lines in package source maps and expose useImports with source ranges in graph JSON.

- Lock malformed import paths and stdlib/package import graph facts in conformance.