### PR TITLE
feat: capability system Layers 1-4 — effect signatures, fine-grained capabilities, affine types, effect handlers

### DIFF
--- a/benchmarks/zero/fs-resource.0
+++ b/benchmarks/zero/fs-resource.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut file: owned<File> = check std.fs.createOrRaise(fs, ".zero/bench/zero-fs-resource.txt")
     check std.fs.writeAllOrRaise(&mut file, std.mem.span("fs resource payload\n"))
     let size: usize = check std.fs.fileLenOrRaise(&mut file)

--- a/benchmarks/zero/networking.0
+++ b/benchmarks/zero/networking.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
+    let net = world.net()
     let addr = std.net.withTimeout(std.net.address("localhost", 8080_u16), std.time.ms(250))
     let conn = std.net.connect(net, addr)
     let method = std.http.parseMethod("GET")

--- a/benchmarks/zero/owned-file.0
+++ b/benchmarks/zero/owned-file.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let created = std.fs.create(fs, ".zero/bench/zero-owned-file.txt")
     if created.has {
         let mut file: owned<File> = created.value

--- a/benchmarks/zero/readall.0
+++ b/benchmarks/zero/readall.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let created = std.fs.create(fs, ".zero/bench/zero-readall-input.txt")
     if created.has {
         let mut file: owned<File> = created.value

--- a/conformance/check/fail/meta-unsupported.0
+++ b/conformance/check/fail/meta-unsupported.0
@@ -1,3 +1,3 @@
-const bad: usize = meta std.fs.host()
+const bad: usize = meta world.fs()
 
 pub fun main() -> Void {}

--- a/conformance/native/fail/fs-read-without-mutref.0
+++ b/conformance/native/fail/fs-read-without-mutref.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let opened = std.fs.open(fs, ".zero/conformance/std-fs-resource.txt")
     if opened.has {
         let file: owned<File> = opened.value

--- a/conformance/native/fail/fs-readall-invalid-alloc.0
+++ b/conformance/native/fail/fs-readall-invalid-alloc.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let body = std.fs.readAll(fs, fs, ".zero/missing.txt", 64)
     if body.has {
         check world.out.write("unexpected\n")

--- a/conformance/native/fail/std-fs-create-error-set-mismatch.0
+++ b/conformance/native/fail/std-fs-create-error-set-mismatch.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises { NotFound } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut file: owned<File> = check std.fs.createOrRaise(fs, ".zero/conformance/unreachable.txt")
     check std.fs.writeAllOrRaise(&mut file, std.mem.span("unreachable\n"))
     check world.out.write("unreachable\n")

--- a/conformance/native/fail/std-fs-error-set-mismatch.0
+++ b/conformance/native/fail/std-fs-error-set-mismatch.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises { NotFound } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut storage: [8]u8 = [0, 0, 0, 0, 0, 0, 0, 0]
     let mut alloc = std.mem.fixedBufAlloc(storage)
     let _body = check std.fs.readAllOrRaise(alloc, fs, ".zero/missing.txt", 8)

--- a/conformance/native/fail/std-fs-target-unsupported.0
+++ b/conformance/native/fail/std-fs-target-unsupported.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let _exists = std.fs.exists(".zero/conformance/no-target-fs.txt")
     check world.out.write("unreachable\n")
 }

--- a/conformance/native/fail/std-fs-unchecked-resource-fallible.0
+++ b/conformance/native/fail/std-fs-unchecked-resource-fallible.0
@@ -1,5 +1,5 @@
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let _file = std.fs.createOrRaise(fs, ".zero/conformance/unreachable.txt")
     check world.out.write("unreachable\n")
 }

--- a/conformance/native/fail/std-http-fetch-raw-timeout.0
+++ b/conformance/native/fail/std-http-fetch-raw-timeout.0
@@ -1,11 +1,10 @@
-export c fun main() -> i32 {
-    let net = std.net.host()
+pub fun main(world: World) -> Void raises {
+    let net = world.net()
     let client = std.http.client(net)
     let request = std.mem.span("GET http://example.invalid\n\n")
     let mut response: [64]u8 = [0_u8; 64]
     let result = std.http.fetch(client, request, response, 1000)
     if std.http.resultOk(result) {
-        return 1
+        return
     }
-    return 0
 }

--- a/conformance/native/pass/std-fs-fallible-resources.0
+++ b/conformance/native/pass/std-fs-fallible-resources.0
@@ -1,11 +1,10 @@
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
-    let mut created: owned<File> = check std.fs.createOrRaise(fs, ".zero/conformance/std-fs-fallible-resources.txt")
+    let mut created: owned<File> = check std.fs.createOrRaise(world.fs(), ".zero/conformance/std-fs-fallible-resources.txt")
     check std.fs.writeAllOrRaise(&mut created, std.mem.span("named resource ok\n"))
     let written_len: usize = check std.fs.fileLenOrRaise(&mut created)
     std.fs.close(&mut created)
 
-    let mut opened: owned<File> = check std.fs.openOrRaise(fs, ".zero/conformance/std-fs-fallible-resources.txt")
+    let mut opened: owned<File> = check std.fs.openOrRaise(world.fs(), ".zero/conformance/std-fs-fallible-resources.txt")
     let mut buf: [32]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let read_len: usize = check std.fs.readOrRaise(&mut opened, buf)
     if written_len == 18 && read_len == 18 && buf[0] == ('n' as u8) {

--- a/conformance/native/pass/std-fs-fallible.0
+++ b/conformance/native/pass/std-fs-fallible.0
@@ -1,6 +1,5 @@
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
-    let created = std.fs.create(fs, ".zero/fallible-readall-input.txt")
+    let created = std.fs.create(world.fs(), ".zero/fallible-readall-input.txt")
     if created.has {
         let mut file: owned<File> = created.value
         if std.fs.writeAll(&mut file, std.mem.span("fallible read all ok\n")) == false {
@@ -8,9 +7,9 @@ pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
         }
     }
 
-    let mut storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    let mut storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let mut alloc = std.mem.fixedBufAlloc(storage)
-    let mut body: owned<ByteBuf> = check std.fs.readAllOrRaise(alloc, fs, ".zero/fallible-readall-input.txt", 64)
+    let mut body: owned<ByteBuf> = check std.fs.readAllOrRaise(alloc, world.fs(), ".zero/fallible-readall-input.txt", 64)
     if std.mem.eqlBytes(std.mem.bufBytes(&body), std.mem.span("fallible read all ok\n")) {
         check world.out.write("fs named errors ok\n")
     }

--- a/conformance/native/pass/std-fs-polish.0
+++ b/conformance/native/pass/std-fs-polish.0
@@ -1,6 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
-    let created = std.fs.create(fs, ".zero/polish-a.txt")
+    let created = std.fs.create(world.fs(), ".zero/polish-a.txt")
     if created.has {
         let mut file: owned<File> = created.value
         if std.fs.writeAll(&mut file, std.mem.span("abc")) {

--- a/conformance/native/pass/std-fs-readall.0
+++ b/conformance/native/pass/std-fs-readall.0
@@ -1,6 +1,5 @@
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
-    let created = std.fs.create(fs, ".zero/readall-input.txt")
+    let created = std.fs.create(world.fs(), ".zero/readall-input.txt")
     if created.has {
         let mut file: owned<File> = created.value
         if std.fs.writeAll(&mut file, std.mem.span("read all ok\n")) == false {
@@ -8,9 +7,9 @@ pub fun main(world: World) -> Void raises {
         }
     }
 
-    let mut storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+    let mut storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let mut alloc = std.mem.fixedBufAlloc(storage)
-    let body = std.fs.readAll(alloc, fs, ".zero/readall-input.txt", 64)
+    let body = std.fs.readAll(alloc, world.fs(), ".zero/readall-input.txt", 64)
     if body.has {
         let mut buf: owned<ByteBuf> = body.value
         let bytes = std.mem.bufBytes(&buf)

--- a/conformance/native/pass/std-fs-resource.0
+++ b/conformance/native/pass/std-fs-resource.0
@@ -9,10 +9,9 @@ fun write_auto(fs: Fs) -> Bool {
 }
 
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
-    let wrote = write_auto(fs)
-    let missing = std.fs.open(fs, ".zero/conformance/std-fs-resource-missing.txt")
-    let opened = std.fs.open(fs, ".zero/conformance/std-fs-resource.txt")
+    let wrote = write_auto(world.fs())
+    let missing = std.fs.open(world.fs(), ".zero/conformance/std-fs-resource-missing.txt")
+    let opened = std.fs.open(world.fs(), ".zero/conformance/std-fs-resource.txt")
     if wrote && missing.has == false && opened.has {
         let mut file: owned<File> = opened.value
         let mut buf: [10]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/conformance/native/pass/std-http-fetch.0
+++ b/conformance/native/pass/std-http-fetch.0
@@ -1,18 +1,17 @@
-export c fun main() -> i32 {
-    let net = std.net.host()
+pub fun main(world: World) -> Void raises {
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [128]u8 = [0_u8; 128]
     let request = std.mem.span("GET ftp://example.invalid\n\n")
     let result = std.http.fetch(client, request, response, std.time.ms(250))
     if std.http.resultOk(result) {
-        return 99
+        return
     }
     if std.http.resultStatus(result) == 0 &&
         std.http.resultBodyLen(result) == 0 &&
         std.http.resultError(result) == std.http.errorUnsupportedProtocol() &&
         std.http.responseLen(response) == 0 &&
         std.http.responseHeadersLen(response) == 0 {
-        return 23
+        check world.out.write("http fetch ok\n")
     }
-    return 98
 }

--- a/conformance/native/pass/std-net-http-breadth.0
+++ b/conformance/native/pass/std-net-http-breadth.0
@@ -1,10 +1,9 @@
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
     let addr = std.net.withTimeout(std.net.address("localhost", 8080_u16), std.time.ms(250))
-    let conn = std.net.connect(net, addr)
-    let listener = std.net.listen(net, addr)
-    let _client = std.http.client(net)
-    let _server = std.http.server(net, addr)
+    let conn = std.net.connect(world.net(), addr)
+    let listener = std.net.listen(world.net(), addr)
+    let _client = std.http.client(world.net())
+    let _server = std.http.server(world.net(), addr)
     let getA = std.http.parseMethod("GET")
     let getB = std.http.parseMethod("GET")
 

--- a/docs-site/articles/design/capability-system.md
+++ b/docs-site/articles/design/capability-system.md
@@ -1,0 +1,374 @@
+# Capability System Design for Zero
+
+> Design proposal for making Zero's capability model first-class, addressing the critique in issue #72 while preserving Zero's agent-first design goals.
+
+## Problem Statement
+
+Zero's current capability system has a documentation-implementation gap. The docs say "capability-based effects" but the implementation is closer to dependency injection. This matters more for Zero than for most languages because **agents need static, machine-readable effect information to reason about code safety and composability**.
+
+### Current State (v0.1.2)
+
+1. `World` is a parameter, not a capability token. It's a plain record — storable, duplicable, aliasable.
+2. `raises` is a boolean with no effect information. `fun foo() -> Void raises` could do anything.
+3. Capabilities like `Fs`, `Net`, `Proc` are mintable from nothing (`world.fs()`), making them unforgeable in documentation only.
+4. Dual API shapes coexist: `std.fs.read(path, buf)` (ambient) and `std.fs.open(fs, path)` (capability-gated). The ambient form always wins.
+5. Effect tracking is done by scanning stdlib call names, not by type-level effect annotations.
+6. `graph --json` reports capabilities as a flat boolean struct, not as a structured effect system.
+
+### What Issue #72 Gets Right
+
+The critique is technically accurate on all five structural points:
+- Value-level, not type-level, effect tracking
+- Coarse-grained god capability (World bundles everything)
+- No substructural discipline (World is copyable/aliasable)
+- No sequencing or handler structure
+- Three orthogonal mechanisms (World parameter, raises, std target-gating) instead of a unified model
+
+### What Issue #72 Misses
+
+The critique evaluates Zero against mature PL research languages (Koka, Pony, E). But Zero has a different target: **agentic programming**. The capability system must serve two masters:
+1. **Human programmers** who want readable, writable code
+2. **AI agents** who need static, structured, machine-readable effect information
+
+These goals are not in tension. Good effect systems help both. But the design must be incremental — Zero is v0.1.2, not a research language with 10 years of backing.
+
+## Design Principles
+
+### P1: Agent-First Static Information
+
+Every effect a function can perform must be recoverable from its signature alone, without reading the body. Agents parse signatures; they don't do whole-program analysis.
+
+### P2: Incremental Adoption
+
+The design must work with Zero's existing syntax and type system. No "start over" proposals. Every change must be implementable as a diff against the current compiler.
+
+### P3: Honest Documentation
+
+The docs should describe what the system *actually does*, not what it aspires to do. If World is a documentation convention, say so. If it's a real capability, enforce it.
+
+### P4: Target-Aware
+
+Zero compiles to multiple targets (darwin-arm64, linux-musl-x64, wasm32-wasi, wasm32-web). The capability system must work across all targets, with target-gating as a first-class concept.
+
+## Proposed Design
+
+### Layer 1: Effect Signatures (v0.2)
+
+Replace the boolean `raises` with effect rows in function signatures.
+
+**Current syntax:**
+```zero
+pub fun main(world: World) -> Void raises {
+    check world.out.write("hello\n")
+}
+```
+
+**Proposed syntax:**
+```zero
+pub fun main(world: World) -> Void raises<io> {
+    check world.out.write("hello\n")
+}
+```
+
+The effect row `<io>` is a comma-separated list of effect names. This is not a breaking change — bare `raises` remains valid and is equivalent to `raises<>` (open effects, inferred by the compiler).
+
+**Effect names** are drawn from a fixed vocabulary:
+- `io` — console I/O (world.out, world.err)
+- `fs` — filesystem operations
+- `net` — network operations
+- `proc` — process spawning/management
+- `env` — environment variable access
+- `args` — command-line argument access
+- `time` — time/clock access
+- `rand` — random number generation
+- `ai` — AI model calls
+- `alloc` — heap allocation
+
+**Compiler changes:**
+- Parser: recognize `<effect1, effect2, ...>` after `raises`
+- Checker: track effect sets per function (replace `bool raises` with `EffectSet raises`)
+- Checker: propagate effect requirements through call chains
+- Checker: emit new diagnostic `EFF001` for effect mismatches
+- JSON: include `effects` array in function signatures in `graph --json`
+
+**Example propagation:**
+```zero
+fun readConfig(path: String, fs: Fs) -> String raises<fs> {
+    // fs operations are allowed because this function declares raises<fs>
+}
+
+fun main(world: World) -> Void raises<io, fs> {
+    // Can call readConfig because our effect set includes <fs>
+    let config = readConfig("config.txt", world.fs())
+    check world.out.write(config)
+}
+```
+
+**Backward compatibility:**
+```zero
+// Old style still works — effects are inferred
+fun legacy() -> Void raises {
+    // Compiler infers effects from stdlib calls
+}
+```
+
+### Layer 2: Fine-Grained Capabilities (v0.3)
+
+Split `World` into a hierarchy of capability types that can be passed independently.
+
+**Current:**
+```zero
+pub fun main(world: World) -> Void raises {
+    // world gives access to everything
+}
+```
+
+**Proposed:**
+```zero
+pub fun main(world: World) -> Void raises<io> {
+    // World is the root capability, but functions can request sub-capabilities
+}
+
+fun processFile(fs: Fs) -> Void raises<fs> {
+    // Only has filesystem access, not network or process
+}
+
+fun main(world: World) -> Void raises<io, fs> {
+    // Derive Fs from World
+    processFile(world.fs())
+}
+```
+
+**Capability type hierarchy:**
+```
+World (root)
+  ├── Out (world.out) — console output
+  ├── Err (world.err) — console error
+  ├── Fs (world.fs()) — filesystem
+  ├── Net (world.net()) — network
+  ├── Env (world.env()) — environment
+  ├── Args (world.args()) — CLI args
+  ├── Clock (world.clock()) — time
+  ├── Rand (world.rand()) — random
+  └── Proc (world.proc()) — processes
+```
+
+**Key change:** `world.fs()` is removed. The only way to get `Fs` is from `world.fs()`. This makes capabilities unforgeable.
+
+**Compiler changes:**
+- Type checker: track capability parameters separately from regular parameters
+- Type checker: verify that capability-derived functions receive capabilities from their caller
+- Type checker: prevent capability types from being stored in globals or heap-allocated structures
+- Parser: recognize `world.fs()`, `world.net()` etc. as capability derivation
+
+### Layer 3: Substructural Discipline (v0.4)
+
+Make capability types linear/affine — they cannot be duplicated or stored ambiently.
+
+**Current (World is copyable):**
+```zero
+let w1 = world
+let w2 = world  // Both are valid — World is just a reference
+storeInGlobal(world)  // No error
+```
+
+**Proposed (World is affine):**
+```zero
+let w1 = world
+let w2 = world  // Error: world has been moved
+storeInGlobal(world)  // Error: cannot store capability in global
+```
+
+**Compiler changes:**
+- Type checker: track capability ownership through move semantics
+- Type checker: prevent capability types from being used in `shape` fields
+- Type checker: prevent capability types from being returned from functions
+- New diagnostic `CAP001`: "capability type cannot be duplicated"
+- New diagnostic `CAP002`: "capability type cannot be stored in global/heap"
+
+**Practical impact:** This is the most invasive change. It requires Zero's borrow checker to understand linearity for capability types specifically. This is why it's Layer 3, not Layer 1.
+
+### Layer 4: Effect Handlers (v0.5+)
+
+Add algebraic effect handlers, allowing users to define custom effects and handle them.
+
+**Proposed syntax:**
+```zero
+effect Http {
+    fun fetch(url: String) -> Response
+}
+
+fun handler(url: String) -> Response raises<Http> {
+    // Uses the Http effect
+}
+
+fun main(world: World) -> Void raises<io> {
+    // Handle the Http effect with a concrete implementation
+    with Http handledBy {
+        fun fetch(url: String) -> Response {
+            // Concrete implementation using world.net()
+        }
+    } {
+        let response = handler("https://example.com")
+        check world.out.write(response.body)
+    }
+}
+```
+
+This is a longer-term goal. Layers 1-3 are sufficient for v0.2-v0.4.
+
+## Agent-Specific Benefits
+
+### Static Effect Reasoning
+
+An agent reading a function signature can now determine exactly what effects it has:
+
+```zero
+// Agent knows: this function only reads files, no network, no process spawning
+fun parseConfig(fs: Fs, path: String) -> Config raises<fs>
+
+// Agent knows: this function makes AI calls with budget tracking
+fun generateCode(ai: Ai, spec: String) -> String raises<ai>
+
+// Agent knows: this function is pure, no effects
+fun validate(input: String) -> Bool
+```
+
+### Capability-Based Sandboxing
+
+Agents generating code for sandboxed environments can verify capability requirements statically:
+
+```zero
+// Agent knows: this function requires fs, which is not available on wasm32-wasi
+// The compiler will reject this at compile time, not runtime
+fun loadPlugin(fs: Fs, path: String) -> Plugin raises<fs>
+```
+
+### Effect-Preserving Composition
+
+Agents can compose functions while tracking effect accumulation:
+
+```zero
+fun step1() -> Data raises<fs>
+fun step2(data: Data) -> Result raises<net>
+fun step3(result: Result) -> Output raises<io>
+
+// Agent knows: the composition requires <fs, net, io>
+fun pipeline() -> Output raises<fs, net, io> {
+    let data = step1()
+    let result = step2(data)
+    step3(result)
+}
+```
+
+### Machine-Readable Contracts
+
+The `graph --json` output becomes a machine-readable contract:
+
+```json
+{
+  "name": "parseConfig",
+  "effects": ["fs"],
+  "requiresCapabilities": ["Fs"],
+  "effectSafety": "sandboxed",
+  "approvalBoundary": false
+}
+```
+
+## Implementation Phasing
+
+### Phase 1: Effect Signatures (2-3 weeks)
+
+**Scope:** Parser + checker changes for `raises<io, fs>` syntax.
+
+**Files changed:**
+- `native/zero-c/src/parser.c` — parse effect rows
+- `native/zero-c/src/checker.c` — track effect sets, propagate through calls
+- `native/zero-c/src/main.c` — output effects in graph JSON
+- `docs-site/articles/language-reference.md` — document effect syntax
+- `docs-site/articles/diagnostics.md` — document new EFF diagnostics
+
+**Tests:**
+- Effect parsing: `raises<>`, `raises<io>`, `raises<io, fs, net>`
+- Effect propagation: callee effects must be subset of caller effects
+- Effect mismatch: calling `raises<fs>` function from `raises<io>` context
+- Backward compatibility: bare `raises` still works
+- JSON output: effects array in graph JSON
+
+### Phase 2: Fine-Grained Capabilities (3-4 weeks)
+
+**Scope:** Split World into capability hierarchy, remove ambient authority.
+
+**Files changed:**
+- `native/zero-c/src/checker.c` — capability tracking, prevent ambient minting
+- `native/zero-c/src/main.c` — update stdlib helper table
+- `docs-site/articles/modules/fs.md` — remove `world.fs()` documentation
+- `docs-site/articles/primitives.md` — update capability hierarchy
+- All examples — update to use `world.fs()` instead of `world.fs()`
+
+**Tests:**
+- `world.fs()` returns `Fs` capability
+- `world.fs()` is rejected (or removed)
+- Capability cannot be stored in global
+- Capability cannot be duplicated
+- Target-gating still works (Fs rejected on wasm32-wasi)
+
+### Phase 3: Substructural Discipline (4-6 weeks)
+
+**Scope:** Linear types for capability tokens.
+
+**Files changed:**
+- `native/zero-c/src/checker.c` — linearity tracking for capability types
+- `native/zero-c/src/ir.c` — IR changes for linear capability values
+- `docs-site/articles/language-reference.md` — document capability linearity
+
+**Tests:**
+- Capability cannot be copied
+- Capability cannot be stored in shape field
+- Capability cannot be returned from function
+- Capability can be moved (passed to callee)
+- Borrowing (`&world`) creates a reference, not a copy
+
+### Phase 4: Effect Handlers (Future)
+
+**Scope:** User-defined effects and handlers.
+
+This is a significant language feature that requires careful design. Defer until Layers 1-3 are stable.
+
+## Relationship to Existing Work
+
+- **Issue #72**: This design directly addresses all five structural concerns
+- **Issue #4** (AI primitives): `std.ai` uses the effect system — `raises<ai>` makes AI effects explicit
+- **PR #65** (AI primitives prototype): The `Ai` capability type fits into Layer 2's hierarchy
+- **PR #49** (effectsSummary in graph JSON): Layer 1 extends this with per-function effect rows
+- **Issue #20** (structured concurrency): Effect handlers (Layer 4) would enable structured concurrency as a library feature
+
+## Open Questions
+
+1. **Effect row syntax**: `raises<io, fs>` vs `raises { io, fs }` vs `raises io | fs`?
+   - Recommendation: Angle brackets match generic syntax (`FixedVec<T, N>`), making it familiar.
+
+2. **Effect inference**: Should bare `raises` infer the maximal effect set, or require explicit annotation?
+   - Recommendation: Infer for private functions, require explicit for public API functions.
+
+3. **Capability derivation**: Should `world.fs()` return a new `Fs` each time, or the same `Fs`?
+   - Recommendation: Same `Fs` (World owns it, lends it out). This is simpler and sufficient for v0.
+
+4. **Backward compatibility**: How long to support the old `world.fs()` pattern?
+   - Recommendation: Deprecate in v0.2, remove in v0.4. Add a migration diagnostic.
+
+5. **Effect granularity**: Is `io` too coarse? Should it be split into `stdout` and `stderr`?
+   - Recommendation: Start coarse (`io`), split later if needed. Coarse is better for agents — fewer concepts to track.
+
+## Appendix: Comparison with Other Languages
+
+| Feature | Zero (current) | Zero (proposed) | Koka | Pony | E |
+|---------|---------------|-----------------|------|------|---|
+| Effect in signature | Boolean `raises` | Effect rows `raises<io, fs>` | Effect rows `<io, console>` | Capability in type `ref` | Guard in type |
+| Effect propagation | Manual `check` | Automatic through call chain | Automatic | Automatic | Automatic |
+| Capability minting | `world.fs()` (ambient) | `world.fs()` (derived) | N/A (effect-based) | `iso`, `trn`, `ref` | N/A |
+| Substructural discipline | None | Affine (Layer 3) | None | Full (iso/trn/ref/val/box) | None |
+| Effect handlers | None | Planned (Layer 4) | Built-in | N/A | N/A |
+| Agent-readable effects | Partial (graph JSON) | Full (signature + JSON) | Partial | Partial | None |
+
+Zero's proposed design is "Koka-lite with Pony-inspired capabilities" — simpler than either, but sufficient for agentic programming.

--- a/docs/articles/modules/fs.md
+++ b/docs/articles/modules/fs.md
@@ -6,7 +6,7 @@ Runnable today:
 | --- | --- | --- |
 | `std.fs.read(path, buf)` | `usize` | Reads bytes from a hosted path into a caller-provided `MutSpan<u8>` buffer. |
 | `std.fs.write(path, bytes)` | `usize` | Writes bytes to a hosted path and returns the byte count. |
-| `std.fs.host()` | `Fs` | Creates the hosted filesystem capability. |
+| `world.fs()` | `Fs` | Creates the hosted filesystem capability. |
 | `std.fs.open(fs, path)` | `Maybe<owned<File>>` | Opens a file and returns `null` when unavailable. |
 | `std.fs.openOrRaise(fs, path)` | `owned<File>` | Opens a file or raises `{ NotFound, TooLarge, Io }`. |
 | `std.fs.create(fs, path)` | `Maybe<owned<File>>` | Creates a file and returns `null` when unavailable. |
@@ -41,7 +41,7 @@ Current limits:
 
 ```zero
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut file: owned<File> = check std.fs.createOrRaise(fs, ".zero/out/example.txt")
     check std.fs.writeAllOrRaise(&mut file, std.mem.span("hello\n"))
     let len = check std.fs.fileLenOrRaise(&mut file)

--- a/docs/articles/modules/http.md
+++ b/docs/articles/modules/http.md
@@ -59,7 +59,7 @@ Metadata helpers:
 
 ```zero
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
+    let net = world.net()
     let addr = std.net.address("localhost", 8080_u16)
     let _client = std.http.client(net)
     let _server = std.http.server(net, addr)
@@ -75,7 +75,7 @@ GET request:
 
 ```zero
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [0_u8; 512]
     let request = std.mem.span("GET https://example.com\n\n")
@@ -92,7 +92,7 @@ Request with headers and body:
 
 ```zero
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let request = std.mem.span("POST https://example.com/api\ncontent-type: application/json\n\n{\"ping\":1}")
     let mut response: [512]u8 = [0_u8; 512]
@@ -114,7 +114,7 @@ pub fun main(world: World) -> Void raises {
         check world.err.write("usage: pass HTTP request envelope\n")
         return
     }
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [0_u8; 512]
     let result = std.http.fetch(client, std.mem.span(maybe_request.value), response, std.time.ms(5000))

--- a/docs/articles/modules/net.md
+++ b/docs/articles/modules/net.md
@@ -4,7 +4,7 @@ Runnable today:
 
 | API | Return | Notes |
 | --- | --- | --- |
-| `std.net.host()` | `Net` | Creates the hosted network capability. |
+| `world.net()` | `Net` | Creates the hosted network capability. |
 | `std.net.address(host, port)` | `Address` | Builds an address value without allocation. |
 | `std.net.dnsName(address)` | `String` | Reads the address host name. |
 | `std.net.withTimeout(address, duration)` | `Address` | Returns address metadata with a timeout. |
@@ -24,7 +24,7 @@ Metadata labels:
 
 ```zero
 pub fun main(world: World) -> Void raises {
-    let net = std.net.host()
+    let net = world.net()
     let addr = std.net.withTimeout(std.net.address("localhost", 8080_u16), std.time.ms(250))
     let conn = std.net.connect(net, addr)
     if conn.has && std.mem.eql(std.net.dnsName(addr), "localhost") {

--- a/examples/batch3-cli/src/main.0
+++ b/examples/batch3-cli/src/main.0
@@ -2,7 +2,7 @@ use names
 use validate
 
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut path_storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let path = check std.path.join(path_storage, ".zero", inputName())
 

--- a/examples/file-copy.0
+++ b/examples/file-copy.0
@@ -9,7 +9,7 @@ fun seed_input(fs: Fs) -> Bool {
 }
 
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     if seed_input(fs) {
         let input = std.fs.open(fs, ".zero/file-copy-input.txt")
         let output = std.fs.create(fs, ".zero/file-copy-output.txt")

--- a/examples/readall-cli/src/main.0
+++ b/examples/readall-cli/src/main.0
@@ -2,7 +2,7 @@ use reader
 use validate
 
 pub fun main(world: World) -> Void raises {
-    let fs = std.fs.host()
+    let fs = world.fs()
     check seed(fs)
     let mut storage: [126]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let mut arena = std.mem.arena(storage)

--- a/examples/resource-cli/src/main.0
+++ b/examples/resource-cli/src/main.0
@@ -2,7 +2,7 @@ use config
 use payload
 
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     let mut path_storage: [96]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
     let path = check std.path.join(path_storage, outputDir(), outputName())
 

--- a/examples/std-http-headers.0
+++ b/examples/std-http-headers.0
@@ -6,7 +6,7 @@ pub fun main(world: World) -> Void raises {
     }
     let maybe_name = std.args.get(2)
 
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [0_u8; 512]
     let result = std.http.fetch(client, std.mem.span(maybe_request.value), response, std.time.ms(5000))

--- a/examples/std-http-json.0
+++ b/examples/std-http-json.0
@@ -5,7 +5,7 @@ pub fun main(world: World) -> Void raises {
         return
     }
 
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [0_u8; 512]
     let result = std.http.fetch(client, std.mem.span(maybe_request.value), response, std.time.ms(5000))

--- a/examples/std-http-request.0
+++ b/examples/std-http-request.0
@@ -5,7 +5,7 @@ pub fun main(world: World) -> Void raises {
         return
     }
 
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [0_u8; 512]
     let result = std.http.fetch(client, std.mem.span(maybe_request.value), response, std.time.ms(5000))

--- a/examples/zero-hash/src/main.0
+++ b/examples/zero-hash/src/main.0
@@ -1,7 +1,7 @@
 use input
 
 pub fun main(world: World) -> Void raises { NotFound, TooLarge, Io } {
-    let fs = std.fs.host()
+    let fs = world.fs()
     check seed(fs)
 
     let mut storage: [64]u8 = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -159,7 +159,8 @@ typedef enum {
   STMT_BREAK,
   STMT_CONTINUE,
   STMT_MATCH,
-  STMT_RAISE
+  STMT_RAISE,
+  STMT_WITH
 } StmtKind;
 
 typedef struct Stmt Stmt;
@@ -179,6 +180,17 @@ typedef struct {
   size_t len;
   size_t cap;
 } ParamVec;
+
+typedef struct {
+  char **items;
+  size_t len;
+  size_t cap;
+} EffectVec;
+
+void effect_vec_push(EffectVec *vec, const char *name);
+void effect_vec_free(EffectVec *vec);
+void effect_vec_merge(EffectVec *dst, const EffectVec *src);
+bool effect_vec_contains(const EffectVec *vec, const char *name);
 
 typedef struct {
   Stmt **items;
@@ -214,6 +226,7 @@ struct Stmt {
   StmtVec then_body;
   StmtVec else_body;
   MatchArmVec match_arms;
+  void *handler_ops;
   int line;
   int column;
 };
@@ -228,6 +241,7 @@ typedef struct {
   bool raises;
   bool has_error_set;
   ParamVec errors;
+  EffectVec effects;
   bool is_test;
   bool export_c;
   StmtVec body;
@@ -251,6 +265,32 @@ typedef struct {
   int line;
   int column;
 } Shape;
+
+typedef struct {
+  char *name;
+  FunctionVec operations;
+  bool is_public;
+  int line;
+  int column;
+} EffectDecl;
+
+typedef struct {
+  char *name;
+  int line;
+  int column;
+} CapabilityDecl;
+
+typedef struct {
+  CapabilityDecl *items;
+  size_t len;
+  size_t cap;
+} CapabilityDeclVec;
+
+typedef struct {
+  EffectDecl *items;
+  size_t len;
+  size_t cap;
+} EffectDeclVec;
 
 typedef struct {
   Shape *items;
@@ -366,6 +406,8 @@ typedef struct {
   EnumVec enums;
   ChoiceVec choices;
   FunctionVec functions;
+  EffectDeclVec effects;
+  CapabilityDeclVec capabilities;
 } Program;
 
 typedef enum {
@@ -429,7 +471,6 @@ typedef enum {
   IR_VALUE_TIME_AS_MS,
   IR_VALUE_RAND_NEXT_U32,
   IR_VALUE_RAND_ENTROPY_U32,
-  IR_VALUE_FS_HOST,
   IR_VALUE_FS_OPEN,
   IR_VALUE_FS_CREATE,
   IR_VALUE_FS_READ_PATH,

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -568,6 +568,27 @@ static bool scope_set_moved(Scope *scope, const char *name, bool moved) {
   return false;
 }
 
+static void scope_remove(Scope *scope, const char *name) {
+  for (Scope *cursor = scope; cursor; cursor = cursor->parent) {
+    for (size_t i = 0; i < cursor->len; i++) {
+      if (strcmp(cursor->names[i], name) == 0) {
+        free(cursor->names[i]);
+        free(cursor->types[i]);
+        for (size_t j = i; j + 1 < cursor->len; j++) {
+          cursor->names[j] = cursor->names[j + 1];
+          cursor->types[j] = cursor->types[j + 1];
+          cursor->mutable[j] = cursor->mutable[j + 1];
+          cursor->moved[j] = cursor->moved[j + 1];
+          cursor->is_param[j] = cursor->is_param[j + 1];
+          cursor->value_provenance[j] = cursor->value_provenance[j + 1];
+        }
+        cursor->len--;
+        return;
+      }
+    }
+  }
+}
+
 static bool scope_is_param(Scope *scope, const char *name) {
   for (Scope *cursor = scope; cursor; cursor = cursor->parent) {
     for (size_t i = 0; i < cursor->len; i++) {
@@ -1028,7 +1049,6 @@ static const char *std_call_return_type(const Expr *callee) {
   else if (strcmp(name.data, "std.crypto.constantTimeEql") == 0) result = "Bool";
   else if (strcmp(name.data, "std.crypto.secureRandomU32") == 0) result = "u32";
   else if (strcmp(name.data, "std.net.address") == 0) result = "Address";
-  else if (strcmp(name.data, "std.net.host") == 0) result = "Net";
   else if (strcmp(name.data, "std.net.dnsName") == 0) result = "String";
   else if (strcmp(name.data, "std.net.connect") == 0) result = "Maybe<Conn>";
   else if (strcmp(name.data, "std.net.listen") == 0) result = "Maybe<Listener>";
@@ -1053,7 +1073,6 @@ static const char *std_call_return_type(const Expr *callee) {
   else if (strcmp(name.data, "std.args.len") == 0) result = "usize";
   else if (strcmp(name.data, "std.args.get") == 0) result = "Maybe<String>";
   else if (strcmp(name.data, "std.env.get") == 0) result = "Maybe<String>";
-  else if (strcmp(name.data, "std.fs.host") == 0) result = "Fs";
   else if (strcmp(name.data, "std.fs.open") == 0) result = "Maybe<owned<File>>";
   else if (strcmp(name.data, "std.fs.openOrRaise") == 0) result = "owned<File>";
   else if (strcmp(name.data, "std.fs.create") == 0) result = "Maybe<owned<File>>";
@@ -1171,7 +1190,6 @@ static int std_call_arg_count(const char *name) {
   if (strcmp(name, "std.crypto.constantTimeEql") == 0) return 2;
   if (strcmp(name, "std.crypto.secureRandomU32") == 0) return 0;
   if (strcmp(name, "std.net.address") == 0) return 2;
-  if (strcmp(name, "std.net.host") == 0) return 0;
   if (strcmp(name, "std.net.dnsName") == 0) return 1;
   if (strcmp(name, "std.net.connect") == 0) return 2;
   if (strcmp(name, "std.net.listen") == 0) return 2;
@@ -1196,7 +1214,6 @@ static int std_call_arg_count(const char *name) {
   if (strcmp(name, "std.args.len") == 0) return 0;
   if (strcmp(name, "std.args.get") == 0) return 1;
   if (strcmp(name, "std.env.get") == 0) return 1;
-  if (strcmp(name, "std.fs.host") == 0) return 0;
   if (strcmp(name, "std.fs.open") == 0) return 2;
   if (strcmp(name, "std.fs.openOrRaise") == 0) return 2;
   if (strcmp(name, "std.fs.create") == 0) return 2;
@@ -1451,6 +1468,14 @@ static bool is_allocator_type(const char *type) {
   return type && (strcmp(type, "NullAlloc") == 0 || strcmp(type, "FixedBufAlloc") == 0 || strcmp(type, "PageAlloc") == 0 || strcmp(type, "GeneralAlloc") == 0);
 }
 
+static bool type_is_capability(const Program *program, const char *type) {
+  if (!type || !program) return false;
+  for (size_t i = 0; i < program->capabilities.len; i++) {
+    if (strcmp(program->capabilities.items[i].name, type) == 0) return true;
+  }
+  return false;
+}
+
 static bool owned_inner_text(const char *type, char *out, size_t out_len) {
   if (!type || !out || out_len == 0) return false;
   const char *inner = NULL;
@@ -1627,7 +1652,7 @@ static bool check_borrow_conflict_at(Scope *scope, const char *root, const char 
   return true;
 }
 
-static bool check_place_root_available(const Expr *expr, Scope *scope, const char *root, ZDiag *diag) {
+static bool check_place_root_available(const Program *program, const Expr *expr, Scope *scope, const char *root, ZDiag *diag) {
   if (!expr || !scope || !root || !root[0]) return true;
   const char *actual = scope_type(scope, root);
   if (actual && strcmp(actual, "Type") == 0) {
@@ -1639,6 +1664,11 @@ static bool check_place_root_available(const Expr *expr, Scope *scope, const cha
     char actual_detail[160];
     snprintf(actual_detail, sizeof(actual_detail), "%s was moved", root);
     return set_diag_detail(diag, 3013, "owned value was already moved", expr->line, expr->column, "live owned binding", actual_detail, "stop using the old binding after transferring ownership");
+  }
+  if (actual && type_is_capability(program, actual) && scope_is_moved(scope, root)) {
+    char actual_detail[160];
+    snprintf(actual_detail, sizeof(actual_detail), "%s was moved", root);
+    return set_diag_detail(diag, 6003, "capability was already moved", expr->line, expr->column, "live capability binding", actual_detail, "capabilities are affine — pass them to a function or derive a new one from World");
   }
   return true;
 }
@@ -1795,7 +1825,7 @@ static const Function *find_constrained_interface_method_in_function(const Progr
 static const Function *find_constrained_interface_method(const Program *program, const Expr *callee, const InterfaceDecl **out_interface);
 static void strip_ref_like_type(const char *type, char *out, size_t out_len);
 static bool interface_constraint_parts(const Program *program, const char *constraint, const InterfaceDecl **out_interface, char ***out_args, size_t *out_arg_len);
-static void mark_owned_move_if_needed(const Expr *expr, Scope *scope, const char *destination_type);
+static void mark_owned_move_if_needed(const Program *program, const Expr *expr, Scope *scope, const char *destination_type);
 static void mark_owned_target_live_if_needed(const Expr *target, Scope *scope, const char *target_type);
 static int allow_fallible_call;
 static const Function *checking_function;
@@ -1811,6 +1841,14 @@ static bool function_exists(const Program *program, const char *name) {
 static const Function *find_function(const Program *program, const char *name) {
   for (size_t i = 0; i < program->functions.len; i++) {
     if (strcmp(program->functions.items[i].name, name) == 0) return &program->functions.items[i];
+  }
+  return NULL;
+}
+
+static const EffectDecl *find_effect(const Program *program, const char *name) {
+  if (!name) return NULL;
+  for (size_t i = 0; i < program->effects.len; i++) {
+    if (strcmp(program->effects.items[i].name, name) == 0) return &program->effects.items[i];
   }
   return NULL;
 }
@@ -3784,6 +3822,15 @@ static const char *expr_type(const Program *program, const Expr *expr, Scope *sc
       }
       if (expr->left && expr->left->kind == EXPR_MEMBER) {
         if (is_world_stream_write_callee(expr->left, scope)) return "Void";
+        const char *member_type = expr_type(program, expr->left, scope);
+        if (member_type && strcmp(member_type, "Fs") == 0) return "Fs";
+        if (member_type && strcmp(member_type, "Net") == 0) return "Net";
+        if (member_type && strcmp(member_type, "Env") == 0) return "Env";
+        if (member_type && strcmp(member_type, "Args") == 0) return "Args";
+        if (member_type && strcmp(member_type, "Clock") == 0) return "Clock";
+        if (member_type && strcmp(member_type, "Rand") == 0) return "Rand";
+        if (member_type && strcmp(member_type, "Proc") == 0) return "Proc";
+        if (member_type && strcmp(member_type, "Ai") == 0) return "Ai";
         const Shape *shape = NULL;
         const Function *method = find_namespace_shape_method(program, expr->left, &shape);
         if (method) {
@@ -3894,6 +3941,14 @@ static const char *expr_type(const Program *program, const Expr *expr, Scope *sc
         if (owned_inner_text(left_type, owned_shape_type, sizeof(owned_shape_type))) left_type = owned_shape_type;
         if (ref_inner_text(left_type, ref_shape_type, sizeof(ref_shape_type))) left_type = ref_shape_type;
         if (strcmp(left_type, "World") == 0 && (strcmp(expr->text, "out") == 0 || strcmp(expr->text, "err") == 0)) return "WorldStream";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "fs") == 0) return "Fs";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "net") == 0) return "Net";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "env") == 0) return "Env";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "args") == 0) return "Args";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "clock") == 0) return "Clock";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "rand") == 0) return "Rand";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "proc") == 0) return "Proc";
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "ai") == 0) return "Ai";
         const Shape *shape = find_shape_for_type(program, left_type);
         if (shape) {
           const Param *field = find_shape_field(shape, expr->text);
@@ -4172,7 +4227,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
       if (is_builtin_value(expr->text) && !scope_has(scope, expr->text)) {
         char message[256];
         snprintf(message, sizeof(message), "builtin namespace '%s' cannot be used as a runtime value", expr->text);
-        return set_diag_detail(diag, 3005, message, expr->line, expr->column, "runtime value", "builtin namespace", "use a supported member call such as std.fs.host()");
+        return set_diag_detail(diag, 3005, message, expr->line, expr->column, "runtime value", "builtin namespace", "use a supported member call such as world.fs()");
       }
       {
         const char *actual = scope_type(scope, expr->text);
@@ -4185,6 +4240,11 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
           char actual_detail[160];
           snprintf(actual_detail, sizeof(actual_detail), "%s was moved", expr->text);
           return set_diag_detail(diag, 3013, "owned value was already moved", expr->line, expr->column, "live owned binding", actual_detail, "stop using the old binding after transferring ownership");
+        }
+        if (actual && type_is_capability(program, actual) && scope_is_moved(scope, expr->text)) {
+          char actual_detail[160];
+          snprintf(actual_detail, sizeof(actual_detail), "%s was moved", expr->text);
+          return set_diag_detail(diag, 6003, "capability was already moved", expr->line, expr->column, "live capability binding", actual_detail, "capabilities are affine — pass them to a function or derive a new one from World");
         }
         if (!check_read_not_mutably_borrowed(expr, scope, diag)) return false;
       }
@@ -4223,7 +4283,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
       char path[256];
       bool local_place = expr_binding_path(expr, root, sizeof(root), path, sizeof(path)) && scope_has(scope, root);
       if (local_place) {
-        if (!check_place_root_available(expr, scope, root, diag)) return false;
+        if (!check_place_root_available(program, expr, scope, root, diag)) return false;
         if (!check_place_index_exprs(program, expr, scope, diag)) return false;
       } else if (!check_expr(program, expr->left, scope, diag)) return false;
       {
@@ -4235,6 +4295,14 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
         if (strcmp(left_type, "World") == 0 && (strcmp(expr->text, "out") == 0 || strcmp(expr->text, "err") == 0)) {
           return set_diag_detail(diag, 3005, "World stream member cannot be used as a runtime value", expr->line, expr->column, "world.out.write(...) or world.err.write(...)", expr->text, "call write directly on the stream capability");
         }
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "fs") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "net") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "env") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "args") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "clock") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "rand") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "proc") == 0) return true;
+        if (strcmp(left_type, "World") == 0 && strcmp(expr->text, "ai") == 0) return true;
         const Shape *shape = find_shape_for_type(program, left_type);
         if (shape) {
           if (!find_shape_field(shape, expr->text)) {
@@ -4265,7 +4333,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
       char path[256];
       bool local_place = expr_binding_path(expr, root, sizeof(root), path, sizeof(path)) && scope_has(scope, root);
       if (local_place) {
-        if (!check_place_root_available(expr, scope, root, diag)) return false;
+        if (!check_place_root_available(program, expr, scope, root, diag)) return false;
         if (!check_place_index_exprs(program, expr, scope, diag)) return false;
       } else if (!check_expr(program, expr->left, scope, diag)) return false;
       const char *base_type = expr_type(program, expr->left, scope);
@@ -4435,7 +4503,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
           if (expr->args.len != expected_count) return set_diag_detail(diag, 3108, "choice payload arity mismatch", expr->line, expr->column, expected_count ? "one payload argument" : "no payload arguments", "wrong payload argument count", "add or remove the payload argument");
           for (size_t i = 0; i < expr->args.len; i++) {
             if (!check_expr_expected(program, expr->args.items[i], scope, diag, item_case->type)) return false;
-            mark_owned_move_if_needed(expr->args.items[i], scope, item_case->type);
+            mark_owned_move_if_needed(program, expr->args.items[i], scope, item_case->type);
           }
           if (item_case->type && expr->args.len == 1) {
             const char *actual = expr_type(program, expr->args.items[0], scope);
@@ -4476,7 +4544,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
               free(method_bindings);
               return ok;
             }
-            mark_owned_move_if_needed(expr->args.items[i], scope, expected_type);
+            mark_owned_move_if_needed(program, expr->args.items[i], scope, expected_type);
             free(expected_type);
           }
           if (function_has_error_flow(program, method)) {
@@ -4604,7 +4672,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
                 free(receiver_bindings);
                 return ok;
               }
-              mark_owned_move_if_needed(expr->args.items[i], scope, expected_type);
+              mark_owned_move_if_needed(program, expr->args.items[i], scope, expected_type);
               free(expected_type);
             }
             if (function_has_error_flow(program, receiver_method)) {
@@ -4669,7 +4737,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
               free_type_arg_list(constraint_args, constraint_arg_len);
               return ok;
             }
-            mark_owned_move_if_needed(expr->args.items[i], scope, expected_type);
+            mark_owned_move_if_needed(program, expr->args.items[i], scope, expected_type);
             free(expected_type);
           }
           if (function_has_error_flow(program, required)) {
@@ -4743,7 +4811,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
               free(bindings);
               return ok;
             }
-            mark_owned_move_if_needed(expr->args.items[i], scope, expected_type);
+            mark_owned_move_if_needed(program, expr->args.items[i], scope, expected_type);
             free(expected_type);
           }
           if (function_has_error_flow(program, fun)) {
@@ -4778,7 +4846,7 @@ static bool check_expr_expected(const Program *program, const Expr *expr, Scope 
             snprintf(message, sizeof(message), "argument %zu to '%s' has incompatible type", i + 1, fun->name);
             return set_diag_detail(diag, 3005, message, expr->args.items[i]->line, expr->args.items[i]->column, fun->params.items[i].type, expr_type(program, expr->args.items[i], scope), "pass a compatible value");
           }
-          if (fun && i < fun->params.len) mark_owned_move_if_needed(expr->args.items[i], scope, fun->params.items[i].type);
+          if (fun && i < fun->params.len) mark_owned_move_if_needed(program, expr->args.items[i], scope, fun->params.items[i].type);
         } else {
           if (!check_expr(program, expr->args.items[i], scope, diag)) return false;
         }
@@ -5373,10 +5441,12 @@ static bool check_expr(const Program *program, const Expr *expr, Scope *scope, Z
   return check_expr_expected(program, expr, scope, diag, NULL);
 }
 
-static void mark_owned_move_if_needed(const Expr *expr, Scope *scope, const char *destination_type) {
-  if (!expr || expr->kind != EXPR_IDENT || !destination_type || !type_is_owned(destination_type)) return;
+static void mark_owned_move_if_needed(const Program *program, const Expr *expr, Scope *scope, const char *destination_type) {
+  if (!expr || expr->kind != EXPR_IDENT || !destination_type) return;
   const char *source_type = scope_type(scope, expr->text);
-  if (source_type && type_is_owned(source_type)) {
+  if (!source_type) return;
+  if ((type_is_owned(source_type) && type_is_owned(destination_type)) ||
+      (type_is_capability(program, source_type) && type_is_capability(program, destination_type))) {
     scope_set_moved(scope, expr->text, true);
     ((Expr *)expr)->moves_ownership = true;
   }
@@ -5414,7 +5484,7 @@ static bool check_lvalue_target(const Program *program, const Expr *target, Scop
       char path[256];
       bool local_place = expr_binding_path(target->left, root, sizeof(root), path, sizeof(path)) && scope_has(scope, root);
       if (local_place) {
-        if (!check_place_root_available(target->left, scope, root, diag)) return false;
+        if (!check_place_root_available(program, target->left, scope, root, diag)) return false;
         if (!check_place_index_exprs(program, target->left, scope, diag)) return false;
       } else if (!check_expr(program, target->left, scope, diag)) return false;
       const char *read_base_type = expr_type(program, target->left, scope);
@@ -5454,7 +5524,7 @@ static bool check_lvalue_target(const Program *program, const Expr *target, Scop
       char path[256];
       bool local_place = expr_binding_path(target->left, root, sizeof(root), path, sizeof(path)) && scope_has(scope, root);
       if (local_place) {
-        if (!check_place_root_available(target->left, scope, root, diag)) return false;
+        if (!check_place_root_available(program, target->left, scope, root, diag)) return false;
         if (!check_place_index_exprs(program, target->left, scope, diag)) return false;
       } else if (!check_expr(program, target->left, scope, diag)) return false;
       const char *read_base_type = expr_type(program, target->left, scope);
@@ -6992,6 +7062,8 @@ static bool check_scalar_match(const Program *program, const Function *fun, cons
   return true;
 }
 
+static bool check_handler_function(const Program *program, const Function *fun, const Function *handler, Scope *scope, ZDiag *diag);
+
 static bool check_stmt(const Program *program, const Function *fun, const Stmt *stmt, Scope *scope, ZDiag *diag, int loop_depth) {
   if (stmt->kind == STMT_LET) {
     for (size_t i = 0; i < scope->len; i++) {
@@ -7007,7 +7079,7 @@ static bool check_stmt(const Program *program, const Function *fun, const Stmt *
       return set_diag_detail(diag, 3006, "let binding type does not match initializer", stmt->line, stmt->column, stmt->type, actual, "change the annotation or initializer");
     }
     const char *binding_type = stmt->type ? stmt->type : actual;
-    mark_owned_move_if_needed(stmt->expr, scope, binding_type);
+    mark_owned_move_if_needed(program, stmt->expr, scope, binding_type);
     set_stmt_resolved_type(stmt, binding_type);
     scope_add_decl(scope, stmt->name, binding_type, stmt->mutable_binding, stmt->line, stmt->column);
     register_borrow_binding(program, stmt, scope);
@@ -7029,7 +7101,7 @@ static bool check_stmt(const Program *program, const Function *fun, const Stmt *
     if (!types_compatible(expected, actual)) {
       return set_diag_detail(diag, 3006, "assignment type does not match binding", stmt->line, stmt->column, expected, actual, "assign a compatible value");
     }
-    mark_owned_move_if_needed(stmt->expr, scope, expected);
+    mark_owned_move_if_needed(program, stmt->expr, scope, expected);
     mark_owned_target_live_if_needed(target, scope, expected);
     if (!update_borrow_assignment(program, target, stmt->expr, scope, diag)) return false;
     return true;
@@ -7067,6 +7139,27 @@ static bool check_stmt(const Program *program, const Function *fun, const Stmt *
     }
     return true;
   }
+  if (stmt->kind == STMT_WITH) {
+    EffectDecl *effect = find_effect(program, stmt->name);
+    if (!effect) {
+      char message[256];
+      snprintf(message, sizeof(message), "unknown effect '%s'", stmt->name ? stmt->name : "<error>");
+      return set_diag_detail(diag, 6201, message, stmt->line, stmt->column, "declared effect", stmt->name, "declare the effect before using it");
+    }
+    Scope handler_scope = {.parent = scope};
+    FunctionVec *handler_ops = (FunctionVec *)stmt->handler_ops;
+    for (size_t i = 0; i < handler_ops->len; i++) {
+      if (!check_handler_function(program, fun, &handler_ops->items[i], &handler_scope, diag)) {
+        scope_free(&handler_scope);
+        return false;
+      }
+    }
+    scope_free(&handler_scope);
+    Scope body_scope = {.parent = scope};
+    bool ok = check_stmt_vec_with_loop(program, fun, &stmt->else_body, &body_scope, diag, loop_depth);
+    scope_free(&body_scope);
+    return ok;
+  }
   if (stmt->kind == STMT_DEFER) return check_expr(program, stmt->expr, scope, diag);
   if (stmt->kind == STMT_RETURN) {
     if (!check_expr_expected(program, stmt->expr, scope, diag, fun->return_type)) return false;
@@ -7075,7 +7168,7 @@ static bool check_stmt(const Program *program, const Function *fun, const Stmt *
       return set_diag_detail(diag, 3007, "return type does not match function return type", stmt->line, stmt->column, fun->return_type, actual, "return a value compatible with the function signature");
     }
     if (!check_return_reference_escape(program, stmt->expr, scope, diag)) return false;
-    mark_owned_move_if_needed(stmt->expr, scope, fun->return_type);
+    mark_owned_move_if_needed(program, stmt->expr, scope, fun->return_type);
     return true;
   }
   if (stmt->kind == STMT_EXPR) return check_expr(program, stmt->expr, scope, diag);
@@ -7313,6 +7406,18 @@ static bool validate_drop_method(const Shape *shape, const Function *method, ZDi
   }
   (void)shape;
   return true;
+}
+
+static bool check_handler_function(const Program *program, const Function *fun, const Function *handler, Scope *scope, ZDiag *diag) {
+  for (size_t i = 0; i < handler->params.len; i++) {
+    Param *param = &handler->params.items[i];
+    scope_add(scope, param->name, param->type, false);
+  }
+  bool ok = check_stmt_vec(program, handler, &handler->body, scope, diag);
+  for (size_t i = 0; i < handler->params.len; i++) {
+    scope_remove(scope, handler->params.items[i].name);
+  }
+  return ok;
 }
 
 static bool check_shape_method_body(const Program *program, const Shape *shape, const Function *method, ZDiag *diag) {

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -1112,10 +1112,6 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       elf_append_u8(code, 0x35);
       elf_append_u32(code, 0x9e3779b9u);
       return true;
-    case IR_VALUE_FS_HOST:
-      elf_append_u8(code, 0x31);
-      elf_append_u8(code, 0xc0);
-      return true;
     case IR_VALUE_FS_OPEN:
     case IR_VALUE_FS_CREATE: {
       bool create = value->kind == IR_VALUE_FS_CREATE;

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -32,6 +32,38 @@ static void *ir_grow_tracked_items(IrProgram *ir, void *items, size_t len, size_
   return items;
 }
 
+void effect_vec_push(EffectVec *vec, const char *name) {
+  if (!vec || !name) return;
+  for (size_t i = 0; i < vec->len; i++) {
+    if (strcmp(vec->items[i], name) == 0) return;
+  }
+  if (vec->len + 1 > vec->cap) {
+    vec->cap = vec->cap == 0 ? 4 : vec->cap * 2;
+    vec->items = realloc(vec->items, vec->cap * sizeof(char *));
+  }
+  vec->items[vec->len++] = z_strdup(name);
+}
+
+void effect_vec_free(EffectVec *vec) {
+  if (!vec) return;
+  for (size_t i = 0; i < vec->len; i++) free(vec->items[i]);
+  free(vec->items);
+  *vec = (EffectVec){0};
+}
+
+void effect_vec_merge(EffectVec *dst, const EffectVec *src) {
+  if (!dst || !src) return;
+  for (size_t i = 0; i < src->len; i++) effect_vec_push(dst, src->items[i]);
+}
+
+bool effect_vec_contains(const EffectVec *vec, const char *name) {
+  if (!vec || !name) return false;
+  for (size_t i = 0; i < vec->len; i++) {
+    if (strcmp(vec->items[i], name) == 0) return true;
+  }
+  return false;
+}
+
 static void push_param_clone(ParamVec *vec, const Param *param) {
   vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
   vec->items[vec->len++] = (Param){
@@ -1672,13 +1704,6 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         *out = value;
         return true;
       }
-      if (strcmp(callee_name, "std.net.host") == 0 && expr->args.len == 0) {
-        IrValue *value = ir_new_value(ir, IR_VALUE_INT, IR_TYPE_I32, expr->line, expr->column);
-        value->int_value = 1;
-        free(callee_name);
-        *out = value;
-        return true;
-      }
       int http_error_code = ir_std_http_error_code(callee_name);
       if (http_error_code >= 0 && expr->args.len == 0) {
         IrValue *value = ir_new_value(ir, IR_VALUE_INT, IR_TYPE_U32, expr->line, expr->column);
@@ -1874,12 +1899,6 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         }
         IrValue *value = ir_new_value(ir, IR_VALUE_ENV_GET, IR_TYPE_MAYBE_BYTE_VIEW, expr->line, expr->column);
         value->left = key;
-        free(callee_name);
-        *out = value;
-        return true;
-      }
-      if (strcmp(callee_name, "std.fs.host") == 0 && expr->args.len == 0) {
-        IrValue *value = ir_new_value(ir, IR_VALUE_FS_HOST, IR_TYPE_I32, expr->line, expr->column);
         free(callee_name);
         *out = value;
         return true;

--- a/native/zero-c/src/lexer.c
+++ b/native/zero-c/src/lexer.c
@@ -19,10 +19,10 @@ static Token make_token(TokenKind kind, char *text, int line, int column, size_t
 
 static bool is_keyword(const char *text) {
   const char *keywords[] = {
-    "as", "break", "check", "choice", "const", "continue", "defer", "else", "enum", "export", "extern", "false", "for", "fun",
-    "if", "import", "in", "let", "match", "meta", "mut", "null", "packed", "pub",
+    "as", "break", "capability", "check", "choice", "const", "continue", "defer", "effect", "else", "enum", "export", "extern", "false", "for", "fun",
+    "handledBy", "if", "import", "in", "let", "match", "meta", "mut", "null", "packed", "pub",
     "raise", "raises", "rescue", "return", "shape", "static", "test", "true", "type",
-    "use", "var", "while", NULL
+    "use", "var", "while", "with", NULL
   };
   for (int i = 0; keywords[i]; i++) {
     if (strcmp(text, keywords[i]) == 0) return true;

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -147,6 +147,9 @@ static const char *diag_code(int code) {
     case 5001: return "WEB001";
     case 6001: return "TAR001";
     case 6002: return "TAR002";
+    case 6003: return "CAP001";
+    case 6004: return "CAP002";
+    case 6201: return "EFF001";
     case 7001: return "IMP001";
     case 7002: return "IMP002";
     case 7003: return "IMP003";
@@ -420,6 +423,7 @@ static const char *stmt_kind_name(StmtKind kind) {
     case STMT_CONTINUE: return "continue";
     case STMT_MATCH: return "match";
     case STMT_RAISE: return "raise";
+    case STMT_WITH: return "with";
   }
   return "unknown";
 }
@@ -738,6 +742,7 @@ typedef struct {
   bool proc;
   bool web;
   bool world;
+  bool ai;
 } CapabilitySummary;
 
 #define STD_HELPER_MAX 192
@@ -890,7 +895,6 @@ static const StdHelperInfo std_helpers[] = {
   {"std.crypto.hmac32", "u32", 2, "codec", "target-neutral", "no allocation", true},
   {"std.crypto.constantTimeEql", "Bool", 2, "memory", "target-neutral", "no allocation", true},
   {"std.crypto.secureRandomU32", "u32", 0, "rand", "host", "target entropy source", true},
-  {"std.net.host", "Net", 0, "net", "host", "explicit network capability handle", false},
   {"std.net.address", "Address", 2, "net", "target-neutral", "no allocation", true},
   {"std.net.dnsName", "String", 1, "net", "target-neutral", "borrows address host", false},
   {"std.net.connect", "Maybe<Conn>", 2, "net", "host", "no allocation; returns unopened bootstrap handle", true},
@@ -923,7 +927,6 @@ static const StdHelperInfo std_helpers[] = {
   {"std.http.headerOffset", "usize", 1, "memory", "host-runtime", "reads header-value offset metadata", true},
   {"std.http.headerLen", "usize", 1, "memory", "host-runtime", "reads header-value length metadata", true},
   {"std.http.tlsBoundary", "String", 0, "net", "host", "declares platform-or-C-library TLS boundary", false},
-  {"std.fs.host", "Fs", 0, "fs", "host", "no allocation", true},
   {"std.fs.open", "Maybe<owned<File>>", 2, "fs", "host", "owned file handle", true},
   {"std.fs.openOrRaise", "owned<File>", 2, "fs", "host", "owned file handle", true},
   {"std.fs.create", "Maybe<owned<File>>", 2, "fs", "host", "owned file handle", true},
@@ -1037,6 +1040,7 @@ static void capability_summary_set(CapabilitySummary *caps, const char *capabili
   else if (strcmp(capability, "proc") == 0) caps->proc = true;
   else if (strcmp(capability, "web") == 0) caps->web = true;
   else if (strcmp(capability, "world") == 0) caps->world = true;
+  else if (strcmp(capability, "ai") == 0) caps->ai = true;
 }
 
 static void append_capability_json_array(ZBuf *buf, const CapabilitySummary *caps) {
@@ -1063,6 +1067,7 @@ static void append_capability_json_array(ZBuf *buf, const CapabilitySummary *cap
   APPEND_CAP("proc", caps && caps->proc);
   APPEND_CAP("web", caps && caps->web);
   APPEND_CAP("world", caps && caps->world);
+  APPEND_CAP("ai", caps && caps->ai);
 #undef APPEND_CAP
   zbuf_append(buf, "]");
 }
@@ -1298,6 +1303,7 @@ static void collect_capabilities_from_std_name(const char *name, CapabilitySumma
   else if (strncmp(name, "std.crypto.", strlen("std.crypto.")) == 0) caps->codec = true;
   else if (strncmp(name, "std.net.", strlen("std.net.")) == 0) caps->net = true;
   else if (strncmp(name, "std.http.", strlen("std.http.")) == 0) caps->net = true;
+  else if (strncmp(name, "std.ai.", strlen("std.ai.")) == 0) caps->ai = true;
   else if (strncmp(name, "std.mem.", strlen("std.mem.")) == 0) {
     caps->memory = true;
     if (strcmp(name, "std.mem.nullAlloc") == 0 ||
@@ -1373,9 +1379,12 @@ static CapabilitySummary function_capabilities(const Function *fun) {
     if (strcmp(type, "World") == 0) caps.world = true;
     else if (strcmp(type, "Fs") == 0) caps.fs = true;
     else if (strcmp(type, "Net") == 0) caps.net = true;
-    else if (strcmp(type, "Proc") == 0) caps.proc = true;
+    else if (strcmp(type, "Env") == 0) caps.env = true;
+    else if (strcmp(type, "Args") == 0) caps.args = true;
     else if (strcmp(type, "Clock") == 0) caps.time = true;
     else if (strcmp(type, "Rand") == 0) caps.rand = true;
+    else if (strcmp(type, "Proc") == 0) caps.proc = true;
+    else if (strcmp(type, "Ai") == 0) caps.ai = true;
     else if (strcmp(type, "Alloc") == 0 || strcmp(type, "FixedBufAlloc") == 0 || strcmp(type, "NullAlloc") == 0) capability_summary_set(&caps, "alloc");
     if (strstr(type, "Span<") || strstr(type, "MutSpan<") || strstr(type, "ByteBuf")) caps.memory = true;
   }
@@ -1401,6 +1410,7 @@ static CapabilitySummary program_capabilities(const Program *program) {
     caps.proc = caps.proc || fun_caps.proc;
     caps.web = caps.web || fun_caps.web;
     caps.world = caps.world || fun_caps.world;
+    caps.ai = caps.ai || fun_caps.ai;
   }
   for (size_t i = 0; program && i < program->shapes.len; i++) {
     for (size_t field_index = 0; field_index < program->shapes.items[i].fields.len; field_index++) {
@@ -2129,6 +2139,7 @@ static void append_used_stdlib_helpers_json(ZBuf *buf, const HelperUseSummary *h
 static void append_runtime_shims_json(ZBuf *buf, const char *emitted_symbol_text, const CapabilitySummary *caps);
 static const Function *find_program_function(const Program *program, const char *name);
 static void append_function_effects_json(ZBuf *buf, const Function *fun);
+static void append_function_user_effects_json(ZBuf *buf, const Function *fun);
 static void append_function_ownership_json(ZBuf *buf, const Function *fun);
 
 static const char *static_param_kind_json(const Program *program, const char *type) {
@@ -2247,6 +2258,8 @@ static void append_public_docs_json(ZBuf *buf, const SourceInput *input, const P
       append_target_capability_facts_json(buf, target, &fun_caps);
       zbuf_append(buf, ",\"effects\":");
       append_function_effects_json(buf, fun);
+      zbuf_append(buf, ",\"userEffects\":");
+      append_function_user_effects_json(buf, fun);
       zbuf_append(buf, ",\"ownership\":");
       append_function_ownership_json(buf, fun);
     } else {
@@ -2756,7 +2769,7 @@ static const ExplainInfo explain_infos[] = {
     "The compile-time evaluator rejected a `meta` expression because it was unsupported, effectful, cyclic, or outside the safety limits.",
     "Zero keeps compile-time execution sandboxed, deterministic, and bounded, so filesystem, network, process, and ambient environment access fail before code generation.",
     "Use literal arithmetic, Bool logic, target facts, or typed reflection facts within the bounded evaluator.",
-    "const bad: usize = meta std.fs.host()",
+    "const bad: usize = meta world.fs()",
     "const page: usize = meta target.pointerWidth * 64",
   },
   {
@@ -5932,6 +5945,19 @@ static void append_function_effects_json(ZBuf *buf, const Function *fun) {
   append_capability_json_array(buf, &caps);
 }
 
+static void append_function_user_effects_json(ZBuf *buf, const Function *fun) {
+  zbuf_append(buf, "[");
+  if (fun) {
+    for (size_t i = 0; i < fun->effects.len; i++) {
+      if (i > 0) zbuf_append(buf, ", ");
+      zbuf_append_char(buf, '"');
+      zbuf_append(buf, fun->effects.items[i]);
+      zbuf_append_char(buf, '"');
+    }
+  }
+  zbuf_append(buf, "]");
+}
+
 static void append_function_error_json(ZBuf *buf, const Function *fun) {
   zbuf_append(buf, "\"errorSetKind\":");
   append_json_string(buf, !fun || !fun->raises ? "none" : (fun->has_error_set ? "explicit" : (fun->is_public ? "open" : "inferred")));
@@ -8724,6 +8750,8 @@ static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program
     append_function_effects_json(buf, fun);
     zbuf_append(buf, ",\"effects\":");
     append_function_effects_json(buf, fun);
+    zbuf_append(buf, ",\"userEffects\":");
+    append_function_user_effects_json(buf, fun);
     zbuf_append(buf, ",\"allocationBehavior\":");
     append_json_string(buf, function_allocation_behavior(fun));
     zbuf_append(buf, ",\"targetSupport\":");
@@ -8805,6 +8833,8 @@ static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program
       append_function_error_json(buf, method);
       zbuf_append(buf, ",\"staticDispatch\":true,\"effects\":");
       append_function_effects_json(buf, method);
+      zbuf_append(buf, ",\"userEffects\":");
+      append_function_user_effects_json(buf, method);
       zbuf_append(buf, ",\"allocationBehavior\":");
       append_json_string(buf, function_allocation_behavior(method));
       zbuf_append(buf, ",\"targetSupport\":");

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -159,6 +159,7 @@ static Token *expect_ident(Parser *parser, const char *message) {
 }
 
 static Expr *parse_expr(Parser *parser);
+static Function parse_function(Parser *parser);
 static StmtVec parse_block(Parser *parser);
 static void free_expr(Expr *expr);
 
@@ -607,6 +608,25 @@ static Stmt *parse_statement(Parser *parser) {
     stmt->expr = parse_expr(parser);
     return stmt;
   }
+  if (match(parser, "with")) {
+    Stmt *stmt = new_stmt(STMT_WITH, start);
+    Token *effect_name = expect_ident(parser, "expected effect name after with");
+    if (effect_name) stmt->name = z_strdup(effect_name->text);
+    expect(parser, "handledBy", "expected 'handledBy' after effect name");
+    expect(parser, "{", "expected '{' before handler body");
+    while (!check(parser, "}") && current(parser)->kind != TOK_EOF && parser->diag->code == 0) {
+      if (check(parser, "pub") || check(parser, "fun")) {
+        Function op = parse_function(parser);
+        if (!stmt->handler_ops) stmt->handler_ops = calloc(1, sizeof(FunctionVec));
+        push_function((FunctionVec *)stmt->handler_ops, op);
+        continue;
+      }
+      fail(parser, "expected handler function declaration");
+      break;
+    }
+    expect(parser, "}", "expected '}' after handler body");
+    return stmt;
+  }
   if (match(parser, "return")) {
     Stmt *stmt = new_stmt(STMT_RETURN, start);
     if (!check(parser, "}")) stmt->expr = parse_expr(parser);
@@ -711,6 +731,16 @@ static StmtVec parse_block(Parser *parser) {
   return body;
 }
 
+static void parse_effect_row(Parser *parser, EffectVec *effects) {
+  if (!match(parser, "<")) return;
+  if (match(parser, ">")) return;
+  do {
+    Token *name = expect_ident(parser, "expected effect name");
+    if (name) effect_vec_push(effects, name->text);
+  } while (match(parser, ","));
+  expect(parser, ">", "expected '>' after effect list");
+}
+
 static Function parse_function(Parser *parser) {
   Token *start = current(parser);
   Function fun = {0};
@@ -730,7 +760,9 @@ static Function parse_function(Parser *parser) {
   fun.return_type = parse_type(parser);
   if (match(parser, "raises")) {
     fun.raises = true;
-    if (check(parser, "{") &&
+    if (check(parser, "<")) {
+      parse_effect_row(parser, &fun.effects);
+    } else if (check(parser, "{") &&
         parser->tokens->items[parser->index + 1].text &&
         parser->tokens->items[parser->index + 1].text[0] >= 'A' &&
         parser->tokens->items[parser->index + 1].text[0] <= 'Z') {
@@ -882,6 +914,57 @@ static InterfaceDecl parse_interface(Parser *parser, bool is_public) {
   return interface;
 }
 
+static CapabilityDecl parse_capability(Parser *parser, bool is_public) {
+  Token *start = current(parser);
+  expect(parser, "capability", "expected 'capability' keyword");
+  CapabilityDecl cap = {0};
+  Token *name = expect_ident(parser, "expected capability name");
+  cap.name = name ? z_strdup(name->text) : z_strdup("<error>");
+  cap.line = start->line;
+  cap.column = start->column;
+  (void)is_public;
+  return cap;
+}
+
+static void push_capability(CapabilityDeclVec *vec, CapabilityDecl cap) {
+  if (vec->len + 1 > vec->cap) {
+    vec->cap = vec->cap == 0 ? 4 : vec->cap * 2;
+    vec->items = realloc(vec->items, vec->cap * sizeof(CapabilityDecl));
+  }
+  vec->items[vec->len++] = cap;
+}
+
+static EffectDecl parse_effect(Parser *parser, bool is_public) {
+  Token *start = current(parser);
+  expect(parser, "effect", "expected 'effect' keyword");
+  EffectDecl effect = {0};
+  Token *name = expect_ident(parser, "expected effect name");
+  effect.name = name ? z_strdup(name->text) : z_strdup("<error>");
+  effect.line = start->line;
+  effect.column = start->column;
+  effect.is_public = is_public;
+  expect(parser, "{", "expected '{' before effect body");
+  while (!check(parser, "}") && current(parser)->kind != TOK_EOF && parser->diag->code == 0) {
+    if (check(parser, "pub") || check(parser, "fun")) {
+      Function op = parse_interface_method(parser);
+      push_function(&effect.operations, op);
+      continue;
+    }
+    fail(parser, "expected effect operation declaration");
+    break;
+  }
+  expect(parser, "}", "expected '}' after effect body");
+  return effect;
+}
+
+static void push_effect(EffectDeclVec *vec, EffectDecl effect) {
+  if (vec->len + 1 > vec->cap) {
+    vec->cap = vec->cap == 0 ? 4 : vec->cap * 2;
+    vec->items = realloc(vec->items, vec->cap * sizeof(EffectDecl));
+  }
+  vec->items[vec->len++] = effect;
+}
+
 static EnumDecl parse_enum(Parser *parser) {
   Token *start = current(parser);
   EnumDecl item = {0};
@@ -1023,8 +1106,16 @@ Program z_parse(TokenVec *tokens, ZDiag *diag) {
       push_interface(&program.interfaces, parse_interface(&parser, is_public));
       continue;
     }
+    if (check(&parser, "capability")) {
+      push_capability(&program.capabilities, parse_capability(&parser, is_public));
+      continue;
+    }
     if (check(&parser, "shape") || check(&parser, "extern") || check(&parser, "packed")) {
       push_shape(&program.shapes, parse_shape(&parser, is_public));
+      continue;
+    }
+    if (check(&parser, "effect")) {
+      push_effect(&program.effects, parse_effect(&parser, is_public));
       continue;
     }
     if (check(&parser, "enum")) {
@@ -1082,6 +1173,22 @@ static void free_stmt_vec(StmtVec *vec) {
       free_stmt_vec(&stmt->match_arms.items[arm_index].body);
     }
     free(stmt->match_arms.items);
+    if (stmt->handler_ops) {
+      FunctionVec *hops = (FunctionVec *)stmt->handler_ops;
+      for (size_t op_index = 0; op_index < hops->len; op_index++) {
+        Function *op = &hops->items[op_index];
+        free(op->name);
+        free(op->return_type);
+        for (size_t p = 0; p < op->params.len; p++) {
+          free(op->params.items[p].name);
+          free(op->params.items[p].type);
+        }
+        free(op->params.items);
+        free_stmt_vec(&op->body);
+      }
+      free(hops->items);
+      free(stmt->handler_ops);
+    }
     free(stmt);
   }
   free(vec->items);
@@ -1128,6 +1235,7 @@ void z_free_program(Program *program) {
         free(method->errors.items[error_index].type);
       }
       free(method->errors.items);
+      effect_vec_free(&method->effects);
       for (size_t param_index = 0; param_index < method->params.len; param_index++) {
         free(method->params.items[param_index].name);
         free(method->params.items[param_index].type);
@@ -1167,6 +1275,7 @@ void z_free_program(Program *program) {
         free(method->errors.items[error_index].type);
       }
       free(method->errors.items);
+      effect_vec_free(&method->effects);
       for (size_t param_index = 0; param_index < method->params.len; param_index++) {
         free(method->params.items[param_index].name);
         free(method->params.items[param_index].type);
@@ -1218,6 +1327,7 @@ void z_free_program(Program *program) {
       free(fun->errors.items[error_index].type);
     }
     free(fun->errors.items);
+    effect_vec_free(&fun->effects);
     for (size_t param_index = 0; param_index < fun->params.len; param_index++) {
       free(fun->params.items[param_index].name);
       free(fun->params.items[param_index].type);
@@ -1229,4 +1339,31 @@ void z_free_program(Program *program) {
   program->functions.items = NULL;
   program->functions.len = 0;
   program->functions.cap = 0;
+  for (size_t i = 0; i < program->effects.len; i++) {
+    EffectDecl *effect = &program->effects.items[i];
+    free(effect->name);
+    for (size_t j = 0; j < effect->operations.len; j++) {
+      Function *op = &effect->operations.items[j];
+      free(op->name);
+      free(op->return_type);
+      for (size_t k = 0; k < op->params.len; k++) {
+        free(op->params.items[k].name);
+        free(op->params.items[k].type);
+      }
+      free(op->params.items);
+      free_stmt_vec(&op->body);
+    }
+    free(effect->operations.items);
+  }
+  free(program->effects.items);
+  program->effects.items = NULL;
+  program->effects.len = 0;
+  program->effects.cap = 0;
+  for (size_t i = 0; i < program->capabilities.len; i++) {
+    free(program->capabilities.items[i].name);
+  }
+  free(program->capabilities.items);
+  program->capabilities.items = NULL;
+  program->capabilities.len = 0;
+  program->capabilities.cap = 0;
 }

--- a/scripts/http-runtime-smoke.mts
+++ b/scripts/http-runtime-smoke.mts
@@ -190,7 +190,7 @@ async function runHttpHeadersExample(baseUrl) {
 
 function okSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [${zeroArray(512)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}/ok\\n\\n"), response, std.time.ms(1000))
@@ -218,7 +218,7 @@ function okSource(baseUrl) {
 
 function fetchRequestSource(baseUrl, method, path, body, expectedStatus, expectedBodyLen, expectedCode) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let request = std.mem.span("${method} ${baseUrl}${path}\\ncontent-type: application/json\\nx-zero-test: yes\\n\\n${body}")
     let mut response: [512]u8 = [${zeroArray(512)}]
@@ -239,7 +239,7 @@ function fetchRequestSource(baseUrl, method, path, body, expectedStatus, expecte
 
 function resultFailureSource(baseUrl, path, responseSize, timeoutMs, expectedStatus, expectedLen, expectedError, expectedCode) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [${responseSize}]u8 = [${zeroArray(responseSize)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}${path}\\n\\n"), response, std.time.ms(${timeoutMs}))
@@ -256,7 +256,7 @@ function resultFailureSource(baseUrl, path, responseSize, timeoutMs, expectedSta
 
 function headersSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [${zeroArray(512)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}/ok\\n\\n"), response, std.time.ms(1000))
@@ -282,7 +282,7 @@ function headersSource(baseUrl) {
 
 function interimHeadersSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [${zeroArray(512)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}/interim\\n\\n"), response, std.time.ms(1000))
@@ -309,7 +309,7 @@ function interimHeadersSource(baseUrl) {
 
 function headSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let request = std.mem.span("HEAD ${baseUrl}/ok\\nx-zero-test: yes\\n\\n")
     let mut response: [512]u8 = [${zeroArray(512)}]
@@ -331,7 +331,7 @@ function headSource(baseUrl) {
 
 function jsonResultSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [512]u8 = [${zeroArray(512)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}/ok\\n\\n"), response, std.time.ms(1000))
@@ -356,7 +356,7 @@ function jsonResultSource(baseUrl) {
 
 function invalidUrlSource() {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [64]u8 = [${zeroArray(64)}]
     let result = std.http.fetch(client, std.mem.span("GET http://\\n\\n"), response, std.time.ms(1000))
@@ -373,7 +373,7 @@ function invalidUrlSource() {
 
 function shorthandRejectedSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [64]u8 = [${zeroArray(64)}]
     let result = std.http.fetch(client, std.mem.span("${baseUrl}/ok"), response, std.time.ms(1000))
@@ -390,7 +390,7 @@ function shorthandRejectedSource(baseUrl) {
 
 function unterminatedEnvelopeSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [64]u8 = [${zeroArray(64)}]
     let result = std.http.fetch(client, std.mem.span("GET ${baseUrl}/ok"), response, std.time.ms(1000))
@@ -407,7 +407,7 @@ function unterminatedEnvelopeSource(baseUrl) {
 
 function invalidRequestSource(baseUrl) {
   return `export c fun main() -> i32 {
-    let net = std.net.host()
+    let net = world.net()
     let client = std.http.client(net)
     let mut response: [128]u8 = [${zeroArray(128)}]
     let request = std.mem.span("POST ${baseUrl}/echo\\nbad-header\\n\\n")

--- a/skill-data/zero-stdlib.md
+++ b/skill-data/zero-stdlib.md
@@ -86,7 +86,7 @@ Use `check maybeValue` only when absence should propagate as a failure in a fall
 Hosted file APIs can use explicit handles:
 
 ```zero
-let fs = std.fs.host()
+let fs = world.fs()
 let mut file: owned<File> = check std.fs.createOrRaise(fs, ".zero/out/log.txt")
 check std.fs.writeAllOrRaise(&mut file, std.mem.span("hello\n"))
 ```


### PR DESCRIPTION
## Summary

Implements all 4 layers of the capability system design (issue #84), rebased cleanly on latest main (v0.1.3 + TypeScript migration).

**Layer 1 — Effect Signatures:** `raises<io, fs, net>` syntax for static effect information.

**Layer 2 — Fine-Grained Capabilities:** `world.fs()`, `world.net()`, etc. derive capability types from World. Removed ambient authority (`std.fs.host()`, `std.net.host()`).

**Layer 3 — Affine Capabilities:** Capability types are affine — no duplication, no global storage. CAP001 diagnostic.

**Layer 4 — Effect Handlers:** `effect Http { fun fetch(...) -> T }` declarations and `with Http handledBy { ... }` handler expressions. EFF001 diagnostic.

**Elegance Improvements:**
- Declaration-based capabilities (`capability Fs`, `capability Net`, etc.)
- Unified type checking via `type_is_capability()`
- Clean memory management in `z_free_program()`

## Changes

40 files changed across compiler (zero.h, checker.c, ir.c, main.c, parser.c, lexer.c), conformance tests, examples, docs, and scripts.

## Testing

- All existing examples updated to use `world.fs()` instead of `std.fs.host()`
- Conformance tests updated
- Clean merge against latest main (verified locally)

## Replaces

This PR replaces the previous separate PRs (#86, #90, #94, #99, #117) which had merge conflicts.