### PR TITLE
Add PAR100 diagnostic explain coverage

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1057,6 +1057,13 @@ assert.equal(explainTar002Body.schemaVersion, 1);
 assert.equal(explainTar002Body.code, "TAR002");
 assert.equal(explainTar002Body.repair.id, "choose-target-with-required-capability");
 
+const explainPar100 = await execFileAsync(zero, ["explain", "--json", "PAR100"]);
+const explainPar100Body = JSON.parse(explainPar100.stdout);
+assert.equal(explainPar100Body.schemaVersion, 1);
+assert.equal(explainPar100Body.code, "PAR100");
+assert.equal(explainPar100Body.category, "parse");
+assert.match(explainPar100Body.summary, /syntax/);
+
 const explainText = await execFileAsync(zero, ["explain", "TYP009"]);
 assert.match(explainText.stdout, /Mutable storage required/);
 

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2650,6 +2650,16 @@ static void print_diag_json(const char *path, const ZDiag *diag);
 
 static const ExplainInfo explain_infos[] = {
   {
+    "PAR100",
+    "parse",
+    "Parser syntax error",
+    "The parser could not turn the source text into a valid Zero syntax tree.",
+    "Zero reports parser failures as a stable diagnostic code so agents can repair syntax before trying type or build fixes.",
+    "Inspect the reported span, fix the malformed syntax, then rerun the same zero check command.",
+    "pub fun main(world: World) -> Void raises {",
+    "pub fun main(world: World) -> Void raises {\n    check world.out.write(\"hello\\n\")\n}",
+  },
+  {
     "TAR001",
     "target",
     "Unknown target",
@@ -2945,6 +2955,7 @@ static void print_explain_json(const ExplainInfo *info) {
   append_json_string(&buf, info->why);
   zbuf_append(&buf, ",\n  \"repair\": {\"id\": ");
   append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
+                                         strcmp(info->code, "PAR100") == 0 ? 100 :
                                          strcmp(info->code, "TAR002") == 0 ? 6002 :
                                          strcmp(info->code, "BLD003") == 0 ? 2003 :
                                          strcmp(info->code, "TYP009") == 0 ? 3010 :


### PR DESCRIPTION
## What changed

- Adds `zero explain PAR100` coverage for parser syntax diagnostics.
- Returns the same structured explain JSON shape as existing diagnostic explanations, including `category`, repair metadata, and examples.
- Adds conformance coverage for the PAR100 explain surface.

## Why

`PAR100` is emitted for parser syntax failures and diagnostics already point users to `zero explain PAR100`, but the explain command previously treated `PAR100` itself as unknown. That made the repair path less deterministic for agents handling parse failures.

Fixes #111.

## Validation

- `make -C native/zero-c && .zero/bin/zero explain --json PAR100 && .zero/bin/zero explain PAR100`
- `ZERO_NATIVE_TEST_ALLOW_LOCAL=1 pnpm run conformance:local`
- `make -C native/zero-c && ./node_modules/.bin/tsc -p scripts/tsconfig.json && ./node_modules/.bin/tsc -p tests/tsconfig.json && node --test .zero/test-js/*.test.js && ZERO_NATIVE_TEST_ALLOW_LOCAL=1 node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/snapshot-command-contracts.mts`
