### PR TITLE
Finish native checked allocation cleanup

### DIFF
--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -248,7 +248,7 @@ static char *origin_path_join(const char *prefix, const char *suffix) {
   size_t left_len = strlen(left);
   size_t right_len = strlen(right);
   const char *separator = right[0] == '[' ? "" : ".";
-  char *joined = malloc(left_len + right_len + strlen(separator) + 1);
+  char *joined = z_checked_malloc(left_len + right_len + strlen(separator) + 1);
   snprintf(joined, left_len + right_len + strlen(separator) + 1, "%s%s%s", left, separator, right);
   return joined;
 }
@@ -766,10 +766,10 @@ static ProvenanceScopeSnapshot *provenance_scope_snapshot_capture(Scope *scope) 
   ProvenanceScopeSnapshot *head = NULL;
   ProvenanceScopeSnapshot *tail = NULL;
   for (Scope *cursor = scope; cursor; cursor = cursor->parent) {
-    ProvenanceScopeSnapshot *frame = calloc(1, sizeof(ProvenanceScopeSnapshot));
+    ProvenanceScopeSnapshot *frame = z_checked_calloc(1, sizeof(ProvenanceScopeSnapshot));
     frame->scope = cursor;
     frame->len = cursor->len;
-    frame->origins = calloc(frame->len, sizeof(ValueProvenance));
+    frame->origins = z_checked_calloc(frame->len, sizeof(ValueProvenance));
     for (size_t i = 0; i < frame->len; i++) {
       value_provenance_add_all(&frame->origins[i], &cursor->value_provenance[i]);
     }
@@ -2313,7 +2313,7 @@ static bool validate_generic_constraints(const Program *program, const Function 
       free_type_arg_list(constraint_args, constraint_arg_len);
       return set_diag_detail(diag, 3038, message, call->line, call->column, "concrete shape type", actual_type ? actual_type : "Unknown", "pass a shape with matching static methods");
     }
-    GenericBinding *interface_bindings = calloc(interface->type_params.len, sizeof(GenericBinding));
+    GenericBinding *interface_bindings = z_checked_calloc(interface->type_params.len, sizeof(GenericBinding));
     for (size_t i = 0; i < interface->type_params.len; i++) {
       interface_bindings[i].name = interface->type_params.items[i].name;
       interface_bindings[i].type = type_substitute_generic(i < constraint_arg_len ? constraint_args[i] : "Unknown", bindings, binding_len);
@@ -2742,7 +2742,7 @@ static char *shape_field_type_for_owner(const Shape *shape, const char *owner_ty
     char **args = NULL;
     size_t arg_len = 0;
     if (type_generic_arg_list(owner_type, shape->name, &args, &arg_len) && arg_len == shape->type_params.len) {
-      GenericBinding *bindings = calloc(arg_len, sizeof(GenericBinding));
+      GenericBinding *bindings = z_checked_calloc(arg_len, sizeof(GenericBinding));
       for (size_t i = 0; i < arg_len; i++) {
         bindings[i].name = shape->type_params.items[i].name;
         bindings[i].type = z_strdup(args[i]);
@@ -2841,7 +2841,7 @@ static bool meta_cache_get(const char *key, MetaValue *out) {
 }
 
 static void meta_cache_put(const char *key, MetaValue value) {
-  MetaCacheEntry *entry = calloc(1, sizeof(MetaCacheEntry));
+  MetaCacheEntry *entry = z_checked_calloc(1, sizeof(MetaCacheEntry));
   entry->key = z_strdup(key);
   entry->value = value;
   entry->next = meta_cache;
@@ -3230,7 +3230,7 @@ static char *receiver_self_arg_type(const char *receiver_type, bool requires_mut
 
 static bool build_receiver_shape_method_bindings(const Program *program, const Shape *shape, const Function *method, const Expr *call, const char *self_arg_type, Scope *scope, ZDiag *diag, GenericBinding **out_bindings, size_t *out_len) {
   size_t binding_len = 1 + (shape ? shape->type_params.len : 0);
-  GenericBinding *bindings = calloc(binding_len, sizeof(GenericBinding));
+  GenericBinding *bindings = z_checked_calloc(binding_len, sizeof(GenericBinding));
   bindings[0].name = "Self";
   for (size_t i = 0; shape && i < shape->type_params.len; i++) bindings[i + 1].name = shape->type_params.items[i].name;
   const TypeArgVec *type_args = call_type_args(call);
@@ -3321,7 +3321,7 @@ static bool bind_shape_method_from_expected_self(const Program *program, const S
 
 static bool build_shape_method_bindings(const Program *program, const Shape *shape, const Function *method, const Expr *call, Scope *scope, const char *expected, ZDiag *diag, GenericBinding **out_bindings, size_t *out_len) {
   size_t binding_len = 1 + (shape ? shape->type_params.len : 0);
-  GenericBinding *bindings = calloc(binding_len, sizeof(GenericBinding));
+  GenericBinding *bindings = z_checked_calloc(binding_len, sizeof(GenericBinding));
   bindings[0].name = "Self";
   for (size_t i = 0; shape && i < shape->type_params.len; i++) bindings[i + 1].name = shape->type_params.items[i].name;
   const TypeArgVec *type_args = call_type_args(call);
@@ -3774,7 +3774,7 @@ static const char *expr_type(const Program *program, const Expr *expr, Scope *sc
         const Function *fun = find_function(program, expr->left->text);
         if (!fun) return "Unknown";
         if (function_is_generic(fun)) {
-          GenericBinding *bindings = calloc(fun->type_params.len, sizeof(GenericBinding));
+          GenericBinding *bindings = z_checked_calloc(fun->type_params.len, sizeof(GenericBinding));
           for (size_t i = 0; i < fun->type_params.len; i++) bindings[i].name = fun->type_params.items[i].name;
           ZDiag ignored = {0};
           if (build_generic_bindings(program, fun, expr, scope, &ignored, bindings, fun->type_params.len, NULL)) {
@@ -3818,7 +3818,7 @@ static const char *expr_type(const Program *program, const Expr *expr, Scope *sc
           char **constraint_args = NULL;
           size_t constraint_arg_len = 0;
           constrained_interface_for_type_param(program, checking_function, expr->left->left->text, &constraint_args, &constraint_arg_len);
-          GenericBinding *interface_bindings = calloc(interface->type_params.len, sizeof(GenericBinding));
+          GenericBinding *interface_bindings = z_checked_calloc(interface->type_params.len, sizeof(GenericBinding));
           for (size_t i = 0; i < interface->type_params.len; i++) {
             interface_bindings[i].name = interface->type_params.items[i].name;
             interface_bindings[i].type = z_strdup(i < constraint_arg_len ? constraint_args[i] : "Unknown");
@@ -4653,7 +4653,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
           char **constraint_args = NULL;
           size_t constraint_arg_len = 0;
           constrained_interface_for_type_param(program, checking_function, expr->left->left->text, &constraint_args, &constraint_arg_len);
-          GenericBinding *interface_bindings = calloc(interface->type_params.len, sizeof(GenericBinding));
+          GenericBinding *interface_bindings = z_checked_calloc(interface->type_params.len, sizeof(GenericBinding));
           for (size_t i = 0; i < interface->type_params.len; i++) {
             interface_bindings[i].name = interface->type_params.items[i].name;
             interface_bindings[i].type = z_strdup(i < constraint_arg_len ? constraint_args[i] : "Unknown");
@@ -4720,7 +4720,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
           return set_diag_detail(diag, 3032, "non-generic function cannot take type arguments", expr->line, expr->column, "call without <...>", "type arguments on non-generic function", "remove the explicit type arguments or make the function generic");
         }
         if (fun && function_is_generic(fun)) {
-          GenericBinding *bindings = calloc(fun->type_params.len, sizeof(GenericBinding));
+          GenericBinding *bindings = z_checked_calloc(fun->type_params.len, sizeof(GenericBinding));
           for (size_t binding_index = 0; binding_index < fun->type_params.len; binding_index++) bindings[binding_index].name = fun->type_params.items[binding_index].name;
           if (!build_generic_bindings(program, fun, expr, scope, diag, bindings, fun->type_params.len, expected)) {
             generic_bindings_free(bindings, fun->type_params.len);
@@ -5177,7 +5177,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
           return set_diag_detail(diag, 3034, "generic shape literal requires an explicit annotated type", expr->line, expr->column, "let value: Shape<T> = Shape { ... }", expected ? expected : "untyped shape literal", "add an explicit generic shape type annotation");
         }
         shape_binding_len = shape->type_params.len;
-        shape_bindings = calloc(shape_binding_len, sizeof(GenericBinding));
+        shape_bindings = z_checked_calloc(shape_binding_len, sizeof(GenericBinding));
         for (size_t i = 0; i < shape_binding_len; i++) {
           shape_bindings[i].name = shape->type_params.items[i].name;
           if (shape->type_params.items[i].is_static) {
@@ -5508,7 +5508,7 @@ static bool generic_call_bindings_from_checked_call(const Program *program, cons
   if (!callee || !function_is_generic(callee) || !call || !out_bindings || !out_len) return false;
 
   size_t binding_len = callee->type_params.len;
-  GenericBinding *bindings = calloc(binding_len, sizeof(GenericBinding));
+  GenericBinding *bindings = z_checked_calloc(binding_len, sizeof(GenericBinding));
   for (size_t i = 0; i < binding_len; i++) bindings[i].name = callee->type_params.items[i].name;
 
   const TypeArgVec *type_args = call_type_args(call);
@@ -5557,7 +5557,7 @@ static bool build_constrained_interface_bindings_for_provenance(const Program *p
   char **constraint_args = NULL;
   size_t constraint_arg_len = 0;
   constrained_interface_for_type_param(program, context_fun, callee->left->text, &constraint_args, &constraint_arg_len);
-  GenericBinding *bindings = calloc(interface->type_params.len, sizeof(GenericBinding));
+  GenericBinding *bindings = z_checked_calloc(interface->type_params.len, sizeof(GenericBinding));
   for (size_t i = 0; i < interface->type_params.len; i++) {
     bindings[i].name = interface->type_params.items[i].name;
     bindings[i].type = provenance_context_type_text(i < constraint_arg_len ? constraint_args[i] : "Unknown", context_bindings, context_binding_len);
@@ -6154,7 +6154,7 @@ static void assignment_provenance_snapshot_clear(const Expr *target, Scope *scop
   *snapshot = (AssignmentProvenanceSnapshot){0};
   if (!target || !scope) return;
   if (!collect_assignment_target_places(target, scope, &snapshot->targets)) return;
-  snapshot->previous = calloc(snapshot->targets.len, sizeof(ValueProvenance));
+  snapshot->previous = z_checked_calloc(snapshot->targets.len, sizeof(ValueProvenance));
   for (size_t i = 0; i < snapshot->targets.len; i++) {
     Place *place = &snapshot->targets.items[i];
     ValueProvenance full = {0};
@@ -6342,8 +6342,8 @@ static bool collect_return_value_provenance_from_stmt_vec(const Program *program
         return added;
       }
       ProvenanceScopeSnapshot *before = provenance_scope_snapshot_capture(scope);
-      ProvenanceScopeSnapshot **arm_states = calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
-      bool *arm_continues = calloc(stmt->match_arms.len, sizeof(bool));
+      ProvenanceScopeSnapshot **arm_states = z_checked_calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
+      bool *arm_continues = z_checked_calloc(stmt->match_arms.len, sizeof(bool));
       const char *match_type = stmt->resolved_type ? stmt->resolved_type : (stmt->expr ? expr_type(program, stmt->expr, scope) : "Unknown");
       const Choice *item_choice = find_choice(program, match_type);
       for (size_t arm_index = 0; arm_index < stmt->match_arms.len; arm_index++) {
@@ -6975,8 +6975,8 @@ static bool check_scalar_match(const Program *program, const Function *fun, cons
     }
   }
   ProvenanceScopeSnapshot *before = provenance_scope_snapshot_capture(scope);
-  ProvenanceScopeSnapshot **arm_states = calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
-  bool *arm_continues = calloc(stmt->match_arms.len, sizeof(bool));
+  ProvenanceScopeSnapshot **arm_states = z_checked_calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
+  bool *arm_continues = z_checked_calloc(stmt->match_arms.len, sizeof(bool));
   for (size_t arm_index = 0; arm_index < stmt->match_arms.len; arm_index++) {
     provenance_scope_snapshot_restore(before);
     Scope arm_scope = {.parent = scope};
@@ -7224,8 +7224,8 @@ static bool check_stmt(const Program *program, const Function *fun, const Stmt *
       if (!seen && !has_fallback) return set_diag_detail(diag, 3106, "non-exhaustive match", stmt->line, stmt->column, "one arm for every variant case", cases->items[case_index].name, "add the missing match arm or a fallback `._` arm");
     }
     ProvenanceScopeSnapshot *before = provenance_scope_snapshot_capture(scope);
-    ProvenanceScopeSnapshot **arm_states = calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
-    bool *arm_continues = calloc(stmt->match_arms.len, sizeof(bool));
+    ProvenanceScopeSnapshot **arm_states = z_checked_calloc(stmt->match_arms.len, sizeof(ProvenanceScopeSnapshot *));
+    bool *arm_continues = z_checked_calloc(stmt->match_arms.len, sizeof(bool));
     for (size_t arm_index = 0; arm_index < stmt->match_arms.len; arm_index++) {
       provenance_scope_snapshot_restore(before);
       Scope arm_scope = {.parent = scope};
@@ -7327,7 +7327,7 @@ static bool validate_drop_method(const Shape *shape, const Function *method, ZDi
 static bool check_shape_method_body(const Program *program, const Shape *shape, const Function *method, ZDiag *diag) {
   Scope scope = {0};
   size_t binding_len = 1 + shape->type_params.len;
-  GenericBinding *bindings = calloc(binding_len, sizeof(GenericBinding));
+  GenericBinding *bindings = z_checked_calloc(binding_len, sizeof(GenericBinding));
   bindings[0].name = "Self";
   bindings[0].type = shape_open_instance_type(shape);
   for (size_t i = 0; i < shape->type_params.len; i++) {

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -236,11 +236,11 @@ static char *normalize_path_text(const char *path) {
       if (segment_count > 0 && strcmp(segments[segment_count - 1], "..") != 0) {
         segment_count--;
       } else if (!absolute) {
-        segments = realloc(segments, (segment_count + 1) * sizeof(char *));
+        segments = z_checked_reallocarray(segments, segment_count + 1, sizeof(char *));
         segments[segment_count++] = start;
       }
     } else {
-      segments = realloc(segments, (segment_count + 1) * sizeof(char *));
+      segments = z_checked_reallocarray(segments, segment_count + 1, sizeof(char *));
       segments[segment_count++] = start;
     }
     if (!saved) break;
@@ -280,13 +280,13 @@ static unsigned long long fs_mix_hash_text(unsigned long long hash, const char *
 }
 
 static void source_input_push_file(SourceInput *input, const char *path) {
-  input->source_files = realloc(input->source_files, (input->source_file_count + 1) * sizeof(char *));
+  input->source_files = z_checked_reallocarray(input->source_files, input->source_file_count + 1, sizeof(char *));
   input->source_files[input->source_file_count++] = z_strdup(path);
 }
 
 static void source_input_push_source_line(SourceInput *input, const char *path, int original_line) {
-  input->source_line_paths = realloc(input->source_line_paths, (input->source_line_count + 1) * sizeof(char *));
-  input->source_line_numbers = realloc(input->source_line_numbers, (input->source_line_count + 1) * sizeof(int));
+  input->source_line_paths = z_checked_reallocarray(input->source_line_paths, input->source_line_count + 1, sizeof(char *));
+  input->source_line_numbers = z_checked_reallocarray(input->source_line_numbers, input->source_line_count + 1, sizeof(int));
   input->source_line_paths[input->source_line_count] = z_strdup(path);
   input->source_line_numbers[input->source_line_count] = original_line > 0 ? original_line : 1;
   input->source_line_count++;
@@ -298,26 +298,26 @@ static void source_input_push_final_source_line(SourceInput *input) {
 }
 
 static void source_input_push_import(SourceInput *input, const char *name) {
-  input->imports = realloc(input->imports, (input->import_count + 1) * sizeof(char *));
+  input->imports = z_checked_reallocarray(input->imports, input->import_count + 1, sizeof(char *));
   input->imports[input->import_count++] = z_strdup(name);
 }
 
 static void source_input_push_module(SourceInput *input, const char *name, const char *path) {
-  input->module_names = realloc(input->module_names, (input->module_count + 1) * sizeof(char *));
-  input->module_paths = realloc(input->module_paths, (input->module_count + 1) * sizeof(char *));
+  input->module_names = z_checked_reallocarray(input->module_names, input->module_count + 1, sizeof(char *));
+  input->module_paths = z_checked_reallocarray(input->module_paths, input->module_count + 1, sizeof(char *));
   input->module_names[input->module_count] = z_strdup(name);
   input->module_paths[input->module_count] = z_strdup(path);
   input->module_count++;
 }
 
 static void source_input_push_import_edge(SourceInput *input, const char *from, const char *to, const char *path, const char *source_path, int line, int column, int length) {
-  input->import_from = realloc(input->import_from, (input->import_edge_count + 1) * sizeof(char *));
-  input->import_to = realloc(input->import_to, (input->import_edge_count + 1) * sizeof(char *));
-  input->import_paths = realloc(input->import_paths, (input->import_edge_count + 1) * sizeof(char *));
-  input->import_source_paths = realloc(input->import_source_paths, (input->import_edge_count + 1) * sizeof(char *));
-  input->import_lines = realloc(input->import_lines, (input->import_edge_count + 1) * sizeof(int));
-  input->import_columns = realloc(input->import_columns, (input->import_edge_count + 1) * sizeof(int));
-  input->import_lengths = realloc(input->import_lengths, (input->import_edge_count + 1) * sizeof(int));
+  input->import_from = z_checked_reallocarray(input->import_from, input->import_edge_count + 1, sizeof(char *));
+  input->import_to = z_checked_reallocarray(input->import_to, input->import_edge_count + 1, sizeof(char *));
+  input->import_paths = z_checked_reallocarray(input->import_paths, input->import_edge_count + 1, sizeof(char *));
+  input->import_source_paths = z_checked_reallocarray(input->import_source_paths, input->import_edge_count + 1, sizeof(char *));
+  input->import_lines = z_checked_reallocarray(input->import_lines, input->import_edge_count + 1, sizeof(int));
+  input->import_columns = z_checked_reallocarray(input->import_columns, input->import_edge_count + 1, sizeof(int));
+  input->import_lengths = z_checked_reallocarray(input->import_lengths, input->import_edge_count + 1, sizeof(int));
   input->import_from[input->import_edge_count] = z_strdup(from);
   input->import_to[input->import_edge_count] = z_strdup(to);
   input->import_paths[input->import_edge_count] = z_strdup(path ? path : "");
@@ -329,7 +329,7 @@ static void source_input_push_import_edge(SourceInput *input, const char *from, 
 }
 
 static void source_input_push_dependency(SourceInput *input, const ZManifestDependency *dep, const char *resolved_manifest, const char *resolved_name, const char *resolved_version, const char *status, bool direct) {
-  input->dependencies = realloc(input->dependencies, (input->dependency_count + 1) * sizeof(SourceDependency));
+  input->dependencies = z_checked_reallocarray(input->dependencies, input->dependency_count + 1, sizeof(SourceDependency));
   SourceDependency *item = &input->dependencies[input->dependency_count++];
   memset(item, 0, sizeof(*item));
   item->name = z_strdup(dep && dep->name ? dep->name : "");
@@ -379,10 +379,10 @@ static bool source_input_push_symbol(SourceInput *input, const char *module, con
       }
     }
   }
-  input->symbol_names = realloc(input->symbol_names, (input->symbol_count + 1) * sizeof(char *));
-  input->symbol_modules = realloc(input->symbol_modules, (input->symbol_count + 1) * sizeof(char *));
-  input->symbol_kinds = realloc(input->symbol_kinds, (input->symbol_count + 1) * sizeof(char *));
-  input->symbol_public = realloc(input->symbol_public, (input->symbol_count + 1) * sizeof(bool));
+  input->symbol_names = z_checked_reallocarray(input->symbol_names, input->symbol_count + 1, sizeof(char *));
+  input->symbol_modules = z_checked_reallocarray(input->symbol_modules, input->symbol_count + 1, sizeof(char *));
+  input->symbol_kinds = z_checked_reallocarray(input->symbol_kinds, input->symbol_count + 1, sizeof(char *));
+  input->symbol_public = z_checked_reallocarray(input->symbol_public, input->symbol_count + 1, sizeof(bool));
   input->symbol_names[input->symbol_count] = z_strdup(name);
   input->symbol_modules[input->symbol_count] = z_strdup(module);
   input->symbol_kinds[input->symbol_count] = z_strdup(kind ? kind : "unknown");
@@ -761,7 +761,7 @@ static bool resolve_imported_source(const char *path, const char *src_root, Sour
   char *source = z_read_file(path, diag);
   if (!source) return false;
   char *module_name = module_name_from_path(src_root, path);
-  *stack = realloc(*stack, (*stack_len + 1) * sizeof(char *));
+  *stack = z_checked_reallocarray(*stack, *stack_len + 1, sizeof(char *));
   (*stack)[(*stack_len)++] = z_strdup(path);
   bool ok = scan_imports_and_append_dependencies(source, src_root, module_name, path, input, combined, diag, stack, stack_len);
   free((*stack)[--(*stack_len)]);
@@ -967,12 +967,12 @@ static char *json_get_array_path(const char *json, const char **path, size_t pat
 }
 
 static void manifest_push_c_lib(ZManifest *manifest, ZManifestCLib lib) {
-  manifest->c_libs = realloc(manifest->c_libs, (manifest->c_lib_count + 1) * sizeof(ZManifestCLib));
+  manifest->c_libs = z_checked_reallocarray(manifest->c_libs, manifest->c_lib_count + 1, sizeof(ZManifestCLib));
   manifest->c_libs[manifest->c_lib_count++] = lib;
 }
 
 static void manifest_push_dependency(ZManifest *manifest, ZManifestDependency dep) {
-  manifest->dependencies = realloc(manifest->dependencies, (manifest->dependency_count + 1) * sizeof(ZManifestDependency));
+  manifest->dependencies = z_checked_reallocarray(manifest->dependencies, manifest->dependency_count + 1, sizeof(ZManifestDependency));
   manifest->dependencies[manifest->dependency_count++] = dep;
 }
 
@@ -1293,7 +1293,7 @@ static bool resolve_manifest_dependencies(const char *manifest_path, const ZMani
       return false;
     }
     source_input_push_dependency(out, dep, dep_manifest_path, resolved_name, resolved_version, "path-resolved", direct);
-    *stack = realloc(*stack, (*stack_len + 1) * sizeof(char *));
+    *stack = z_checked_reallocarray(*stack, *stack_len + 1, sizeof(char *));
     (*stack)[(*stack_len)++] = z_strdup(dep_manifest_path);
     bool ok = resolve_manifest_dependencies(dep_manifest_path, &parsed_dep, out, diag, stack, stack_len, false);
     free((*stack)[--(*stack_len)]);
@@ -1359,7 +1359,7 @@ bool z_resolve_source(const char *input, SourceInput *out, ZDiag *diag) {
     out->manifest_hash = fs_fnv1a_text(manifest);
     char **dependency_stack = NULL;
     size_t dependency_stack_len = 0;
-    dependency_stack = realloc(dependency_stack, sizeof(char *));
+    dependency_stack = z_checked_reallocarray(dependency_stack, 1, sizeof(char *));
     dependency_stack[dependency_stack_len++] = z_strdup(manifest_path);
     bool deps_ok = resolve_manifest_dependencies(manifest_path, &parsed_manifest, out, diag, &dependency_stack, &dependency_stack_len, true);
     while (dependency_stack_len > 0) free(dependency_stack[--dependency_stack_len]);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -1573,7 +1573,7 @@ static char *read_optional_file(const char *path) {
     return NULL;
   }
   rewind(file);
-  char *data = calloc((size_t)size + 1, 1);
+  char *data = z_checked_calloc((size_t)size + 1, 1);
   if (size > 0 && fread(data, 1, (size_t)size, file) != (size_t)size) {
     free(data);
     fclose(file);
@@ -3619,11 +3619,7 @@ static void print_artifact(const char *path, long long elapsed_ms) {
 static int run_executable_artifact(const char *exe_file, const Command *command) {
   int run_argc = command ? command->run_argc : 0;
   if (run_argc < 0) run_argc = 0;
-  char **child_argv = (char **)calloc((size_t)run_argc + 2, sizeof(char *));
-  if (!child_argv) {
-    fprintf(stderr, "zero run: out of memory\n");
-    return 1;
-  }
+  char **child_argv = (char **)z_checked_calloc((size_t)run_argc + 2, sizeof(char *));
   child_argv[0] = (char *)exe_file;
   for (int i = 0; i < run_argc; i++) child_argv[i + 1] = command->run_argv[i];
   child_argv[run_argc + 1] = NULL;
@@ -6174,10 +6170,10 @@ static TestValue test_value_copy(const TestValue *value) {
   copy.string_value = value->string_value ? z_strdup(value->string_value) : NULL;
   copy.field_len = value->field_len;
   if (copy.field_len > 0) {
-    copy.fields = calloc(copy.field_len, sizeof(TestFieldValue));
+    copy.fields = z_checked_calloc(copy.field_len, sizeof(TestFieldValue));
     for (size_t i = 0; i < copy.field_len; i++) {
       copy.fields[i].name = z_strdup(value->fields[i].name);
-      copy.fields[i].value = calloc(1, sizeof(TestValue));
+      copy.fields[i].value = z_checked_calloc(1, sizeof(TestValue));
       *copy.fields[i].value = test_value_copy(value->fields[i].value);
     }
   }
@@ -6203,8 +6199,8 @@ static bool test_env_set(TestEnv *env, const char *name, const TestValue *value)
     }
   }
   if (env->len + 1 > env->cap) {
-    env->cap = env->cap == 0 ? 8 : env->cap * 2;
-    env->items = realloc(env->items, env->cap * sizeof(TestBinding));
+    env->cap = z_grow_capacity(env->cap, env->len + 1, 8);
+    env->items = z_checked_reallocarray(env->items, env->cap, sizeof(TestBinding));
   }
   env->items[env->len].name = z_strdup(name);
   env->items[env->len].value = test_value_copy(value);
@@ -6381,10 +6377,10 @@ static bool test_eval_expr(const Program *program, TestEnv *env, const Expr *exp
     case EXPR_SHAPE_LITERAL:
       out->kind = TEST_VALUE_SHAPE;
       out->field_len = expr->fields.len;
-      out->fields = calloc(out->field_len ? out->field_len : 1, sizeof(TestFieldValue));
+      out->fields = z_checked_calloc(out->field_len ? out->field_len : 1, sizeof(TestFieldValue));
       for (size_t i = 0; i < expr->fields.len; i++) {
         out->fields[i].name = z_strdup(expr->fields.items[i].name);
-        out->fields[i].value = calloc(1, sizeof(TestValue));
+        out->fields[i].value = z_checked_calloc(1, sizeof(TestValue));
         if (!test_eval_expr(program, env, expr->fields.items[i].value, out->fields[i].value, failure)) return false;
       }
       return true;
@@ -6456,7 +6452,7 @@ static bool test_eval_expr(const Program *program, TestEnv *env, const Expr *exp
         return false;
       }
       const char *callee_name = name.data ? name.data : "";
-      TestValue *args = calloc(expr->args.len ? expr->args.len : 1, sizeof(TestValue));
+      TestValue *args = z_checked_calloc(expr->args.len ? expr->args.len : 1, sizeof(TestValue));
       for (size_t i = 0; i < expr->args.len; i++) {
         if (!test_eval_expr(program, env, expr->args.items[i], &args[i], failure)) {
           for (size_t j = 0; j <= i; j++) test_value_free(&args[j]);
@@ -7103,14 +7099,8 @@ static bool direct_split_generic_args(const char *inner, size_t inner_len, char 
         return false;
       }
       if (len + 1 > cap) {
-        cap = cap == 0 ? 4 : cap * 2;
-        char **next = realloc(items, cap * sizeof(char *));
-        if (!next) {
-          for (size_t j = 0; j < len; j++) free(items[j]);
-          free(items);
-          return false;
-        }
-        items = next;
+        cap = z_grow_capacity(cap, len + 1, 4);
+        items = z_checked_reallocarray(items, cap, sizeof(char *));
       }
       items[len++] = z_strndup(inner + start, end - start);
       start = i + 1;
@@ -7479,20 +7469,18 @@ static void direct_collect_shape_specializations_from_type(ZBuf *buf, DirectGene
     char **args = NULL;
     size_t arg_len = 0;
     if (direct_type_generic_arg_list(resolved, shape->name, &args, &arg_len) && arg_len == shape->type_params.len) {
-      char **specialized_args = calloc(arg_len, sizeof(char *));
-      if (specialized_args) {
-        for (size_t arg_index = 0; arg_index < arg_len; arg_index++) {
-          specialized_args[arg_index] = shape->type_params.items[arg_index].is_static
-            ? direct_canonical_static_arg(program, args[arg_index])
-            : NULL;
-          if (!specialized_args[arg_index]) specialized_args[arg_index] = z_strdup(args[arg_index]);
-          direct_collect_shape_specializations_from_type(buf, state, program, specialized_args[arg_index], NULL, 0);
-        }
-        char *name = direct_shape_specialized_name(shape, specialized_args, arg_len);
-        append_direct_generic_specialization_item(buf, state, name);
-        free(name);
-        direct_free_type_arg_list(specialized_args, arg_len);
+      char **specialized_args = z_checked_calloc(arg_len, sizeof(char *));
+      for (size_t arg_index = 0; arg_index < arg_len; arg_index++) {
+        specialized_args[arg_index] = shape->type_params.items[arg_index].is_static
+          ? direct_canonical_static_arg(program, args[arg_index])
+          : NULL;
+        if (!specialized_args[arg_index]) specialized_args[arg_index] = z_strdup(args[arg_index]);
+        direct_collect_shape_specializations_from_type(buf, state, program, specialized_args[arg_index], NULL, 0);
       }
+      char *name = direct_shape_specialized_name(shape, specialized_args, arg_len);
+      append_direct_generic_specialization_item(buf, state, name);
+      free(name);
+      direct_free_type_arg_list(specialized_args, arg_len);
     }
     direct_free_type_arg_list(args, arg_len);
   }
@@ -7555,44 +7543,42 @@ static void direct_collect_generic_function_specializations_from_expr(ZBuf *buf,
     const Function *fun = find_program_function(program, expr->left->text);
     if (fun && fun->type_params.len > 0) {
       size_t specialized_len = fun->type_params.len;
-      DirectGenericBinding *specialized = calloc(specialized_len, sizeof(DirectGenericBinding));
-      if (specialized) {
-        for (size_t i = 0; i < specialized_len; i++) {
-          specialized[i].name = fun->type_params.items[i].name;
-          specialized[i].is_static = fun->type_params.items[i].is_static;
-        }
-        const TypeArgVec *type_args = direct_call_type_args(expr);
-        if (type_args && type_args->len == specialized_len) {
-          for (size_t i = 0; i < specialized_len; i++) {
-            char *arg = direct_substitute_type(program, type_args->items[i].type, bindings, binding_len);
-            direct_set_binding(program, specialized, specialized_len, specialized[i].name, arg);
-            free(arg);
-          }
-        } else {
-          size_t arg_len = expr->args.len < fun->params.len ? expr->args.len : fun->params.len;
-          for (size_t i = 0; i < arg_len; i++) {
-            char *actual = direct_substitute_type(program, expr->args.items[i]->resolved_type, bindings, binding_len);
-            direct_bind_type_pattern(program, fun->params.items[i].type, actual, specialized, specialized_len);
-            free(actual);
-          }
-        }
-        if (expr->resolved_type && fun->return_type) {
-          char *actual_return = direct_substitute_type(program, expr->resolved_type, bindings, binding_len);
-          direct_bind_type_pattern(program, fun->return_type, actual_return, specialized, specialized_len);
-          free(actual_return);
-        }
-        if (direct_bindings_complete(specialized, specialized_len)) {
-          char *name = direct_function_specialized_name(fun, specialized, specialized_len);
-          bool wrote = append_direct_generic_specialization_item(buf, state, name);
-          if (wrote) {
-            direct_collect_shape_specializations_from_stmt_vec(buf, state, program, &fun->body, specialized, specialized_len);
-            direct_collect_generic_function_specializations_from_stmt_vec(buf, state, program, &fun->body, specialized, specialized_len);
-          }
-          free(name);
-        }
-        direct_free_bindings(specialized, specialized_len);
-        free(specialized);
+      DirectGenericBinding *specialized = z_checked_calloc(specialized_len, sizeof(DirectGenericBinding));
+      for (size_t i = 0; i < specialized_len; i++) {
+        specialized[i].name = fun->type_params.items[i].name;
+        specialized[i].is_static = fun->type_params.items[i].is_static;
       }
+      const TypeArgVec *type_args = direct_call_type_args(expr);
+      if (type_args && type_args->len == specialized_len) {
+        for (size_t i = 0; i < specialized_len; i++) {
+          char *arg = direct_substitute_type(program, type_args->items[i].type, bindings, binding_len);
+          direct_set_binding(program, specialized, specialized_len, specialized[i].name, arg);
+          free(arg);
+        }
+      } else {
+        size_t arg_len = expr->args.len < fun->params.len ? expr->args.len : fun->params.len;
+        for (size_t i = 0; i < arg_len; i++) {
+          char *actual = direct_substitute_type(program, expr->args.items[i]->resolved_type, bindings, binding_len);
+          direct_bind_type_pattern(program, fun->params.items[i].type, actual, specialized, specialized_len);
+          free(actual);
+        }
+      }
+      if (expr->resolved_type && fun->return_type) {
+        char *actual_return = direct_substitute_type(program, expr->resolved_type, bindings, binding_len);
+        direct_bind_type_pattern(program, fun->return_type, actual_return, specialized, specialized_len);
+        free(actual_return);
+      }
+      if (direct_bindings_complete(specialized, specialized_len)) {
+        char *name = direct_function_specialized_name(fun, specialized, specialized_len);
+        bool wrote = append_direct_generic_specialization_item(buf, state, name);
+        if (wrote) {
+          direct_collect_shape_specializations_from_stmt_vec(buf, state, program, &fun->body, specialized, specialized_len);
+          direct_collect_generic_function_specializations_from_stmt_vec(buf, state, program, &fun->body, specialized, specialized_len);
+        }
+        free(name);
+      }
+      direct_free_bindings(specialized, specialized_len);
+      free(specialized);
     }
   }
   direct_collect_generic_function_specializations_from_expr(buf, state, program, expr->left, bindings, binding_len);

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -345,7 +345,7 @@ static int precedence(const char *op) {
 }
 
 static Expr *new_expr(ExprKind kind, Token *token) {
-  Expr *expr = calloc(1, sizeof(Expr));
+  Expr *expr = z_checked_calloc(1, sizeof(Expr));
   expr->kind = kind;
   expr->line = token->line;
   expr->column = token->column;
@@ -562,7 +562,7 @@ static Expr *parse_expr(Parser *parser) {
 }
 
 static Stmt *new_stmt(StmtKind kind, Token *token) {
-  Stmt *stmt = calloc(1, sizeof(Stmt));
+  Stmt *stmt = z_checked_calloc(1, sizeof(Stmt));
   stmt->kind = kind;
   stmt->line = token->line;
   stmt->column = token->column;

--- a/native/zero-c/src/target.c
+++ b/native/zero-c/src/target.c
@@ -189,7 +189,7 @@ static void push_target(ZTargetInfo current) {
   if (!current.object_format) current.object_format = z_strdup("unknown");
   if (!current.linker) current.linker = z_strdup("cc");
   if (!current.capabilities) current.capabilities = z_strdup("\"memory\", \"stdio\"");
-  targets = realloc(targets, (target_count + 2) * sizeof(ZTargetInfo));
+  targets = z_checked_reallocarray(targets, target_count + 2, sizeof(ZTargetInfo));
   targets[target_count++] = current;
   targets[target_count] = (ZTargetInfo){0};
 }


### PR DESCRIPTION
- Move remaining native parser, checker, source, target, and driver allocations onto checked helpers

- Leave raw allocation calls only inside the shared checked allocation implementation

- Keep the final allocation hardening work grouped as one reviewable native compiler slice