### PR TITLE
Add structured backend blockers

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -541,7 +541,7 @@ const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json",
 const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
 assert.equal(agentSurfaceOwnedDropCheckBody.ok, true);
 
-async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, expectedPattern, nativeTarget = true) {
+async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, expectedPattern, expectedObjectFormat, expectedBackend, nativeTarget = true) {
   const build = await execFileAsync(zero, [
     "build",
     "--json",
@@ -559,14 +559,21 @@ async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, exp
   assert.equal(diagnostic.code, "CGEN004");
   assert.match(diagnostic.expected, expectedPattern);
   assert.equal(diagnostic.actual, "owned<Tracked>");
+  assert.deepEqual(diagnostic.backendBlocker, {
+    target,
+    objectFormat: expectedObjectFormat,
+    backend: expectedBackend,
+    stage: "lower",
+    unsupportedFeature: "owned<Tracked>",
+  });
   if (nativeTarget) assert(!/wasm/i.test(diagnostic.message));
   else assert.match(diagnostic.expected, /wasm/i);
 }
 
-await assertAgentSurfaceOwnedDropUnsupported("linux-musl-x64", "obj", "agent-surface-owned-drop-elf.o", /ELF64/);
-await assertAgentSurfaceOwnedDropUnsupported("darwin-arm64", "obj", "agent-surface-owned-drop-macho.o", /Mach-O/);
-await assertAgentSurfaceOwnedDropUnsupported("win32-x64.exe", "obj", "agent-surface-owned-drop-coff.obj", /COFF/);
-await assertAgentSurfaceOwnedDropUnsupported("wasm32-web", "wasm", "agent-surface-owned-drop.wasm", /wasm/, false);
+await assertAgentSurfaceOwnedDropUnsupported("linux-musl-x64", "obj", "agent-surface-owned-drop-elf.o", /ELF64/, "elf", "zero-elf64");
+await assertAgentSurfaceOwnedDropUnsupported("darwin-arm64", "obj", "agent-surface-owned-drop-macho.o", /Mach-O/, "macho", "zero-macho64");
+await assertAgentSurfaceOwnedDropUnsupported("win32-x64.exe", "obj", "agent-surface-owned-drop-coff.obj", /COFF/, "coff", "zero-coff-x64");
+await assertAgentSurfaceOwnedDropUnsupported("wasm32-web", "wasm", "agent-surface-owned-drop.wasm", /wasm/, "wasm", "zero-wasm", false);
 
 const compileTimeJson = await execFileAsync(zero, ["check", "--json", "conformance/native/pass/compile-time-v1.0"]);
 const compileTimeBody = JSON.parse(compileTimeJson.stdout);

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -541,7 +541,9 @@ const agentSurfaceOwnedDropCheck = await execFileAsync(zero, ["check", "--json",
 const agentSurfaceOwnedDropCheckBody = JSON.parse(agentSurfaceOwnedDropCheck.stdout);
 assert.equal(agentSurfaceOwnedDropCheckBody.ok, true);
 
-async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, expectedPattern, expectedObjectFormat, expectedBackend, nativeTarget = true) {
+async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, expectedPattern, expectedObjectFormat, expectedBackend, options = {}) {
+  const nativeTarget = options.nativeTarget ?? true;
+  const extraArgs = options.extraArgs ?? [];
   const build = await execFileAsync(zero, [
     "build",
     "--json",
@@ -549,6 +551,7 @@ async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, exp
     emit,
     "--target",
     target,
+    ...extraArgs,
     "conformance/agent-surface/fixtures/owned-drop-direct-backend-unsupported.0",
     "--out",
     `${outDir}/${outName}`,
@@ -573,7 +576,9 @@ async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, exp
 await assertAgentSurfaceOwnedDropUnsupported("linux-musl-x64", "obj", "agent-surface-owned-drop-elf.o", /ELF64/, "elf", "zero-elf64");
 await assertAgentSurfaceOwnedDropUnsupported("darwin-arm64", "obj", "agent-surface-owned-drop-macho.o", /Mach-O/, "macho", "zero-macho64");
 await assertAgentSurfaceOwnedDropUnsupported("win32-x64.exe", "obj", "agent-surface-owned-drop-coff.obj", /COFF/, "coff", "zero-coff-x64");
-await assertAgentSurfaceOwnedDropUnsupported("wasm32-web", "wasm", "agent-surface-owned-drop.wasm", /wasm/, "wasm", "zero-wasm", false);
+await assertAgentSurfaceOwnedDropUnsupported("wasm32-web", "wasm", "agent-surface-owned-drop.wasm", /wasm/, "wasm", "zero-wasm", { nativeTarget: false });
+await assertAgentSurfaceOwnedDropUnsupported("darwin-arm64", "obj", "agent-surface-owned-drop-macho-backend-ignored.o", /Mach-O/, "macho", "zero-macho64", { extraArgs: ["--backend", "zero-elf64"] });
+await assertAgentSurfaceOwnedDropUnsupported("wasm32-web", "wasm", "agent-surface-owned-drop-wasm-backend-ignored.wasm", /wasm/, "wasm", "zero-wasm", { nativeTarget: false, extraArgs: ["--backend", "not-a-real-backend"] });
 
 const compileTimeJson = await execFileAsync(zero, ["check", "--json", "conformance/native/pass/compile-time-v1.0"]);
 const compileTimeBody = JSON.parse(compileTimeJson.stdout);

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -23,6 +23,15 @@ typedef struct {
 } ZBorrowTrace;
 
 typedef struct {
+  bool present;
+  char target[64];
+  char object_format[32];
+  char backend[64];
+  char stage[32];
+  char unsupported_feature[128];
+} ZBackendBlocker;
+
+typedef struct {
   int code;
   char code_text[16];
   char message[256];
@@ -33,6 +42,7 @@ typedef struct {
   size_t borrow_trace_count;
   bool borrow_trace_truncated;
   char borrow_repair[256];
+  ZBackendBlocker backend_blocker;
   const char *path;
   int line;
   int column;
@@ -597,6 +607,7 @@ typedef struct {
   char mir_actual[128];
   char mir_message[256];
   char mir_help[256];
+  ZBackendBlocker backend_blocker;
   int mir_line;
   int mir_column;
   size_t mir_bytes;
@@ -783,6 +794,8 @@ void z_free_program(Program *program);
 bool z_check_program(const Program *program, ZDiag *diag);
 void z_set_check_target(const ZTargetInfo *target);
 ZMetaCacheStats z_meta_cache_stats(void);
+void z_backend_blocker_set(ZBackendBlocker *blocker, const char *target, const char *object_format, const char *backend, const char *stage, const char *unsupported_feature);
+void z_diag_set_backend_blocker(ZDiag *diag, const ZBackendBlocker *blocker);
 IrProgram z_lower_program(const Program *program);
 IrProgram z_lower_program_with_source(const Program *program, const SourceInput *input);
 void z_free_ir_program(IrProgram *program);

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -940,7 +940,11 @@ static void coff_append_rodata(ZBuf *rodata, const IrProgram *program, unsigned 
 
 bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
   if (!program || !out) return coff_diag(diag, "direct COFF backend received no program");
-  if (!program->mir_valid) return coff_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+  if (!program->mir_valid) {
+    bool ok = coff_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
   if (program->function_len == 0) return coff_diag_at(diag, "direct COFF object backend requires at least one exported function", 1, 1, "empty program");
   bool has_export = false;
   for (size_t i = 0; i < program->function_len; i++) {
@@ -1288,7 +1292,11 @@ static void coff_append_import_table(ZBuf *rdata, uint32_t rdata_rva, CoffImport
 
 bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
   if (!program || !out) return coff_diag(diag, "direct COFF executable backend received no program");
-  if (!program->mir_valid) return coff_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+  if (!program->mir_valid) {
+    bool ok = coff_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
   unsigned main_index = 0;
   if (!coff_find_executable_main(program, diag, &main_index)) return false;
   for (size_t i = 0; i < program->function_len; i++) {

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -64,6 +64,7 @@ static bool elf_ir_diag(ZDiag *diag, const IrProgram *ir) {
   snprintf(diag->expected, sizeof(diag->expected), "direct ELF64 object MVP subset");
   snprintf(diag->actual, sizeof(diag->actual), "%s", ir && ir->mir_actual[0] ? ir->mir_actual : "unsupported construct");
   snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to exported primitive integer arithmetic functions");
+  if (ir) z_diag_set_backend_blocker(diag, &ir->backend_blocker);
   return false;
 }
 

--- a/native/zero-c/src/emit_elf_aarch64.c
+++ b/native/zero-c/src/emit_elf_aarch64.c
@@ -135,7 +135,11 @@ static void a64_append_section_header(ZBuf *out, uint32_t name, uint32_t type, u
 
 bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
   if (!ir) return a64_diag(diag, "direct AArch64 ELF object backend requires MIR", 1, 1, "missing MIR");
-  if (!ir->mir_valid) return a64_diag(diag, ir->mir_message[0] ? ir->mir_message : "direct backend lowering failed", ir->mir_line, ir->mir_column, ir->mir_actual);
+  if (!ir->mir_valid) {
+    bool ok = a64_diag(diag, ir->mir_message[0] ? ir->mir_message : "direct backend lowering failed", ir->mir_line, ir->mir_column, ir->mir_actual);
+    z_diag_set_backend_blocker(diag, &ir->backend_blocker);
+    return ok;
+  }
 
   ZBuf text;
   ZBuf strtab;
@@ -266,7 +270,11 @@ bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *di
 
 bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
   if (!ir) return a64_diag(diag, "direct AArch64 ELF executable backend requires MIR", 1, 1, "missing MIR");
-  if (!ir->mir_valid) return a64_diag(diag, ir->mir_message[0] ? ir->mir_message : "direct backend lowering failed", ir->mir_line, ir->mir_column, ir->mir_actual);
+  if (!ir->mir_valid) {
+    bool ok = a64_diag(diag, ir->mir_message[0] ? ir->mir_message : "direct backend lowering failed", ir->mir_line, ir->mir_column, ir->mir_actual);
+    z_diag_set_backend_blocker(diag, &ir->backend_blocker);
+    return ok;
+  }
   unsigned main_index = 0;
   if (!a64_find_main(ir, &main_index, diag)) return false;
 

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -1596,7 +1596,11 @@ static void macho_append_rodata(ZBuf *rodata, const IrProgram *program, unsigned
 
 bool z_emit_macho64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
   if (!program || !out) return macho_diag(diag, "direct Mach-O backend received no program");
-  if (!program->mir_valid) return macho_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+  if (!program->mir_valid) {
+    bool ok = macho_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
   if (program->function_len == 0) return macho_diag_at(diag, "direct AArch64 Mach-O object backend requires at least one exported function", 1, 1, "empty program");
   bool has_export = false;
   for (size_t i = 0; i < program->function_len; i++) {
@@ -2119,7 +2123,11 @@ static size_t macho_emit_exe_world_write(ZBuf *text) {
 
 bool z_emit_macho64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
   if (!program || !out) return macho_diag(diag, "direct Mach-O executable backend received no program");
-  if (!program->mir_valid) return macho_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+  if (!program->mir_valid) {
+    bool ok = macho_diag_at(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
   unsigned main_index = 0;
   if (!macho_find_executable_main(program, diag, &main_index)) return false;
   for (size_t i = 0; i < program->function_len; i++) {

--- a/native/zero-c/src/emit_wasm.c
+++ b/native/zero-c/src/emit_wasm.c
@@ -25,6 +25,7 @@ static bool wasm_ir_diag(ZDiag *diag, const IrProgram *ir) {
   snprintf(diag->expected, sizeof(diag->expected), "%s", ir && ir->mir_expected[0] ? ir->mir_expected : "direct wasm MVP subset");
   snprintf(diag->actual, sizeof(diag->actual), "%s", ir && ir->mir_actual[0] ? ir->mir_actual : "unsupported construct");
   snprintf(diag->help, sizeof(diag->help), "%s", ir && ir->mir_help[0] ? ir->mir_help : "restrict this program to direct-wasm-supported features");
+  if (ir) z_diag_set_backend_blocker(diag, &ir->backend_blocker);
   return false;
 }
 

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -521,6 +521,22 @@ static bool ir_parse_fixed_array_type(const char *type, unsigned *out_len, IrTyp
   return ir_parse_fixed_array_type_for_program(NULL, type, out_len, out_element);
 }
 
+void z_backend_blocker_set(ZBackendBlocker *blocker, const char *target, const char *object_format, const char *backend, const char *stage, const char *unsupported_feature) {
+  if (!blocker) return;
+  memset(blocker, 0, sizeof(*blocker));
+  blocker->present = true;
+  snprintf(blocker->target, sizeof(blocker->target), "%s", target ? target : "");
+  snprintf(blocker->object_format, sizeof(blocker->object_format), "%s", object_format ? object_format : "");
+  snprintf(blocker->backend, sizeof(blocker->backend), "%s", backend ? backend : "");
+  snprintf(blocker->stage, sizeof(blocker->stage), "%s", stage ? stage : "");
+  snprintf(blocker->unsupported_feature, sizeof(blocker->unsupported_feature), "%s", unsupported_feature ? unsupported_feature : "");
+}
+
+void z_diag_set_backend_blocker(ZDiag *diag, const ZBackendBlocker *blocker) {
+  if (!diag || !blocker || !blocker->present) return;
+  diag->backend_blocker = *blocker;
+}
+
 static void ir_mark_unsupported(IrProgram *ir, const char *message, int line, int column, const char *actual) {
   if (!ir || !ir->mir_valid) return;
   ir->mir_valid = false;
@@ -530,6 +546,7 @@ static void ir_mark_unsupported(IrProgram *ir, const char *message, int line, in
   snprintf(ir->mir_expected, sizeof(ir->mir_expected), "direct wasm MVP subset");
   snprintf(ir->mir_actual, sizeof(ir->mir_actual), "%s", actual ? actual : "unsupported construct");
   snprintf(ir->mir_help, sizeof(ir->mir_help), "restrict this program to exported primitive arithmetic functions or choose another supported direct target");
+  z_backend_blocker_set(&ir->backend_blocker, NULL, NULL, NULL, "lower", ir->mir_actual);
 }
 
 static bool ir_parse_integer_literal(const char *text, unsigned long long *out) {

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2901,6 +2901,20 @@ static int explain_command(const Command *command) {
   return 0;
 }
 
+static void append_backend_blocker_json(ZBuf *buf, const ZBackendBlocker *blocker) {
+  zbuf_append(buf, "{\"target\":");
+  append_json_string(buf, blocker && blocker->target[0] ? blocker->target : "unknown");
+  zbuf_append(buf, ",\"objectFormat\":");
+  append_json_string(buf, blocker && blocker->object_format[0] ? blocker->object_format : "unknown");
+  zbuf_append(buf, ",\"backend\":");
+  append_json_string(buf, blocker && blocker->backend[0] ? blocker->backend : "unknown");
+  zbuf_append(buf, ",\"stage\":");
+  append_json_string(buf, blocker && blocker->stage[0] ? blocker->stage : "unknown");
+  zbuf_append(buf, ",\"unsupportedFeature\":");
+  append_json_string(buf, blocker && blocker->unsupported_feature[0] ? blocker->unsupported_feature : "unsupported construct");
+  zbuf_append(buf, "}");
+}
+
 static void print_diag_json(const char *path, const ZDiag *diag) {
   ZBuf buf;
   zbuf_init(&buf);
@@ -2925,6 +2939,10 @@ static void print_diag_json(const char *path, const ZDiag *diag) {
   zbuf_append(&buf, ", \"summary\": ");
   append_json_string(&buf, diag_repair_summary(diag->code));
   zbuf_append(&buf, "}");
+  if (diag->backend_blocker.present) {
+    zbuf_append(&buf, ",\n      \"backendBlocker\": ");
+    append_backend_blocker_json(&buf, &diag->backend_blocker);
+  }
   if (diag_has_borrow_trace(diag)) {
     zbuf_append(&buf, ",\n      \"borrowTrace\": ");
     append_diag_borrow_trace_json(&buf, path, diag);
@@ -2967,6 +2985,10 @@ static void append_fix_plan_diagnostic(ZBuf *buf, const char *path, const ZDiag 
   zbuf_append(buf, ", \"summary\": ");
   append_json_string(buf, diag_repair_summary(diag->code));
   zbuf_append(buf, "}");
+  if (diag->backend_blocker.present) {
+    zbuf_append(buf, ", \"backendBlocker\": ");
+    append_backend_blocker_json(buf, &diag->backend_blocker);
+  }
   if (diag_has_borrow_trace(diag)) {
     zbuf_append(buf, ", \"borrowTrace\": ");
     append_diag_borrow_trace_json(buf, path, diag);
@@ -3482,7 +3504,28 @@ static char *apply_direct_wasm_suffix(const char *path) {
   return buf.data;
 }
 
-static void init_direct_backend_diag(ZDiag *diag, const SourceInput *input, const ZTargetInfo *target, const char *emit_kind, const char *reason) {
+static const char *backend_blocker_backend_name(const ZTargetInfo *target, const Command *command, const char *emit_kind) {
+  if (command && command->backend && command->backend[0]) return command->backend;
+  if (emit_kind && (strcmp(emit_kind, "obj") == 0 || strcmp(emit_kind, "wasm") == 0)) return z_direct_object_emitter(target);
+  if (emit_kind && strcmp(emit_kind, "exe") == 0) return z_direct_exe_emitter(target);
+  return "none";
+}
+
+static void complete_backend_blocker_diag(ZDiag *diag, const ZTargetInfo *target, const Command *command, const char *emit_kind, const char *stage) {
+  if (!diag || diag->code != 4004) return;
+  const char *blocker_stage = diag->backend_blocker.present && diag->backend_blocker.stage[0] ? diag->backend_blocker.stage : stage;
+  const char *unsupported_feature = diag->backend_blocker.present && diag->backend_blocker.unsupported_feature[0] ? diag->backend_blocker.unsupported_feature : diag->actual;
+  ZBackendBlocker blocker;
+  z_backend_blocker_set(&blocker,
+                        target && target->name ? target->name : "unknown",
+                        target && target->object_format ? target->object_format : "unknown",
+                        backend_blocker_backend_name(target, command, emit_kind),
+                        blocker_stage && blocker_stage[0] ? blocker_stage : "emit",
+                        unsupported_feature && unsupported_feature[0] ? unsupported_feature : "unsupported construct");
+  z_diag_set_backend_blocker(diag, &blocker);
+}
+
+static void init_direct_backend_diag(ZDiag *diag, const Command *command, const SourceInput *input, const ZTargetInfo *target, const char *emit_kind, const char *reason) {
   memset(diag, 0, sizeof(*diag));
   diag->code = 4004;
   diag->path = input ? input->source_file : NULL;
@@ -3500,11 +3543,12 @@ static void init_direct_backend_diag(ZDiag *diag, const SourceInput *input, cons
            target && target->abi ? target->abi : "",
            z_direct_backend_status(target));
   snprintf(diag->help, sizeof(diag->help), "%s", reason ? reason : z_direct_backend_reason(target));
+  complete_backend_blocker_diag(diag, target, command, emit_kind, "select");
 }
 
 static int return_direct_backend_error(const Command *command, const SourceInput *input, const ZTargetInfo *target, const char *emit_kind, const char *reason, IrProgram *ir, Program *program) {
   ZDiag diag;
-  init_direct_backend_diag(&diag, input, target, emit_kind, reason);
+  init_direct_backend_diag(&diag, command, input, target, emit_kind, reason);
   if (command && command->json) print_diag_json(input ? input->source_file : NULL, &diag);
   else print_diag(input ? input->source_file : NULL, &diag);
   if (ir) z_free_ir_program(ir);
@@ -9180,6 +9224,7 @@ int main(int argc, char **argv) {
     if (!emitted_wasm) {
       z_map_source_diag(&input, &diag);
       if (!diag.path) diag.path = input.source_file;
+      complete_backend_blocker_diag(&diag, target, &command, "wasm", "emit");
       if (command.json) print_diag_json(input.source_file, &diag);
       else print_diag(input.source_file, &diag);
       z_free_ir_program(&ir);
@@ -9242,6 +9287,7 @@ int main(int argc, char **argv) {
     if (!emitted_object) {
       z_map_source_diag(&input, &diag);
       if (!diag.path) diag.path = input.source_file;
+      complete_backend_blocker_diag(&diag, target, &command, "obj", "emit");
       if (command.json) print_diag_json(input.source_file, &diag);
       else print_diag(input.source_file, &diag);
       z_free_ir_program(&ir);
@@ -9315,6 +9361,7 @@ int main(int argc, char **argv) {
     if (!emitted_object) {
       z_map_source_diag(&input, &diag);
       if (!diag.path) diag.path = input.source_file;
+      complete_backend_blocker_diag(&diag, target, &command, "exe", "emit");
       if (command.json) print_diag_json(input.source_file, &diag);
       else print_diag(input.source_file, &diag);
       zbuf_free(&object);
@@ -9436,6 +9483,7 @@ int main(int argc, char **argv) {
     if (!emitted_exe) {
       z_map_source_diag(&input, &diag);
       if (!diag.path) diag.path = input.source_file;
+      complete_backend_blocker_diag(&diag, target, &command, "exe", "emit");
       if (command.json) print_diag_json(input.source_file, &diag);
       else print_diag(input.source_file, &diag);
       z_free_ir_program(&ir);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -3505,9 +3505,11 @@ static char *apply_direct_wasm_suffix(const char *path) {
 }
 
 static const char *backend_blocker_backend_name(const ZTargetInfo *target, const Command *command, const char *emit_kind) {
-  if (command && command->backend && command->backend[0]) return command->backend;
   if (emit_kind && (strcmp(emit_kind, "obj") == 0 || strcmp(emit_kind, "wasm") == 0)) return z_direct_object_emitter(target);
-  if (emit_kind && strcmp(emit_kind, "exe") == 0) return z_direct_exe_emitter(target);
+  if (emit_kind && strcmp(emit_kind, "exe") == 0) {
+    if (command && command->backend && command->backend[0]) return command->backend;
+    return z_direct_exe_emitter(target);
+  }
   return "none";
 }
 


### PR DESCRIPTION
- Carry lowering blocker facts through direct emitters

- Expose target and backend blocker fields in diagnostic JSON

- Assert blocker fields across direct object formats