### PR TITLE
Stamp git commit in version output and fail loudly when net builds cannot link libcurl

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,11 +95,14 @@ jobs:
           mkdir -p /tmp/zero-release
           node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
 
+          ZERO_GIT_COMMIT="$(git rev-parse --short HEAD 2>/dev/null || echo unknown)"
+          echo "Stamping commit: $ZERO_GIT_COMMIT"
+
           build_asset() {
             target="$1"
             name="$2"
             echo "Building $name (target: $target)..."
-            zig cc -target "$target" -std=c11 -D_POSIX_C_SOURCE=200809L -Os -Inative/zero-c/include native/zero-c/src/*.c -o "/tmp/zero-release/$name"
+            zig cc -target "$target" -std=c11 -D_POSIX_C_SOURCE=200809L -Os -DZERO_GIT_COMMIT="\"$ZERO_GIT_COMMIT\"" -Inative/zero-c/include native/zero-c/src/*.c -o "/tmp/zero-release/$name"
             chmod 755 "/tmp/zero-release/$name"
           }
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import assert from "node:assert/strict";
 import { execFile } from "node:child_process";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { promisify } from "node:util";
 
 if (process.env.ZERO_NATIVE_TEST_SANDBOX !== "1" && process.env.ZERO_NATIVE_TEST_ALLOW_LOCAL !== "1") {
@@ -1057,6 +1057,17 @@ assert.equal(explainTar002Body.schemaVersion, 1);
 assert.equal(explainTar002Body.code, "TAR002");
 assert.equal(explainTar002Body.repair.id, "choose-target-with-required-capability");
 
+const explainBld004 = await execFileAsync(zero, ["explain", "--json", "BLD004"]);
+const explainBld004Body = JSON.parse(explainBld004.stdout);
+assert.equal(explainBld004Body.schemaVersion, 1);
+assert.equal(explainBld004Body.code, "BLD004");
+assert.equal(explainBld004Body.category, "build");
+assert.equal(explainBld004Body.repair.id, "install-libcurl-dev");
+assert.match(explainBld004Body.summary, /libcurl/i);
+
+const explainBld004Text = await execFileAsync(zero, ["explain", "BLD004"]);
+assert.match(explainBld004Text.stdout, /net capability requires libcurl/i);
+
 const explainText = await execFileAsync(zero, ["explain", "TYP009"]);
 assert.match(explainText.stdout, /Mutable storage required/);
 
@@ -1325,6 +1336,66 @@ assert.equal(darwinArm64Target.httpRuntime.provider, targetsBody.host === "darwi
 assert.equal(darwinArm64Target.httpRuntime.tlsVerification, targetsBody.host === "darwin-arm64");
 if (targetsBody.host === "darwin-arm64") {
   assert.equal(darwinArm64Target.httpRuntime.customCa.env, "ZERO_HTTP_TEST_CA_BUNDLE");
+  // P2-11: supported host httpRuntime advertises whether the host can
+  // actually link libcurl, so silent-stub builds are observable.
+  assert.equal(darwinArm64Target.httpRuntime.status, "supported");
+  assert.equal(typeof darwinArm64Target.httpRuntime.hostLinkable, "boolean");
+}
+// unsupported targets must not claim a host libcurl link path.
+assert.equal(linuxMuslTarget.httpRuntime.hostLinkable, undefined);
+
+// P2-11: a `net` build on a host that cannot link libcurl must fail loudly
+// with BLD004 instead of silently producing a no-op-stub binary. We simulate
+// "no libcurl" with a stub cc that rejects the `-lcurl` link probe and forwards
+// everything else to the real cc, so the rest of the toolchain still works.
+if (runnableDirectTarget) {
+  const stubCc = `${outDir}/nocurl-cc`;
+  await writeFile(
+    stubCc,
+    [
+      "#!/bin/sh",
+      "for arg in \"$@\"; do",
+      "  case \"$arg\" in",
+      "    -lcurl*) echo 'stub-cc: libcurl unavailable' >&2; exit 1;;",
+      "  esac",
+      "done",
+      "exec cc \"$@\"",
+      "",
+    ].join("\n"),
+  );
+  await chmod(stubCc, 0o755);
+
+  const stubAbs = `${process.cwd()}/${stubCc}`;
+  const netNoCurl = await execFileAsync(zero, [
+    "build",
+    "--json",
+    "--emit",
+    "exe",
+    "--target",
+    runnableDirectTarget,
+    "--cc",
+    stubAbs,
+    "conformance/native/pass/std-http-fetch.0",
+    "--out",
+    `${outDir}/std-http-fetch-nocurl`,
+  ]).catch((error) => error);
+  assert(netNoCurl instanceof Error, "net build without libcurl must fail loudly");
+  const netNoCurlBody = JSON.parse(netNoCurl.stdout);
+  assert.equal(netNoCurlBody.diagnostics[0].code, "BLD004");
+  assert.match(netNoCurlBody.diagnostics[0].message, /libcurl/i);
+
+  // With the real host toolchain the same net build still succeeds unchanged.
+  const netWithCurl = await execFileAsync(zero, [
+    "build",
+    "--emit",
+    "exe",
+    "--target",
+    runnableDirectTarget,
+    "conformance/native/pass/std-http-fetch.0",
+    "--out",
+    `${outDir}/std-http-fetch-curl`,
+  ]);
+  assert.match(netWithCurl.stdout, /std-http-fetch-curl/);
 }
 assert.equal(linuxArm64Target.directBackend.status, "native-exe");
 assert.equal(linuxArm64Target.directBackend.objectEmitter, "zero-elf-aarch64");

--- a/docs-site/articles/install.md
+++ b/docs-site/articles/install.md
@@ -47,6 +47,38 @@ make -C native/zero-c
 bin/zero --version
 ```
 
+`make -C native/zero-c` stamps the short git commit into the binary, so a
+from-source build reports its real commit instead of `unknown`:
+
+```sh
+bin/zero --version --json
+```
+
+The JSON output reports `commit`, plus separate `hostCompiler` and
+`targetCompiler` facts. `hostCompiler` is the native `cc` that links host
+executables; `targetCompiler` is the cross toolchain used for non-host
+targets. A missing cross toolchain (`"targetCompiler": {"status": "missing"}`)
+does not mean the host compiler is missing — the two are reported
+independently. When git is unavailable at build time the commit falls back to
+`unknown` and `make` still succeeds.
+
+### libcurl is required for the `net` capability
+
+Programs that use `std.http.fetch(...)` (the `net` capability) link the system
+libcurl as their HTTP runtime provider. If the build host has no libcurl
+development files (`curl/curl.h` and the libcurl library), building a `net`
+program fails loudly with diagnostic `BLD004` instead of silently producing a
+binary whose HTTP calls always fail:
+
+```sh
+bin/zero explain BLD004
+```
+
+Install the libcurl development package to fix it (for example
+`libcurl4-openssl-dev` on Debian/Ubuntu, or `brew install curl` on macOS).
+`zero targets --json` reports `httpRuntime.hostLinkable` so you can check host
+readiness before building.
+
 The repository validation commands are:
 
 ```sh

--- a/docs-site/articles/target-capabilities.md
+++ b/docs-site/articles/target-capabilities.md
@@ -41,8 +41,22 @@ direct Darwin arm64 and Linux x64 host executable paths.
 
 `zero targets --json` includes an `httpRuntime` object for each target. On a
 supported host target it reports the curl provider, the platform-or-C-library
-TLS boundary, TLS verification state, the curl system library, and the
-`ZERO_HTTP_TEST_CA_BUNDLE` custom CA override.
+TLS boundary, TLS verification state, the curl system library, the
+`ZERO_HTTP_TEST_CA_BUNDLE` custom CA override, and a `hostLinkable` boolean.
+
+`hostLinkable` reflects whether the build host actually has the libcurl
+development files. The HTTP runtime provider links the system libcurl, so a
+`net` build on a host without `curl/curl.h` and the libcurl library fails
+loudly with diagnostic `BLD004` (repair id `install-libcurl-dev`) instead of
+silently producing a binary whose `std.http.fetch(...)` calls always fail:
+
+```sh
+zero explain BLD004
+```
+
+Install the libcurl development package (for example `libcurl4-openssl-dev` on
+Debian/Ubuntu, or `brew install curl` on macOS) to make the `net` capability
+buildable. Builds that do not use the `net` capability are unaffected.
 
 The smallest common target-neutral subset remains:
 

--- a/native/zero-c/Makefile
+++ b/native/zero-c/Makefile
@@ -5,7 +5,12 @@ OUT := $(ROOT)/.zero/bin/zero
 NODE_TS := node --experimental-strip-types --disable-warning=ExperimentalWarning
 BUILD_STAMP := $(OUT).build
 HOST_ID := $(shell uname -s 2>/dev/null || echo unknown)-$(shell uname -m 2>/dev/null || echo unknown)
-BUILD_ID := $(HOST_ID)|$(CC)|$(CFLAGS)
+# Stamp the short git commit into the binary so `zero --version --json` reports
+# a real commit on from-source builds. Falls back to "unknown" when git is
+# unavailable or this is not a checkout; `make` itself must never fail here.
+ZERO_GIT_COMMIT := $(shell git -C $(ROOT) rev-parse --short HEAD 2>/dev/null || echo unknown)
+COMMIT_FLAGS := -DZERO_GIT_COMMIT='"$(ZERO_GIT_COMMIT)"'
+BUILD_ID := $(HOST_ID)|$(CC)|$(CFLAGS)|$(ZERO_GIT_COMMIT)
 SRC := $(wildcard src/*.c)
 INCLUDES := $(wildcard include/*.h) $(wildcard src/*.inc)
 EMBEDDED_SKILLS := src/embedded_skills.inc
@@ -27,7 +32,7 @@ $(EMBEDDED_SKILLS): $(ROOT)/scripts/embed-skill-data.mts $(SKILL_INPUTS)
 
 $(OUT): $(BUILD_STAMP) $(SRC) $(INCLUDES) $(EMBEDDED_SKILLS)
 	@mkdir -p $(dir $(OUT))
-	$(CC) $(CFLAGS) -Iinclude $(SRC) -o $(OUT)
+	$(CC) $(CFLAGS) $(COMMIT_FLAGS) -Iinclude $(SRC) -o $(OUT)
 
 clean:
 	rm -f $(OUT) $(BUILD_STAMP)

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -75,6 +75,7 @@ typedef struct {
 } ShipArtifacts;
 
 static void print_command_help(const char *command);
+static int zero_mkdir(const char *path);
 
 static const char *diag_code(int code) {
   switch (code) {
@@ -84,6 +85,7 @@ static const char *diag_code(int code) {
     case 2001: return "APP001";
     case 2002: return "BLD002";
     case 2003: return "BLD003";
+    case 2004: return "BLD004";
     case 3002: return "NAM002";
     case 3003: return "NAM003";
     case 3004: return "NAM004";
@@ -480,9 +482,18 @@ static void append_parse_json(ZBuf *buf, const char *source_file, const Program 
   zbuf_append(buf, program && program->functions.len ? "\n  ]\n}\n" : "]\n}\n");
 }
 
+#ifndef ZERO_GIT_COMMIT
+#define ZERO_GIT_COMMIT "unknown"
+#endif
+
 static const char *zero_commit(void) {
+  // An explicit ZERO_COMMIT env override wins (used by packaging that builds
+  // outside the git tree); otherwise report the commit stamped at build time
+  // by the Makefile / release workflow.
   const char *commit = getenv("ZERO_COMMIT");
-  return commit && commit[0] ? commit : "unknown";
+  if (commit && commit[0]) return commit;
+  const char *stamped = ZERO_GIT_COMMIT;
+  return stamped && stamped[0] ? stamped : "unknown";
 }
 
 static bool command_available(const char *name) {
@@ -600,6 +611,54 @@ static bool compile_zero_runtime_object(const char *runtime_object_file, const Z
     snprintf(diag->help, sizeof(diag->help), "install a host C compiler or pass --cc for the runtime link plan");
   }
   return ok;
+}
+
+// Probe whether the link plan can actually see the libcurl development files
+// (curl/curl.h and the libcurl import). The embedded HTTP provider compiles to
+// a silent no-op stub under __has_include when curl/curl.h is absent, so
+// without this check a `net` build "succeeds" but std.http.fetch always fails
+// at runtime. Compiling + linking a tiny probe against the *real* toolchain
+// plan is the only reliable signal (a `cc -I` search path can differ from the
+// link path), so reuse the same plan that the runtime object/link will use.
+static bool host_libcurl_available(const ZToolchainPlan *plan, const Command *command, const ZTargetInfo *target) {
+  static const char probe_src[] =
+    "#include <curl/curl.h>\n"
+    "int main(void){ return curl_easy_init() ? 0 : 0; }\n";
+  char src_path[64];
+  char exe_path[64];
+  long pid = (long)getpid();
+  snprintf(src_path, sizeof(src_path), ".zero/.zero-curl-probe-%ld.c", pid);
+  snprintf(exe_path, sizeof(exe_path), ".zero/.zero-curl-probe-%ld", pid);
+  (void)zero_mkdir(".zero");
+  FILE *f = fopen(src_path, "wb");
+  if (!f) return false;
+  fwrite(probe_src, 1, sizeof(probe_src) - 1, f);
+  fclose(f);
+  const char *object_files[1] = {src_path};
+  bool ok = z_toolchain_link_objects(
+    plan, target, object_files, 1, exe_path,
+    "",
+    "-lcurl >/dev/null 2>&1"
+  );
+  (void)command;
+  remove(src_path);
+  remove(exe_path);
+  return ok;
+}
+
+static bool require_host_libcurl(const ZToolchainPlan *plan, const Command *command, const ZTargetInfo *target, ZDiag *diag) {
+  if (host_libcurl_available(plan, command, target)) return true;
+  if (diag) {
+    diag->code = 2004;
+    diag->line = 1;
+    diag->column = 1;
+    diag->length = 1;
+    snprintf(diag->message, sizeof(diag->message), "net capability requires libcurl development files");
+    snprintf(diag->expected, sizeof(diag->expected), "curl/curl.h and the libcurl library are available to the host link plan");
+    snprintf(diag->actual, sizeof(diag->actual), "the host toolchain cannot compile or link against libcurl, so std.http.fetch would silently degrade to a no-op stub");
+    snprintf(diag->help, sizeof(diag->help), "install the libcurl development package (e.g. libcurl4-openssl-dev on Debian/Ubuntu, `brew install curl` on macOS), or pass --cc/ZERO_CC to a toolchain that can see libcurl; run `zero explain BLD004`");
+  }
+  return false;
 }
 
 static bool compile_zero_http_curl_object(const char *runtime_object_file, const ZToolchainPlan *plan, const Command *command, const ZTargetInfo *target, ZDiag *diag) {
@@ -2521,6 +2580,7 @@ static const char *diag_repair_id(int code) {
     case 3030: return "return-owned-value";
     case 3031: return "make-c-abi-safe";
     case 2003: return "use-direct-emitter";
+    case 2004: return "install-libcurl-dev";
     case 3032: return "match-generic-type-arguments";
     case 3033: return "make-generic-argument-types-match";
     case 3034: return "add-explicit-generic-type-arguments";
@@ -2571,6 +2631,7 @@ static const char *diag_repair_summary(int code) {
     case 3030: return "Return an owned value, or keep references to local bindings inside the current function.";
     case 3031: return "Use explicit scalar, ref, or mutref types at C ABI boundaries and keep exported C functions non-raising.";
     case 2003: return "Use a direct emitter such as --emit exe or --emit obj.";
+    case 2004: return "Install the libcurl development files (curl/curl.h and libcurl) so the net capability can link its HTTP runtime provider.";
     case 3032: return "Pass one type argument for each generic parameter, or remove type arguments from non-generic calls.";
     case 3033: return "Make all values that bind the same generic parameter use the same concrete type.";
     case 3034: return "Add explicit generic type arguments when the compiler cannot infer them from runtime arguments.";
@@ -2678,6 +2739,16 @@ static const ExplainInfo explain_infos[] = {
     "Use a direct emitter such as `--emit exe` or `--emit obj`.",
     "zero build --emit c examples/hello.0",
     "zero build --emit exe examples/hello.0",
+  },
+  {
+    "BLD004",
+    "build",
+    "net capability requires libcurl development files",
+    "A program used the net capability (std.http.fetch) but the build host has no libcurl development headers/library, so the HTTP runtime provider cannot be linked.",
+    "Zero links libcurl as the audited HTTP provider; without it the runtime would silently degrade to a no-op stub, so the build fails loudly instead.",
+    "Install the libcurl development package (for example libcurl4-openssl-dev on Debian/Ubuntu, curl via Homebrew on macOS), or build for a target that does not require the net capability.",
+    "zero build examples/http-get.0 # on a host without curl/curl.h",
+    "sudo apt-get install libcurl4-openssl-dev && zero build examples/http-get.0",
   },
   {
     "TYP009",
@@ -2947,6 +3018,7 @@ static void print_explain_json(const ExplainInfo *info) {
   append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
                                          strcmp(info->code, "TAR002") == 0 ? 6002 :
                                          strcmp(info->code, "BLD003") == 0 ? 2003 :
+                                         strcmp(info->code, "BLD004") == 0 ? 2004 :
                                          strcmp(info->code, "TYP009") == 0 ? 3010 :
                                          strcmp(info->code, "TYP023") == 0 ? 3032 :
                                          strcmp(info->code, "TYP024") == 0 ? 3033 :
@@ -5454,6 +5526,16 @@ static int print_version_command(bool json) {
   bool target_cc_available = target_cc_override || bundled_target_cc_available;
   char *target_cc_version = target_cc_override ? z_strdup("configured via ZERO_CC") : (bundled_target_cc_available ? command_first_line("zig version 2>/dev/null") : z_strdup(""));
 
+  // The host C compiler is what actually links host executables, and is
+  // distinct from the cross "target compiler". Report it accurately so
+  // `zero --version --json` no longer conflates the two (P2-10): a missing
+  // cross toolchain is not the same as a missing host cc.
+  bool host_cc_override = target_cc_override;
+  bool host_cc_available = host_cc_override || command_available("cc");
+  char *host_cc_version = host_cc_override
+    ? z_strdup("configured via ZERO_CC")
+    : (host_cc_available ? command_first_line("cc --version 2>/dev/null") : z_strdup(""));
+
   ZBuf buf;
   zbuf_init(&buf);
   zbuf_append(&buf, "{\n  \"schemaVersion\": 1,\n  \"version\": ");
@@ -5464,9 +5546,17 @@ static int print_version_command(bool json) {
   append_json_string(&buf, z_host_target());
   zbuf_append(&buf, ",\n  \"backend\": \"zero-c\",\n  \"targets\": ");
   z_append_target_names_json(&buf);
-  zbuf_append(&buf, ",\n  \"targetCompiler\": {\"available\": ");
+  zbuf_append(&buf, ",\n  \"hostCompiler\": {\"available\": ");
+  zbuf_append(&buf, host_cc_available ? "true" : "false");
+  zbuf_append(&buf, ", \"kind\": \"host C compiler\", \"status\": ");
+  append_json_string(&buf, host_cc_available ? "present" : "missing");
+  zbuf_append(&buf, ", \"version\": ");
+  append_json_string(&buf, host_cc_version);
+  zbuf_append(&buf, "},\n  \"targetCompiler\": {\"available\": ");
   zbuf_append(&buf, target_cc_available ? "true" : "false");
-  zbuf_append(&buf, ", \"kind\": \"target-capable C compiler\", \"version\": ");
+  zbuf_append(&buf, ", \"kind\": \"target-capable C compiler\", \"status\": ");
+  append_json_string(&buf, target_cc_available ? "present" : "missing");
+  zbuf_append(&buf, ", \"version\": ");
   append_json_string(&buf, target_cc_version);
   zbuf_append(&buf, "},\n  \"crossCompilation\": {\"ready\": ");
   zbuf_append(&buf, target_cc_available ? "true" : "false");
@@ -5474,6 +5564,7 @@ static int print_version_command(bool json) {
   fputs(buf.data, stdout);
   zbuf_free(&buf);
   free(target_cc_version);
+  free(host_cc_version);
   return 0;
 }
 
@@ -9473,6 +9564,7 @@ int main(int argc, char **argv) {
     input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, strcmp(object_emitter, "zero-macho64") == 0 ? "direct-macho64-object-runtime-link" : "direct-elf64-object-runtime-link"));
     bool wrote_object = z_write_binary_file(object_file, (const unsigned char *)object.data, object.len, &diag);
     if (wrote_object) wrote_object = compile_zero_runtime_object(runtime_object_file, &runtime_toolchain, &command, target, &diag);
+    if (wrote_object && needs_http_runtime) wrote_object = require_host_libcurl(&runtime_toolchain, &command, target, &diag);
     if (wrote_object && needs_http_runtime) wrote_object = compile_zero_http_curl_object(http_object_file, &runtime_toolchain, &command, target, &diag);
     input.object_ms = now_ms() - phase_started;
     if (!wrote_object) {

--- a/native/zero-c/src/target.c
+++ b/native/zero-c/src/target.c
@@ -417,9 +417,34 @@ static bool target_http_runtime_supported(const ZTargetInfo *target) {
           (target->os && strcmp(target->os, "linux") == 0));
 }
 
+// Whether the host toolchain can see curl/curl.h. The embedded HTTP provider
+// degrades to a silent no-op stub when this header is absent, so report it as
+// a fact (`hostLinkable`) instead of unconditionally claiming "supported".
+// Probed once per process via the host preprocessor.
+static bool host_curl_header_available(void) {
+  static int cached = -1;
+  if (cached >= 0) return cached != 0;
+  const char *zero_cc = getenv("ZERO_CC");
+  const char *cc = zero_cc && zero_cc[0] ? zero_cc : "cc";
+  ZBuf cmd;
+  zbuf_init(&cmd);
+  zbuf_appendf(&cmd, "echo '#include <curl/curl.h>' | '%s' -E -x c - >/dev/null 2>&1", cc);
+  cached = (cmd.data && system(cmd.data) == 0) ? 1 : 0;
+  zbuf_free(&cmd);
+  return cached != 0;
+}
+
 void z_append_http_runtime_json(ZBuf *buf, const ZTargetInfo *target) {
   if (target_http_runtime_supported(target)) {
-    zbuf_append(buf, "{\"status\":\"supported\",\"provider\":\"curl\",\"providerLink\":\"system-library\",\"tlsBoundary\":\"platform-or-c-library\",\"caSource\":\"provider-default\",\"tlsVerification\":true,\"customCa\":{\"supported\":true,\"mode\":\"test-harness\",\"env\":\"ZERO_HTTP_TEST_CA_BUNDLE\"},\"insecureMode\":false,\"protocols\":[\"http\",\"https\"],\"staticLibraries\":[\"zero_runtime.o\",\"zero_http_curl.o\"],\"systemLibraries\":[\"curl\"],\"reason\":\"host direct runtime link plan uses libcurl with verification enabled\"}");
+    bool host_linkable = host_curl_header_available();
+    zbuf_appendf(
+      buf,
+      "{\"status\":\"supported\",\"provider\":\"curl\",\"providerLink\":\"system-library\",\"hostLinkable\":%s,\"tlsBoundary\":\"platform-or-c-library\",\"caSource\":\"provider-default\",\"tlsVerification\":true,\"customCa\":{\"supported\":true,\"mode\":\"test-harness\",\"env\":\"ZERO_HTTP_TEST_CA_BUNDLE\"},\"insecureMode\":false,\"protocols\":[\"http\",\"https\"],\"staticLibraries\":[\"zero_runtime.o\",\"zero_http_curl.o\"],\"systemLibraries\":[\"curl\"],\"reason\":\"%s\"}",
+      host_linkable ? "true" : "false",
+      host_linkable
+        ? "host direct runtime link plan uses libcurl with verification enabled"
+        : "net capability requires libcurl development files; install libcurl to build std.http.fetch (see BLD004)"
+    );
     return;
   }
   const char *reason = "target has no audited HTTP runtime provider";

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -205,6 +205,17 @@ assert(version.targets.includes("darwin-arm64"));
 assert(version.targets.includes("linux-musl-x64"));
 assert(version.targets.includes("win32-x64.exe"));
 assert.equal(typeof version.targetCompiler.available, "boolean");
+// P2-10: a from-source `make` build stamps the git commit, so the contract
+// build must report a real short commit (not the `unknown` fallback) and
+// must report host/target compiler facts independently.
+assert.equal(typeof version.commit, "string");
+assert(version.commit.length > 0);
+assert.notEqual(version.commit, "unknown");
+assert.match(version.commit, /^[0-9a-f]{7,40}$/);
+assert.equal(typeof version.hostCompiler.available, "boolean");
+assert.equal(version.hostCompiler.available, true);
+assert.equal(version.hostCompiler.status, "present");
+assert(["present", "missing"].includes(version.targetCompiler.status));
 
 const doctor = json(["doctor", "--json"]).body;
 assert.equal(doctor.schemaVersion, 1);


### PR DESCRIPTION
## Summary

- P2-10: `make` and the release workflow stamp the short git commit into the binary, so a from-source build's `zero --version --json` reports a real `commit` instead of `unknown`. The version JSON now reports independent `hostCompiler` and `targetCompiler` facts (each with `status`), so a missing cross toolchain is no longer conflated with a missing host `cc`. git-unavailable builds fall back to `unknown` without failing `make`.
- P2-11: the embedded HTTP provider silently compiles to a no-op stub when `curl/curl.h` is absent, so `net` programs built without libcurl produced a binary whose `std.http.fetch` always failed. The host build path now probes the real toolchain plan for libcurl and emits a hard `BLD004` diagnostic with remediation text instead of a silent stub. `zero targets --json` surfaces `httpRuntime.hostLinkable`, and `zero explain BLD004` documents the fix.

## Source

Addresses P2-10 + P2-11. Reproduction confirmed against main @ 44f02f1: a from-source build reported `"commit": "unknown"` with no host-compiler fact, and a `net` build on a host that cannot link libcurl produced a stub binary with no diagnostic.

## Changes

- `native/zero-c/Makefile`: pass `-DZERO_GIT_COMMIT=$(git rev-parse --short HEAD)` (fallback `unknown`, never fails make); include the commit in the build-id stamp.
- `.github/workflows/release.yml`: stamp `-DZERO_GIT_COMMIT` into each cross-compiled release asset.
- `native/zero-c/src/main.c`: `zero_commit()` reads the stamped macro (env override still wins); `--version --json` adds `hostCompiler`/`targetCompiler` `status`; new `BLD004` code, repair id `install-libcurl-dev`, repair summary, and `explain` entry; `require_host_libcurl()` probes the real link plan before building the HTTP runtime object and emits `BLD004` instead of a silent stub.
- `native/zero-c/src/target.c`: supported `httpRuntime` fact gains `hostLinkable` (probes the host `cc` for `curl/curl.h`) and an actionable reason when libcurl is absent.
- `docs-site/articles/install.md`, `docs-site/articles/target-capabilities.md`: document commit stamping, host/target compiler facts, and the libcurl requirement / `BLD004`.
- `scripts/snapshot-command-contracts.mts`, `conformance/run.mjs`: assertions for a real stamped commit, host/target compiler facts, `httpRuntime.hostLinkable`, `explain BLD004`, and that a `net` build without libcurl fails loudly while the libcurl-present path is unchanged.

## Conformance

- `command-contracts:local`: green — asserts `--version --json` shows a real `^[0-9a-f]{7,40}$` commit and `hostCompiler.status == present`.
- `conformance:local`: green — asserts `explain BLD004`, `httpRuntime.hostLinkable`, and (on a runnable host target) that a `net` build with a libcurl-hiding stub `cc` fails with `BLD004` while the real-toolchain build still succeeds.
- `native:test:local`: not green in this environment — fails at the pre-existing `--target linux-musl-x64` cross-build step because no cross C toolchain (`zig`) is installed on the build host. Verified identical failure at main @ 44f02f1 with an unmodified build, so it is an environment limitation unrelated to this change.
- Manual repro: `zero build <net-program> --cc <stub-cc-rejecting--lcurl>` prints `BLD004` (text and `--json`); the same build with the real host `cc` succeeds unchanged; non-`net` builds are unaffected.

## Proposed CHANGELOG line

- Stamp the git commit into `zero --version`, report host vs target compiler separately, and fail `net` builds loudly with `BLD004` when libcurl development files are missing instead of producing a silent no-op HTTP stub.