### PR TITLE
Lower large constant array fills to O(1) code/IR

### DIFF
--- a/conformance/native/pass/array-zeroinit-bss.0
+++ b/conformance/native/pass/array-zeroinit-bss.0
@@ -1,0 +1,10 @@
+export c fun main() -> i32 {
+    let mut buffer: [1048576]u8 = [0_u8; 1048576]
+    buffer[0] = 1_u8
+    if buffer[0] == 1_u8 &&
+        buffer[1] == 0_u8 &&
+        buffer[1048575] == 0_u8 {
+        return 0
+    }
+    return 1
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -260,6 +260,7 @@ for (const fixture of [
   "conformance/native/pass/std-mem-arrays.0",
   "conformance/native/pass/array-repeat-literal.0",
   "conformance/native/pass/array-repeat-record-field.0",
+  "conformance/native/pass/array-zeroinit-bss.0",
   "conformance/native/pass/integer-widths.0",
   "conformance/native/pass/std-codec-widths.0",
   "conformance/native/pass/parse-integers.0",
@@ -706,6 +707,37 @@ assert.equal(directObjBody.generatedCBytes, 0);
 assert(directObjBody.loweredIrBytes > 0);
 assert.equal(directObjBody.objectBackend.objectEmission.path, "direct-elf64-object");
 await assertElf64Object(directObjOut, "main");
+
+// P0-2: a constant `[v; N]` repeat literal must lower to an O(1) counted fill
+// instead of N immediate stores, so the emitted .text (and lowered IR) stay
+// constant as N grows. Build the 1 MiB zeroed-buffer fixture and a tiny
+// variant and assert the larger array does not grow .text and links small.
+// Two zeroed buffers 16x apart in size must lower to byte-identical .text:
+// the fill loop's instruction count is independent of the element count, so
+// growth is strictly O(1) (no per-element stores remain).
+const zeroinitSmallOut = `${outDir}/array-zeroinit-64k.o`;
+const zeroinitHugeOut = `${outDir}/array-zeroinit-huge.o`;
+const zeroinitSmallSrc = `${outDir}/array-zeroinit-64k.0`;
+await writeFile(zeroinitSmallSrc, "export c fun main() -> i32 {\n    let mut buffer: [65536]u8 = [0_u8; 65536]\n    buffer[0] = 1_u8\n    if buffer[0] == 1_u8 && buffer[1] == 0_u8 && buffer[65535] == 0_u8 { return 0 }\n    return 1\n}\n");
+const zeroinitSmallJson = await execFileAsync(zero, ["build", "--json", "--emit", "obj", "--target", "linux-musl-x64", zeroinitSmallSrc, "--out", zeroinitSmallOut]);
+const zeroinitHugeJson = await execFileAsync(zero, ["build", "--json", "--emit", "obj", "--target", "linux-musl-x64", "conformance/native/pass/array-zeroinit-bss.0", "--out", zeroinitHugeOut]);
+const zeroinitSmallBody = JSON.parse(zeroinitSmallJson.stdout);
+const zeroinitHugeBody = JSON.parse(zeroinitHugeJson.stdout);
+assert.equal(zeroinitHugeBody.generatedCBytes, 0);
+// Lowered IR is O(1): a 16x larger buffer must not enlarge the lowered IR.
+assert.equal(zeroinitHugeBody.loweredIrBytes, zeroinitSmallBody.loweredIrBytes,
+  `zero-init lowered IR must be O(1) (64k=${zeroinitSmallBody.loweredIrBytes}, 1MiB=${zeroinitHugeBody.loweredIrBytes})`);
+const zeroinitSmall = await assertElf64Object(zeroinitSmallOut, "main");
+const zeroinitHuge = await assertElf64Object(zeroinitHugeOut, "main");
+const hugeTextBytes = zeroinitHuge.sections.get(".text").size;
+const smallTextBytes = zeroinitSmall.sections.get(".text").size;
+// O(1) .text growth: a 16x larger array emits exactly the same code size.
+assert.equal(hugeTextBytes, smallTextBytes,
+  `1 MiB zero-init .text must be O(1) (64k=${smallTextBytes}, 1MiB=${hugeTextBytes})`);
+// The linked object for a 1 MiB zeroed buffer must stay far under 256 KiB.
+const hugeObjectBytes = (await readFile(zeroinitHugeOut)).length;
+assert(hugeObjectBytes < 256 * 1024,
+  `1 MiB zero-init object should be < 256 KiB, got ${hugeObjectBytes}`);
 
 const directI64ObjOut = `${outDir}/direct-i64-return.o`;
 const directI64ObjJson = await execFileAsync(zero, ["build", "--json", "--emit", "obj", "--target", "linux-musl-x64", "examples/direct-i64-return.0", "--out", directI64ObjOut]);

--- a/docs-site/articles/optimization.md
+++ b/docs-site/articles/optimization.md
@@ -56,6 +56,19 @@ metadata block stayed in the artifact. Use `optimizationHints` for the next
 action, such as switching away from `debug`, removing hosted filesystem helpers
 from target-neutral code, or inspecting `topLargestEmittedHelpers`.
 
+## Constant Array Zero/Fill
+
+A repeat literal such as `[0_u8; 1048576]` (or a record's `[v; N]` array field)
+is lowered to a single counted fill instruction instead of `N` immediate
+stores. Code size and lowered IR for a constant `[v; N]` byte array are
+**O(1)** in `N`: a 1 MiB zeroed buffer emits the same `.text` as a 64 KiB one
+instead of growing by roughly one store per element. Small arrays (`N` up to
+32 elements) stay fully unrolled so existing codegen is unchanged. This applies
+to byte (`u8`/`bool`) arrays with a constant fill value; other element types
+keep the unrolled form. Inspect the effect with `bin/zero size --json`
+(`loweredIrBytes`) or by comparing the `.text` section of two differently sized
+zeroed buffers.
+
 ## Benchmark Trends
 
 The benchmark gate writes both a full one-run report and a compact trend

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -519,6 +519,8 @@ struct IrValue {
 typedef enum {
   IR_INSTR_LOCAL_SET,
   IR_INSTR_INDEX_STORE,
+  IR_INSTR_INDEX_FILL,
+  IR_INSTR_FIELD_FILL,
   IR_INSTR_FIELD_STORE,
   IR_INSTR_WORLD_WRITE,
   IR_INSTR_RAISE,
@@ -534,6 +536,8 @@ struct IrInstr {
   unsigned array_index;
   unsigned field_offset;
   unsigned error_code;
+  unsigned fill_count;
+  unsigned fill_stride;
   IrValue *value;
   IrValue *index;
   IrInstr *then_instrs;

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -759,6 +759,40 @@ static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *in
     coff_emit_store_local_from_reg(text, fun, instr->local_index, 0);
     return true;
   }
+  if (instr->kind == IR_INSTR_INDEX_FILL || instr->kind == IR_INSTR_FIELD_FILL) {
+    /* O(1) constant byte fill: a counted loop instead of one store per element
+       keeps the emitted .text size independent of the array length. */
+    if (instr->kind == IR_INSTR_INDEX_FILL) {
+      if (instr->array_index >= fun->local_len) return coff_diag_at(diag, "direct COFF array fill is out of range", instr->line, instr->column, "invalid array local");
+      coff_emit_array_base_rdx(text, fun, instr->array_index);
+    } else {
+      if (instr->local_index >= fun->local_len) return coff_diag_at(diag, "direct COFF record fill is out of range", instr->line, instr->column, "invalid record local");
+      unsigned offset = coff_local_slot_offset(fun, instr->local_index, instr->field_offset);
+      coff_emit_rbp_disp_reg(text, 0x8d, 2, offset, true); /* lea rdx, [rbp - field] */
+    }
+    unsigned char byte = instr->value ? (unsigned char)(instr->value->int_value & 0xffu) : 0u;
+    /* xor ecx, ecx */
+    append_u8(text, 0x31);
+    append_u8(text, 0xc9);
+    size_t loop_start = text->len;
+    /* cmp ecx, fill_count */
+    append_u8(text, 0x81);
+    append_u8(text, 0xf9);
+    append_u32le(text, instr->fill_count);
+    size_t exit_patch = coff_emit_jcc32_placeholder(text, 0x83); /* jae */
+    /* mov byte [rdx+rcx*1], imm8 */
+    append_u8(text, 0xc6);
+    append_u8(text, 0x04);
+    append_u8(text, 0x0a);
+    append_u8(text, byte);
+    /* inc ecx */
+    append_u8(text, 0xff);
+    append_u8(text, 0xc1);
+    size_t back_patch = coff_emit_jmp32_placeholder(text, 0xe9);
+    coff_patch_rel32(text, back_patch, loop_start);
+    coff_patch_rel32(text, exit_patch, text->len);
+    return true;
+  }
   if (instr->kind == IR_INSTR_FIELD_STORE) {
     if (instr->local_index >= fun->local_len) return coff_diag_at(diag, "direct COFF field store record is out of range", instr->line, instr->column, "invalid record local");
     if (!fun->locals[instr->local_index].is_record) return coff_diag_at(diag, "direct COFF field store requires record local", instr->line, instr->column, "non-record local");

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -2462,6 +2462,45 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
     }
     return true;
   }
+  if (instr->kind == IR_INSTR_INDEX_FILL || instr->kind == IR_INSTR_FIELD_FILL) {
+    /* O(1) constant byte fill: emit a counted loop instead of one immediate
+       store per element so the .text size is independent of the array length. */
+    unsigned disp = 0;
+    if (instr->kind == IR_INSTR_INDEX_FILL) {
+      if (instr->array_index >= fun->local_len) return elf_diag(diag, "direct ELF64 array fill is out of range", instr->line, instr->column, "invalid array local");
+      disp = fun->locals[instr->array_index].frame_offset;
+    } else {
+      if (instr->local_index >= fun->local_len) return elf_diag(diag, "direct ELF64 record fill is out of range", instr->line, instr->column, "invalid record local");
+      disp = elf_record_field_disp(&fun->locals[instr->local_index], instr->field_offset);
+    }
+    unsigned char byte = instr->value ? (unsigned char)(instr->value->int_value & 0xffu) : 0u;
+    /* lea rax, [rbp - disp] */
+    elf_append_u8(text, 0x48);
+    elf_append_u8(text, 0x8d);
+    elf_append_u8(text, 0x85);
+    elf_append_u32(text, (uint32_t)(-(int32_t)disp));
+    /* xor ecx, ecx */
+    elf_append_u8(text, 0x31);
+    elf_append_u8(text, 0xc9);
+    size_t loop_start = text->len;
+    /* cmp ecx, fill_count */
+    elf_append_u8(text, 0x81);
+    elf_append_u8(text, 0xf9);
+    elf_append_u32(text, instr->fill_count);
+    size_t exit_patch = elf_emit_jcc32_placeholder(text, 0x83); /* jae */
+    /* mov byte [rax+rcx*1], imm8 */
+    elf_append_u8(text, 0xc6);
+    elf_append_u8(text, 0x04);
+    elf_append_u8(text, 0x08);
+    elf_append_u8(text, byte);
+    /* inc ecx */
+    elf_append_u8(text, 0xff);
+    elf_append_u8(text, 0xc1);
+    size_t back_patch = elf_emit_jmp32_placeholder(text, 0xe9);
+    elf_patch_rel32(text, back_patch, loop_start);
+    elf_patch_rel32(text, exit_patch, text->len);
+    return true;
+  }
   if (instr->kind == IR_INSTR_FIELD_STORE) {
     if (instr->local_index >= fun->local_len) return elf_diag(diag, "direct ELF64 field store record is out of range", instr->line, instr->column, "invalid record local");
     const IrLocal *local = &fun->locals[instr->local_index];

--- a/native/zero-c/src/emit_elf_aarch64.c
+++ b/native/zero-c/src/emit_elf_aarch64.c
@@ -65,6 +65,9 @@ static bool a64_return_literal(const IrFunction *fun, uint32_t *out, ZDiag *diag
   *out = 0;
   for (size_t i = 0; i < fun->instr_len; i++) {
     const IrInstr *instr = &fun->instrs[i];
+    if (instr->kind == IR_INSTR_INDEX_FILL || instr->kind == IR_INSTR_FIELD_FILL) {
+      return a64_diag(diag, "direct AArch64 ELF object backend does not yet lower counted array/field fill loops", instr->line, instr->column, fun->name);
+    }
     if (instr->kind != IR_INSTR_RETURN || !instr->value || instr->value->kind != IR_VALUE_INT || instr->value->int_value > 65535) continue;
     *out = (uint32_t)instr->value->int_value;
     return true;

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -1419,6 +1419,33 @@ static bool macho_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *i
     else macho_emit_store_local_w(text, fun, 8, instr->local_index, 0, frame_size);
     return true;
   }
+  if (instr->kind == IR_INSTR_INDEX_FILL || instr->kind == IR_INSTR_FIELD_FILL) {
+    /* O(1) constant byte fill: a counted loop instead of one store per element,
+       so the emitted .text stays constant regardless of the array length. */
+    unsigned slot = 0;
+    if (instr->kind == IR_INSTR_INDEX_FILL) {
+      if (instr->array_index >= fun->local_len) return macho_diag_at(diag, "direct AArch64 Mach-O array fill is out of range", instr->line, instr->column, "invalid array local");
+      slot = macho_local_slot_offset(fun, instr->array_index, 0, frame_size);
+    } else {
+      if (instr->local_index >= fun->local_len) return macho_diag_at(diag, "direct AArch64 Mach-O record fill is out of range", instr->line, instr->column, "invalid record local");
+      slot = macho_local_slot_offset(fun, instr->local_index, instr->field_offset, frame_size);
+    }
+    uint32_t byte = instr->value ? (uint32_t)(instr->value->int_value & 0xffu) : 0u;
+    macho_emit_add_x_sp_imm(text, 9, slot);          // x9 = base
+    macho_emit_movz_w(text, 10, byte);               // w10 = value
+    macho_emit_movz_w(text, 11, 0);                  // w11 = counter
+    macho_emit_movz_w(text, 12, instr->fill_count);  // w12 = count
+    size_t loop_start = text->len;
+    macho_emit_cmp_w(text, 11, 12);
+    size_t exit_patch = macho_emit_b_cond_placeholder(text, 2); // b.hs (counter >= count)
+    macho_emit_add_x_reg(text, 13, 9, 11);           // x13 = base + counter (stride 1)
+    macho_emit_strb_w(text, 10, 13);                 // store byte
+    macho_emit_add_w_imm(text, 11, 11, 1);           // counter++
+    size_t back_patch = macho_emit_b_placeholder(text);
+    macho_patch_branch26(text, back_patch, loop_start);
+    macho_patch_cond19(text, exit_patch, text->len);
+    return true;
+  }
   if (instr->kind == IR_INSTR_FIELD_STORE) {
     if (instr->local_index >= fun->local_len) return macho_diag_at(diag, "direct AArch64 Mach-O field store record is out of range", instr->line, instr->column, "invalid record local");
     if (!fun->locals[instr->local_index].is_record) return macho_diag_at(diag, "direct AArch64 Mach-O field store requires record local", instr->line, instr->column, "non-record local");

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -8,6 +8,11 @@
 
 #define IR_READONLY_DATA_BASE 1024u
 #define IR_READONLY_DATA_LIMIT 65536u
+/* Repeat literals up to this many elements stay fully unrolled (matches the
+   previous behaviour and existing fixtures). Larger constant fills lower to a
+   single IR_INSTR_INDEX_FILL / IR_INSTR_FIELD_FILL counted loop so the lowered
+   IR and emitted .text stay O(1) instead of O(N). */
+#define IR_ARRAY_FILL_UNROLL_MAX 32u
 
 static Expr *clone_expr(const Expr *expr);
 static Stmt *clone_stmt(const Stmt *stmt);
@@ -2635,6 +2640,30 @@ static bool ir_lower_array_initializer(const Program *program, IrProgram *ir, Ir
       return false;
     }
     const Expr *value_expr = expr->args.items[0];
+    /* O(1) lowering: a repeat literal `[v; N]` with a constant element and a
+       large count expands to N immediate stores, so the lowered IR (and the
+       emitted .text) grow linearly with N. Detect the constant case and emit a
+       single IR_INSTR_INDEX_FILL that backends lower to a counted loop, keeping
+       both IR size and code size O(1). Small arrays keep the unrolled stores so
+       existing fixtures and codegen are unchanged. */
+    if (local->array_len > IR_ARRAY_FILL_UNROLL_MAX) {
+      IrValue *probe = NULL;
+      if (!ir_lower_expr(program, ir, mir_fun, value_expr, &probe)) return false;
+      if (probe->type != local->element_type) {
+        ir_free_value(probe);
+        ir_mark_unsupported(ir, "direct backend array repeat literal element type does not match local type", value_expr->line, value_expr->column, local->name);
+        return false;
+      }
+      if ((probe->kind == IR_VALUE_INT || probe->kind == IR_VALUE_BOOL) &&
+          ir_type_byte_size(local->element_type) == 1) {
+        ir_instr_vec_push(ir, out_items, out_len, out_cap, (IrInstr){
+          .kind = IR_INSTR_INDEX_FILL, .array_index = local->index, .value = probe,
+          .fill_count = local->array_len, .fill_stride = 1,
+          .line = value_expr->line, .column = value_expr->column});
+        return true;
+      }
+      ir_free_value(probe);
+    }
     for (size_t i = 0; i < local->array_len; i++) {
       IrValue *index = ir_new_index_literal(ir, (unsigned)i, value_expr->line, value_expr->column);
       IrValue *value = NULL;
@@ -2728,6 +2757,31 @@ static bool ir_lower_shape_initializer(const Program *program, IrProgram *ir, Ir
         ir_type_arg_vec_free(&shape_args);
         ir_mark_unsupported(ir, "direct backend record array field requires a matching array literal", field_expr->line, field_expr->column, field->name);
         return false;
+      }
+      /* Same O(1) treatment for large constant repeat literals initialising a
+         record's fixed-array field: one IR_INSTR_FIELD_FILL counted loop
+         instead of field_array_len immediate field stores. */
+      if (field_expr->array_repeat && field_array_len > IR_ARRAY_FILL_UNROLL_MAX) {
+        IrValue *probe = NULL;
+        if (!ir_lower_expr(program, ir, mir_fun, field_expr->args.items[0], &probe)) {
+          ir_type_arg_vec_free(&shape_args);
+          return false;
+        }
+        if (probe->type != field_element_type) {
+          ir_free_value(probe);
+          ir_type_arg_vec_free(&shape_args);
+          ir_mark_unsupported(ir, "direct backend record array field initializer type does not match element", field_expr->line, field_expr->column, field->name);
+          return false;
+        }
+        if ((probe->kind == IR_VALUE_INT || probe->kind == IR_VALUE_BOOL) &&
+            ir_type_byte_size(field_element_type) == 1) {
+          ir_instr_vec_push(ir, out_items, out_len, out_cap, (IrInstr){
+            .kind = IR_INSTR_FIELD_FILL, .local_index = local->index, .field_offset = field_offset,
+            .value = probe, .fill_count = field_array_len, .fill_stride = 1,
+            .line = field_expr->line, .column = field_expr->column});
+          continue;
+        }
+        ir_free_value(probe);
       }
       for (size_t element_index = 0; element_index < field_array_len; element_index++) {
         const Expr *element_expr = field_expr->array_repeat ? field_expr->args.items[0] : field_expr->args.items[element_index];


### PR DESCRIPTION
## Summary
- A constant repeat literal `[v; N]` (and a record's `[v; N]` array field) lowered to `N` immediate stores, so lowered IR and emitted `.text` grew linearly with `N` — a `[1048576]u8 = [0_u8; 1048576]` produced ~638 MB of lowered IR and a ~165 KB binary for just 4 KB of array.
- Detect a constant byte fill above a small (≤32) unroll threshold and emit a single `IR_INSTR_INDEX_FILL` / `IR_INSTR_FIELD_FILL`, which each backend lowers to a compact counted byte-fill loop. Result: O(1) IR and O(1) `.text` regardless of `N`; small arrays keep the existing unrolled codegen.

## Source
Addresses P0-2. Reproduction confirmed against `main` @ 44f02f1 (origin/main; static-analysis line numbers from 5b91e7f verified and updated): a 1 MiB zeroed buffer measured `loweredIrBytes: 637,537,832` before, `4,568` after; elf64 `.text` 833 B (16-byte unrolled) vs 193 B (1 MiB fill) — constant.

## Changes
- `native/zero-c/include/zero.h`: add `IR_INSTR_INDEX_FILL` / `IR_INSTR_FIELD_FILL` kinds and `fill_count` / `fill_stride` fields.
- `native/zero-c/src/ir.c`: in `ir_lower_array_initializer` / `ir_lower_shape_initializer`, emit one fill instruction for constant byte (`stride==1`) repeats with count > 32; unroll otherwise (unchanged).
- `native/zero-c/src/emit_macho64.c`, `emit_elf64.c`, `emit_coff.c`: lower the fill kinds to a counted byte-fill loop (elf-aarch64 is a literal-return stub with no store path; no change needed).
- `conformance/native/pass/array-zeroinit-bss.0` + `conformance/run.mjs`: new fixture; assert a 1 MiB buffer emits byte-identical `.text` and lowered IR to a 64 KiB one and links < 256 KiB. `array-repeat-literal.0` / `array-repeat-record-field.0` stay green.
- `docs-site/articles/optimization.md`: document the constant array fill optimization.

## Conformance
- Fixtures: `conformance/native/pass/array-zeroinit-bss.0` (new), `array-repeat-literal.0`, `array-repeat-record-field.0`.
- Gated: `pnpm run conformance` (ran `conformance:local` — **green**). `pnpm run native:test` (`native:test:local`) fails before reaching changed code: environment lacks a cross C compiler for `linux-musl-x64` (pre-existing, unrelated). INDEX_FILL and FIELD_FILL additionally runtime-verified on the host macho64 backend (zero and non-zero fills, array locals and record array fields).

## Proposed CHANGELOG line (for maintainer, not committed)
- Constant `[v; N]` array and record-field fills now lower to an O(1) counted loop instead of N stores, keeping code size and lowered IR independent of array length.