### PR TITLE
Point import diagnostics at use ranges

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1454,7 +1454,19 @@ assert.notEqual(missingImportJson.code, 0);
 const missingImportBody = JSON.parse(missingImportJson.stdout);
 assert.equal(missingImportBody.diagnostics[0].code, "IMP001");
 assert.match(missingImportBody.diagnostics[0].message, /unknown package-local import/);
+assert.equal(missingImportBody.diagnostics[0].path, "conformance/check/fail/missing-import/src/main.0");
+assert.equal(missingImportBody.diagnostics[0].line, 1);
+assert.equal(missingImportBody.diagnostics[0].column, 1);
+assert.equal(missingImportBody.diagnostics[0].length, 11);
 assert.equal(missingImportBody.diagnostics[0].fixSafety, "requires-human-review");
+
+const missingImportFixPlan = await execFileAsync(zero, ["fix", "--plan", "--json", "conformance/check/fail/missing-import"]);
+const missingImportFixPlanBody = JSON.parse(missingImportFixPlan.stdout);
+assert.equal(missingImportFixPlanBody.diagnostics[0].path, "conformance/check/fail/missing-import/src/main.0");
+assert.equal(missingImportFixPlanBody.diagnostics[0].line, 1);
+assert.equal(missingImportFixPlanBody.diagnostics[0].column, 1);
+assert.equal(missingImportFixPlanBody.diagnostics[0].length, 11);
+assert.equal(missingImportFixPlanBody.fixes[0].id, "fix-import-path");
 
 const importLineMapJson = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/import-line-map"]).catch((error) => error);
 assert.notEqual(importLineMapJson.code, 0);
@@ -1486,6 +1498,19 @@ const importCycleBody = JSON.parse(importCycleJson.stdout);
 assert.equal(importCycleBody.diagnostics[0].code, "IMP002");
 assert.match(importCycleBody.diagnostics[0].message, /import cycle/);
 assert.match(importCycleBody.diagnostics[0].actual, /a -> b -> a/);
+assert.equal(importCycleBody.diagnostics[0].path, "conformance/check/fail/import-cycle/src/b.0");
+assert.equal(importCycleBody.diagnostics[0].line, 1);
+assert.equal(importCycleBody.diagnostics[0].column, 1);
+assert.equal(importCycleBody.diagnostics[0].length, 5);
+assert.equal(importCycleBody.diagnostics[0].repair.id, "break-import-cycle");
+
+const importCycleFixPlan = await execFileAsync(zero, ["fix", "--plan", "--json", "conformance/check/fail/import-cycle"]);
+const importCycleFixPlanBody = JSON.parse(importCycleFixPlan.stdout);
+assert.equal(importCycleFixPlanBody.diagnostics[0].path, "conformance/check/fail/import-cycle/src/b.0");
+assert.equal(importCycleFixPlanBody.diagnostics[0].line, 1);
+assert.equal(importCycleFixPlanBody.diagnostics[0].column, 1);
+assert.equal(importCycleFixPlanBody.diagnostics[0].length, 5);
+assert.equal(importCycleFixPlanBody.fixes[0].id, "break-import-cycle");
 
 const duplicatePublicJson = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/duplicate-public"]).catch((error) => error);
 assert.notEqual(duplicatePublicJson.code, 0);
@@ -1498,6 +1523,10 @@ assert.notEqual(unresolvedNestedImportJson.code, 0);
 const unresolvedNestedImportBody = JSON.parse(unresolvedNestedImportJson.stdout);
 assert.equal(unresolvedNestedImportBody.diagnostics[0].code, "IMP001");
 assert.match(unresolvedNestedImportBody.diagnostics[0].expected, /src\/missing\.0/);
+assert.equal(unresolvedNestedImportBody.diagnostics[0].path, "conformance/check/fail/unresolved-nested-import/src/worker.0");
+assert.equal(unresolvedNestedImportBody.diagnostics[0].line, 1);
+assert.equal(unresolvedNestedImportBody.diagnostics[0].column, 1);
+assert.equal(unresolvedNestedImportBody.diagnostics[0].length, 11);
 
 const duplicatePublicLargeJson = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/duplicate-public-large"]).catch((error) => error);
 assert.notEqual(duplicatePublicLargeJson.code, 0);
@@ -1770,6 +1799,10 @@ assert(importGraphBody.sourceMaps.every((item) => item.columnUnit === "utf8-byte
 assert.deepEqual(importGraphBody.targets.map((item) => item.name), ["cli"]);
 assert.deepEqual(importGraphBody.modules.map((item) => item.name), ["math", "types", "main"]);
 assert.deepEqual(importGraphBody.importEdges.map((item) => `${item.from}->${item.to}`), ["main->math", "main->types"]);
+assert.deepEqual(importGraphBody.importEdges.map((item) => `${item.from}->${item.to}:${item.sourceRange.path}:${item.sourceRange.start.line}:${item.sourceRange.start.column}:${item.sourceRange.end.column}`), [
+  "main->math:conformance/check/pass/imports/src/main.0:1:1:9",
+  "main->types:conformance/check/pass/imports/src/main.0:2:1:10",
+]);
 assert.deepEqual(importGraphBody.useImports.map((item) => `${item.from}->${item.to}:${item.kind}:${item.line}:${item.column}`), [
   "main->math:package-local:1:1",
   "main->types:package-local:2:1",

--- a/docs-site/articles/language-reference.md
+++ b/docs-site/articles/language-reference.md
@@ -771,10 +771,10 @@ Build resolution is declarative and does not execute dependency code. Unknown
 imports, direct import cycles, bad manifests, and duplicate public exports are
 reported before parsing the combined package source.
 
-`zero graph --json <package>` lists module names, source paths, import edges,
-parsed `useImports` with source ranges, public/private symbol counts, target
-metadata, function effects, required capabilities, and whether the selected
-target provides hosted filesystem support.
+`zero graph --json <package>` lists module names, source paths, import edges
+with source ranges, parsed `useImports` with source ranges, public/private
+symbol counts, target metadata, function effects, required capabilities, and
+whether the selected target provides hosted filesystem support.
 
 There is no published package registry or semantic version solver in the
 current compiler.

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -643,6 +643,10 @@ typedef struct {
   char **import_from;
   char **import_to;
   char **import_paths;
+  char **import_source_paths;
+  int *import_lines;
+  int *import_columns;
+  int *import_lengths;
   char **symbol_names;
   char **symbol_modules;
   char **symbol_kinds;

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -259,13 +259,21 @@ static void source_input_push_module(SourceInput *input, const char *name, const
   input->module_count++;
 }
 
-static void source_input_push_import_edge(SourceInput *input, const char *from, const char *to, const char *path) {
+static void source_input_push_import_edge(SourceInput *input, const char *from, const char *to, const char *path, const char *source_path, int line, int column, int length) {
   input->import_from = realloc(input->import_from, (input->import_edge_count + 1) * sizeof(char *));
   input->import_to = realloc(input->import_to, (input->import_edge_count + 1) * sizeof(char *));
   input->import_paths = realloc(input->import_paths, (input->import_edge_count + 1) * sizeof(char *));
+  input->import_source_paths = realloc(input->import_source_paths, (input->import_edge_count + 1) * sizeof(char *));
+  input->import_lines = realloc(input->import_lines, (input->import_edge_count + 1) * sizeof(int));
+  input->import_columns = realloc(input->import_columns, (input->import_edge_count + 1) * sizeof(int));
+  input->import_lengths = realloc(input->import_lengths, (input->import_edge_count + 1) * sizeof(int));
   input->import_from[input->import_edge_count] = z_strdup(from);
   input->import_to[input->import_edge_count] = z_strdup(to);
   input->import_paths[input->import_edge_count] = z_strdup(path ? path : "");
+  input->import_source_paths[input->import_edge_count] = z_strdup(source_path ? source_path : "");
+  input->import_lines[input->import_edge_count] = line > 0 ? line : 1;
+  input->import_columns[input->import_edge_count] = column > 0 ? column : 1;
+  input->import_lengths[input->import_edge_count] = length > 0 ? length : 1;
   input->import_edge_count++;
 }
 
@@ -545,12 +553,13 @@ static void import_line_append_span(ZBuf *buf, const char *text, size_t len) {
   for (size_t i = 0; i < len; i++) zbuf_append_char(buf, text[i]);
 }
 
-static bool parse_use_import_line_module(const char *text, size_t len, char **module_out) {
+static bool parse_use_import_line_module(const char *text, size_t len, char **module_out, int *length_out) {
   size_t pos = 0;
   import_line_skip_ws(text, len, &pos);
   ZBuf module;
   zbuf_init(&module);
   bool wrote_segment = false;
+  size_t last_token_end = 0;
   for (;;) {
     const char *segment = NULL;
     size_t segment_len = 0;
@@ -561,6 +570,7 @@ static bool parse_use_import_line_module(const char *text, size_t len, char **mo
     if (wrote_segment) zbuf_append_char(&module, '.');
     import_line_append_span(&module, segment, segment_len);
     wrote_segment = true;
+    last_token_end = pos;
     import_line_skip_ws(text, len, &pos);
     if (pos < len && text[pos] == '.') {
       pos++;
@@ -586,6 +596,7 @@ static bool parse_use_import_line_module(const char *text, size_t len, char **mo
       zbuf_free(&module);
       return false;
     }
+    last_token_end = pos;
     import_line_skip_ws(text, len, &pos);
     if (import_line_comment_at(text, pos, len)) pos = len;
     if (pos < len) {
@@ -594,11 +605,21 @@ static bool parse_use_import_line_module(const char *text, size_t len, char **mo
     }
   }
   *module_out = module.data ? module.data : z_strdup("");
+  if (length_out) *length_out = 3 + (int)last_token_end;
   return true;
 }
 
-static bool scan_imports_and_append_dependencies(const char *source, const char *src_root, const char *current_module, SourceInput *input, ZBuf *combined, ZDiag *diag, char ***stack, size_t *stack_len) {
+static void set_import_source_diag(ZDiag *diag, int code, const char *path, int line, int column, int length) {
+  diag->code = code;
+  diag->path = z_strdup(path ? path : "");
+  diag->line = line > 0 ? line : 1;
+  diag->column = column > 0 ? column : 1;
+  diag->length = length > 0 ? length : 1;
+}
+
+static bool scan_imports_and_append_dependencies(const char *source, const char *src_root, const char *current_module, const char *current_path, SourceInput *input, ZBuf *combined, ZDiag *diag, char ***stack, size_t *stack_len) {
   const char *line = source;
+  int original_line = 1;
   while (*line && diag->code == 0) {
     const char *end = strchr(line, '\n');
     size_t len = end ? (size_t)(end - line) : strlen(line);
@@ -608,8 +629,10 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
       len--;
     }
     char *module_name = NULL;
+    int import_column = (int)(start - line) + 1;
+    int import_length = (int)len;
     if (len > 3 && strncmp(start, "use", 3) == 0 && isspace((unsigned char)start[3])) {
-      parse_use_import_line_module(start + 3, len - 3, &module_name);
+      parse_use_import_line_module(start + 3, len - 3, &module_name, &import_length);
     } else if (len >= 7 && strncmp(start, "import ", 7) == 0) {
       const char *module = start + 7;
       size_t module_len = len - 7;
@@ -623,36 +646,46 @@ static bool scan_imports_and_append_dependencies(const char *source, const char 
       }
       if (as_kw) module_len = (size_t)(as_kw - module);
       module_name = z_strndup(module, module_len);
+      import_length = 7 + (int)module_len;
     }
     if (module_name) {
       if (strncmp(module_name, "std.", 4) == 0) {
         free(module_name);
-        if (!end) break;
-        line = end + 1;
-        continue;
-      }
-      source_input_push_import(input, module_name);
-      char *module_path = module_path_to_source(src_root, module_name);
-      if (!module_path) {
-        diag->code = 7001;
-        diag->path = input->source_file;
-        diag->line = 1;
-        diag->column = 1;
-        snprintf(diag->message, sizeof(diag->message), "unknown package-local import '%s'", module_name);
-        snprintf(diag->expected, sizeof(diag->expected), "src/%s.0 or src/%s/mod.0", module_name, module_name);
-        snprintf(diag->actual, sizeof(diag->actual), "missing source file");
-        snprintf(diag->help, sizeof(diag->help), "create the module source file or remove the import");
+      } else {
+        source_input_push_import(input, module_name);
+        char *module_path = module_path_to_source(src_root, module_name);
+        if (!module_path) {
+          set_import_source_diag(diag, 7001, current_path, original_line, import_column, import_length);
+          snprintf(diag->message, sizeof(diag->message), "unknown package-local import '%s'", module_name);
+          snprintf(diag->expected, sizeof(diag->expected), "src/%s.0 or src/%s/mod.0", module_name, module_name);
+          snprintf(diag->actual, sizeof(diag->actual), "missing source file");
+          snprintf(diag->help, sizeof(diag->help), "create the module source file or remove the import");
+          free(module_name);
+          return false;
+        }
+        if (import_stack_contains(*stack, *stack_len, module_path)) {
+          ZBuf chain;
+          zbuf_init(&chain);
+          format_cycle_chain(src_root, *stack, *stack_len, module_path, &chain);
+          set_import_source_diag(diag, 7002, current_path, original_line, import_column, import_length);
+          snprintf(diag->message, sizeof(diag->message), "import cycle detected");
+          snprintf(diag->actual, sizeof(diag->actual), "%s", chain.data ? chain.data : module_path);
+          snprintf(diag->help, sizeof(diag->help), "break the module cycle by moving shared declarations into a third module");
+          zbuf_free(&chain);
+          free(module_path);
+          free(module_name);
+          return false;
+        }
+        source_input_push_import_edge(input, current_module, module_name, module_path, current_path, original_line, import_column, import_length);
+        bool ok = resolve_imported_source(module_path, src_root, input, combined, diag, stack, stack_len);
+        free(module_path);
         free(module_name);
-        return false;
+        if (!ok) return false;
       }
-      source_input_push_import_edge(input, current_module, module_name, module_path);
-      bool ok = resolve_imported_source(module_path, src_root, input, combined, diag, stack, stack_len);
-      free(module_path);
-      free(module_name);
-      if (!ok) return false;
     }
     if (!end) break;
     line = end + 1;
+    original_line++;
   }
   return diag->code == 0;
 }
@@ -664,9 +697,10 @@ static bool resolve_imported_source(const char *path, const char *src_root, Sour
     zbuf_init(&chain);
     format_cycle_chain(src_root, *stack, *stack_len, path, &chain);
     diag->code = 7002;
-    diag->path = input->source_file;
+    diag->path = z_strdup(input->source_file);
     diag->line = 1;
     diag->column = 1;
+    diag->length = 1;
     snprintf(diag->message, sizeof(diag->message), "import cycle detected");
     snprintf(diag->actual, sizeof(diag->actual), "%s", chain.data ? chain.data : path);
     snprintf(diag->help, sizeof(diag->help), "break the module cycle by moving shared declarations into a third module");
@@ -678,7 +712,7 @@ static bool resolve_imported_source(const char *path, const char *src_root, Sour
   char *module_name = module_name_from_path(src_root, path);
   *stack = realloc(*stack, (*stack_len + 1) * sizeof(char *));
   (*stack)[(*stack_len)++] = z_strdup(path);
-  bool ok = scan_imports_and_append_dependencies(source, src_root, module_name, input, combined, diag, stack, stack_len);
+  bool ok = scan_imports_and_append_dependencies(source, src_root, module_name, path, input, combined, diag, stack, stack_len);
   free((*stack)[--(*stack_len)]);
   if (ok) ok = scan_top_level_symbols(source, module_name, input, diag);
   if (ok) {
@@ -1372,6 +1406,7 @@ void z_free_source(SourceInput *input) {
     free(input->import_from[i]);
     free(input->import_to[i]);
     free(input->import_paths[i]);
+    free(input->import_source_paths[i]);
   }
   for (size_t i = 0; i < input->symbol_count; i++) {
     free(input->symbol_names[i]);
@@ -1397,6 +1432,10 @@ void z_free_source(SourceInput *input) {
   free(input->import_from);
   free(input->import_to);
   free(input->import_paths);
+  free(input->import_source_paths);
+  free(input->import_lines);
+  free(input->import_columns);
+  free(input->import_lengths);
   free(input->symbol_names);
   free(input->symbol_modules);
   free(input->symbol_kinds);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2399,6 +2399,7 @@ static const char *diag_repair_id(int code) {
     case 1002: return "add-missing-error-name";
     case 1003: return "check-or-rescue-fallible-call";
     case 7001: return "fix-import-path";
+    case 7002: return "break-import-cycle";
     case 3003: return "declare-missing-symbol";
     case 3007: return "match-return-type";
     case 3010: return "make-binding-mutable";
@@ -2448,6 +2449,7 @@ static const char *diag_repair_summary(int code) {
     case 1002: return "Add the missing error name to raises { ... } or rescue the call locally.";
     case 1003: return "Wrap the fallible call in check or rescue so error flow is explicit.";
     case 7001: return "Change the import to a package-local module path that resolves under src/.";
+    case 7002: return "Break the import cycle by moving shared declarations into a third module or removing one import edge.";
     case 3003: return "Declare the referenced symbol, import the module that provides it, or correct the identifier spelling.";
     case 3007: return "Change the returned expression or the function return annotation so both types agree.";
     case 3010: return "Change the root binding to let mut before passing it to a mutable API.";
@@ -8293,6 +8295,19 @@ static const char *resolved_path_for_import(const SourceInput *input, const char
   return NULL;
 }
 
+static void append_source_range_json(ZBuf *buf, const char *path, int line, int column, int length) {
+  int start_line = line > 0 ? line : 1;
+  int start_column = column > 0 ? column : 1;
+  int end_column = start_column + (length > 0 ? length : 1);
+  zbuf_append(buf, "{\"path\":");
+  append_json_string(buf, path ? path : "");
+  zbuf_appendf(buf, ",\"start\":{\"line\":%d,\"column\":%d},\"end\":{\"line\":%d,\"column\":%d},\"columnUnit\":\"utf8-byte\"}",
+               start_line,
+               start_column,
+               start_line,
+               end_column);
+}
+
 static void append_use_imports_json(ZBuf *buf, const SourceInput *input, const Program *program) {
   zbuf_append(buf, "[");
   for (size_t i = 0; program && i < program->use_imports.len; i++) {
@@ -8435,6 +8450,12 @@ static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program
     append_json_string(buf, input->import_to[i]);
     zbuf_append(buf, ",\"path\":");
     append_json_string(buf, input->import_paths[i]);
+    zbuf_append(buf, ",\"sourceRange\":");
+    append_source_range_json(buf,
+                             input->import_source_paths ? input->import_source_paths[i] : "",
+                             input->import_lines ? input->import_lines[i] : 1,
+                             input->import_columns ? input->import_columns[i] : 1,
+                             input->import_lengths ? input->import_lengths[i] : 1);
     zbuf_append(buf, "}");
   }
   zbuf_append(buf, "],\n");


### PR DESCRIPTION
- Carry scanned import source ranges through resolver diagnostics, fix plans, and graph import edges.

- Report nested missing imports and cycles at the import declaration that caused them.

- Cover import diagnostic ranges, cycle repairs, and graph edge ranges in conformance.