### PR TITLE
Stop missing-main diagnostic from masking real errors

### DIFF
--- a/conformance/check/fail/missing-main.0
+++ b/conformance/check/fail/missing-main.0
@@ -1,0 +1,3 @@
+fun helper() -> i32 {
+  return 42
+}

--- a/conformance/check/fail/no-main-type-error.0
+++ b/conformance/check/fail/no-main-type-error.0
@@ -1,0 +1,3 @@
+fun helper() -> Void {
+  let x: i32 = "not an integer"
+}

--- a/conformance/diagnostics/missing-main.0
+++ b/conformance/diagnostics/missing-main.0
@@ -1,0 +1,3 @@
+fun helper() -> i32 {
+  return 42
+}

--- a/conformance/diagnostics/missing-main.expected.json
+++ b/conformance/diagnostics/missing-main.expected.json
@@ -1,0 +1,7 @@
+{
+  "schemaVersion": 1,
+  "code": "APP001",
+  "title": "Missing main function",
+  "fixSafety": "requires-human-review",
+  "defaultOutput": "plain-text-no-ansi"
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -2325,4 +2325,30 @@ for (const [fixture, code] of [
   assert.match(result.stderr, code);
 }
 
+// Diagnostic completeness: a no-main file with a real type error must report
+// the real diagnostic, not have it masked by the missing-main check (APP001).
+const noMainTypeError = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/no-main-type-error.0"]).catch((error) => error);
+assert.notEqual(noMainTypeError.code, 0);
+const noMainTypeErrorBody = JSON.parse(noMainTypeError.stdout);
+assert.equal(noMainTypeErrorBody.ok, false);
+assert.equal(noMainTypeErrorBody.diagnostics[0].code, "TYP002");
+assert.equal(noMainTypeErrorBody.diagnostics[0].line, 2);
+assert.ok(!noMainTypeErrorBody.diagnostics.some((diagnostic) => diagnostic.code === "APP001"));
+
+// The missing-main diagnostic still fires when there are no other errors and
+// no entry point, with the entrypoint repair id.
+const missingMain = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/missing-main.0"]).catch((error) => error);
+assert.notEqual(missingMain.code, 0);
+const missingMainBody = JSON.parse(missingMain.stdout);
+assert.equal(missingMainBody.ok, false);
+assert.equal(missingMainBody.diagnostics[0].code, "APP001");
+assert.equal(missingMainBody.diagnostics[0].repair.id, "add-main-entry-point");
+
+const explainApp001 = await execFileAsync(zero, ["explain", "--json", "APP001"]);
+const explainApp001Body = JSON.parse(explainApp001.stdout);
+assert.equal(explainApp001Body.schemaVersion, 1);
+assert.equal(explainApp001Body.code, "APP001");
+assert.equal(explainApp001Body.category, "app");
+assert.equal(explainApp001Body.repair.id, "add-main-entry-point");
+
 console.log("conformance ok");

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -7831,7 +7831,6 @@ bool z_check_program(const Program *program, ZDiag *diag) {
     if (!validate_function_error_set(fun, diag)) return false;
     if (!validate_export_c_function(fun, diag)) return false;
   }
-  if (!main_fun && !has_test) return set_diag_detail(diag, 2001, "missing main function", 1, 1, "function named main", "no main function", "add pub fun main(...) -> Void");
 	  for (size_t i = 0; i < program->functions.len; i++) {
 	    const Function *fun = &program->functions.items[i];
 	    Scope scope = {0};
@@ -7873,5 +7872,6 @@ bool z_check_program(const Program *program, ZDiag *diag) {
     scope_free(&scope);
     if (!ok) return false;
   }
+  if (!main_fun && !has_test) return set_diag_detail(diag, 2001, "missing main function", 1, 1, "function named main", "no main function", "add pub fun main(...) -> Void");
   return true;
 }

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2520,6 +2520,7 @@ static const char *diag_repair_id(int code) {
     case 3029: return "end-conflicting-borrow";
     case 3030: return "return-owned-value";
     case 3031: return "make-c-abi-safe";
+    case 2001: return "add-main-entry-point";
     case 2003: return "use-direct-emitter";
     case 3032: return "match-generic-type-arguments";
     case 3033: return "make-generic-argument-types-match";
@@ -2554,6 +2555,7 @@ static const char *diag_repair_id(int code) {
 static const char *diag_repair_summary(int code) {
   switch (code) {
     case 100: return "Repair the syntax at the reported parser span, then rerun zero check.";
+    case 2001: return "Add pub fun main(...) -> Void as the program entry point, or add a test function for a library unit.";
     case 1001: return "Add raises to the function signature or handle the fallible expression with rescue.";
     case 1002: return "Add the missing error name to raises { ... } or rescue the call locally.";
     case 1003: return "Wrap the fallible call in check or rescue so error flow is explicit.";
@@ -2919,6 +2921,16 @@ static const ExplainInfo explain_infos[] = {
     "zero build --emit obj --target linux-arm64 examples/direct-call-add.0",
     "zero build --emit obj --target linux-x64 examples/direct-call-add.0",
   },
+  {
+    "APP001",
+    "app",
+    "Missing main function",
+    "The program has no `main` function and no test functions, so there is no entry point to run.",
+    "This diagnostic is emitted only after full type, borrow, and effect analysis has run, so it never masks real errors elsewhere in the file.",
+    "Add `pub fun main(...) -> Void`, or add a test function if this file is meant to be checked as a library unit.",
+    "fun helper() -> Void {}",
+    "fun helper() -> Void {}\n\npub fun main() -> Void {}",
+  },
   {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -2970,7 +2982,8 @@ static void print_explain_json(const ExplainInfo *info) {
                                          strcmp(info->code, "ERR002") == 0 ? 1002 :
                                          strcmp(info->code, "ERR003") == 0 ? 1003 :
                                          strcmp(info->code, "STD003") == 0 ? 3012 :
-                                         strcmp(info->code, "CGEN004") == 0 ? 4004 : 0));
+                                         strcmp(info->code, "CGEN004") == 0 ? 4004 :
+                                         strcmp(info->code, "APP001") == 0 ? 2001 : 0));
   zbuf_append(&buf, ", \"summary\": ");
   append_json_string(&buf, info->canonical_repair);
   zbuf_append(&buf, "},\n  \"examples\": {\"bad\": ");

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -999,6 +999,7 @@ const diagnostics = [
   ["SHM001", ["check", "--json", "conformance/check/fail/generic-shape-method-cannot-infer.0"]],
   ["RCV001", ["check", "--json", "conformance/check/fail/receiver-method-unknown.0"]],
   ["RCV002", ["check", "--json", "conformance/check/fail/receiver-method-immutable.0"]],
+  ["APP001", ["check", "--json", "conformance/check/fail/missing-main.0"]],
 ].map(([code, args]) => {
   const body = json(args, { allowFailure: true }).body;
   const diagnostic = body.diagnostics[0];


### PR DESCRIPTION
## Summary

In single-file / no-`main` checks, `z_check_program` returned the missing-main diagnostic (APP001 / code 2001) *before* the per-function type/borrow/effect analysis loop ran. This short-circuited analysis and masked genuine diagnostics: a no-`main` file with a real type error reported only `APP001`, hiding the actual `TYP002`/etc. error.

This PR decouples the missing-entrypoint diagnostic from analysis. The full per-function analysis loop now always runs first and surfaces real diagnostics; the missing-`main`/`has_test` check is emitted only after analysis completes with no other error, and never short-circuits analysis. Behavior where a `main` or test exists is unchanged (the condition is still `!main_fun && !has_test`).

## Source

Addresses B7d (diagnostic completeness). Reproduction confirmed against main @ 44f02f1136ee30ee372d72138d97eb48c1658d88.

Repro (before fix): `bin/zero check --json` on a no-`main` file containing `let x: i32 = "s"` reported only `APP001`; the same body with a `main` reported `TYP002`. After fix: the no-`main` file reports `TYP002` (real error), and a clean no-`main` file still reports `APP001`.

## Changes

- `native/zero-c/src/checker.c`: move the `!main_fun && !has_test` missing-main check from before the per-function analysis loop to after it (single-line move).
- `native/zero-c/src/main.c`: add an `APP001` entry to the `explain` table (`zero explain APP001` previously failed with "unknown diagnostic code"); map code 2001 to a new `add-main-entry-point` repair id and an entrypoint-specific repair summary.
- `conformance/check/fail/no-main-type-error.0`: no-`main` file with a real type error.
- `conformance/check/fail/missing-main.0`: clean no-`main` file (APP001 coverage).
- `conformance/diagnostics/missing-main.0` + `.expected.json`: explain fixture mirroring `unknown-name`.
- `conformance/run.mjs` (append-only): assert the no-`main` type-error file reports `TYP002` and no `APP001`; assert the clean no-`main` file reports `APP001` with the entrypoint repair id; assert `explain --json APP001`.
- `scripts/snapshot-command-contracts.mts` (append-only): register `APP001` in the diagnostic-code coverage table.

## Conformance

- `make -C native/zero-c`: green, no warnings (`-Wall -Wextra -Wpedantic`).
- `scripts/provenance-guardrails.mts`: passes (29 surfaces).
- Manually verified every assertion added to `conformance/run.mjs` and `scripts/snapshot-command-contracts.mts` against the rebuilt binary, plus regression checks on all existing no-`main` fail fixtures (parse-level and `has_test` fixtures: behavior unchanged) and the existing `unknown-name` diagnostics fixtures (still `NAM003`).
- Draft because the `:local` gate runner scripts could not be executed end-to-end in the contributing sandbox; individual assertions were verified manually. Please run `conformance:local`, `native:test:local`, and `command-contracts:local` in CI.

## Proposed CHANGELOG line

Fixed: the missing-main diagnostic (APP001) no longer masks real type, borrow, or effect errors in single-file no-main checks; `zero explain APP001` is now supported.