### PR TITLE
Add binder-aware type unification

### DIFF
--- a/native/zero-c/src/type_core.c
+++ b/native/zero-c/src/type_core.c
@@ -99,7 +99,11 @@ static const ZTypeBinderDecl *type_binder_lookup(const ZTypeBinderScope *scope, 
 
 static bool static_value_from_binder(const ZTypeBinderDecl *decl, ZStaticValue *out) {
   if (!decl || decl->kind != Z_TYPE_BINDER_STATIC || decl->id == Z_TYPE_BINDER_ID_INVALID || !out) return false;
-  *out = (ZStaticValue){.kind = Z_STATIC_VALUE_BINDER, .text = type_strdup(decl->name ? decl->name : ""), .binder = decl->id};
+  *out = (ZStaticValue){
+      .kind = Z_STATIC_VALUE_BINDER,
+      .text = type_strdup(decl->name ? decl->name : ""),
+      .static_type = type_strdup(decl->static_type && decl->static_type[0] ? decl->static_type : "usize"),
+      .binder = decl->id};
   return true;
 }
 
@@ -107,12 +111,14 @@ bool z_static_value_clone(const ZStaticValue *source, ZStaticValue *out) {
   if (!source || !out) return false;
   *out = *source;
   out->text = type_strdup(source->text ? source->text : "");
+  out->static_type = source->static_type ? type_strdup(source->static_type) : NULL;
   return true;
 }
 
 void z_static_value_free(ZStaticValue *value) {
   if (!value) return;
   free(value->text);
+  free(value->static_type);
   *value = (ZStaticValue){0};
 }
 

--- a/native/zero-c/src/type_core.c
+++ b/native/zero-c/src/type_core.c
@@ -12,6 +12,10 @@ struct ZTypeNode {
   union {
     char *name;
     struct {
+      char *name;
+      ZTypeBinderId binder;
+    } binder;
+    struct {
       ZTypeId inner;
     } constant;
     struct {
@@ -35,6 +39,7 @@ typedef struct {
 typedef struct {
   const char *text;
   size_t cursor;
+  const ZTypeBinderScope *scope;
   ZTypeParseError *error;
 } TypeParser;
 
@@ -83,6 +88,28 @@ static void type_buf_append_char(TypeBuf *buf, char ch) {
   type_buf_append_len(buf, &ch, 1);
 }
 
+static const ZTypeBinderDecl *type_binder_lookup(const ZTypeBinderScope *scope, const char *name, ZTypeBinderKind kind) {
+  if (!scope || !name) return NULL;
+  for (size_t i = 0; i < scope->len; i++) {
+    const ZTypeBinderDecl *decl = &scope->items[i];
+    if (decl->kind == kind && decl->id != Z_TYPE_BINDER_ID_INVALID && decl->name && strcmp(decl->name, name) == 0) return decl;
+  }
+  return NULL;
+}
+
+static bool static_value_from_binder(const ZTypeBinderDecl *decl, ZStaticValue *out) {
+  if (!decl || decl->kind != Z_TYPE_BINDER_STATIC || decl->id == Z_TYPE_BINDER_ID_INVALID || !out) return false;
+  *out = (ZStaticValue){.kind = Z_STATIC_VALUE_BINDER, .text = type_strdup(decl->name ? decl->name : ""), .binder = decl->id};
+  return true;
+}
+
+bool z_static_value_clone(const ZStaticValue *source, ZStaticValue *out) {
+  if (!source || !out) return false;
+  *out = *source;
+  out->text = type_strdup(source->text ? source->text : "");
+  return true;
+}
+
 void z_static_value_free(ZStaticValue *value) {
   if (!value) return;
   free(value->text);
@@ -99,6 +126,8 @@ static void type_node_free(ZTypeNode *node) {
   if (!node) return;
   if (node->kind == Z_TYPE_NODE_NAME) {
     free(node->as.name);
+  } else if (node->kind == Z_TYPE_NODE_BINDER) {
+    free(node->as.binder.name);
   } else if (node->kind == Z_TYPE_NODE_ARRAY) {
     z_static_value_free(&node->as.array.length);
   } else if (node->kind == Z_TYPE_NODE_APPLY) {
@@ -135,6 +164,44 @@ static ZTypeId type_arena_add(ZTypeArena *arena, ZTypeNode node) {
   arena->nodes[arena->len] = node;
   arena->len++;
   return (ZTypeId)arena->len;
+}
+
+ZTypeId z_type_make_name(ZTypeArena *arena, const char *name) {
+  return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_NAME, .as.name = type_strdup(name ? name : "Unknown")});
+}
+
+ZTypeId z_type_make_binder(ZTypeArena *arena, const char *name, ZTypeBinderId binder) {
+  if (binder == Z_TYPE_BINDER_ID_INVALID) return Z_TYPE_ID_INVALID;
+  return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_BINDER, .as.binder = {.name = type_strdup(name ? name : ""), .binder = binder}});
+}
+
+ZTypeId z_type_make_const(ZTypeArena *arena, ZTypeId inner) {
+  if (inner == Z_TYPE_ID_INVALID) return Z_TYPE_ID_INVALID;
+  return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_CONST, .as.constant = {.inner = inner}});
+}
+
+ZTypeId z_type_make_array(ZTypeArena *arena, const ZStaticValue *length, ZTypeId element) {
+  if (element == Z_TYPE_ID_INVALID) return Z_TYPE_ID_INVALID;
+  ZStaticValue length_copy = {0};
+  if (!z_static_value_clone(length, &length_copy)) return Z_TYPE_ID_INVALID;
+  return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_ARRAY, .as.array = {.length = length_copy, .element = element}});
+}
+
+ZTypeId z_type_make_apply(ZTypeArena *arena, const char *name, const ZTypeArg *args, size_t arg_len) {
+  if (!name || !name[0] || (arg_len > 0 && !args)) return Z_TYPE_ID_INVALID;
+  ZTypeArg *arg_copy = NULL;
+  if (arg_len > 0) {
+    arg_copy = type_reallocarray(NULL, arg_len, sizeof(ZTypeArg));
+    for (size_t i = 0; i < arg_len; i++) {
+      arg_copy[i] = args[i];
+      if (args[i].kind == Z_TYPE_ARG_STATIC && !z_static_value_clone(&args[i].as.static_value, &arg_copy[i].as.static_value)) {
+        for (size_t j = 0; j < i; j++) type_arg_free(&arg_copy[j]);
+        free(arg_copy);
+        return Z_TYPE_ID_INVALID;
+      }
+    }
+  }
+  return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_APPLY, .as.apply = {.name = type_strdup(name), .args = arg_copy, .arg_len = arg_len}});
 }
 
 static void type_arena_rewind(ZTypeArena *arena, size_t len) {
@@ -287,7 +354,7 @@ static bool parse_number_text(const char *text, unsigned long long *out) {
   return true;
 }
 
-bool z_static_value_parse(const char *text, ZStaticValue *out, ZTypeParseError *error) {
+static bool static_value_parse_inner(const char *text, const ZTypeBinderScope *scope, ZStaticValue *out, ZTypeParseError *error) {
   if (out) *out = (ZStaticValue){0};
   if (error) *error = (ZTypeParseError){0};
   char *trimmed = trimmed_copy(text ? text : "", strlen(text ? text : ""));
@@ -312,13 +379,24 @@ bool z_static_value_parse(const char *text, ZStaticValue *out, ZTypeParseError *
     return true;
   }
   if (static_symbol_text(trimmed)) {
-    if (out) *out = (ZStaticValue){.kind = Z_STATIC_VALUE_SYMBOL, .text = type_strdup(trimmed)};
+    const ZTypeBinderDecl *binder = type_binder_lookup(scope, trimmed, Z_TYPE_BINDER_STATIC);
+    if (binder) {
+      if (out) static_value_from_binder(binder, out);
+    } else if (out) *out = (ZStaticValue){.kind = Z_STATIC_VALUE_SYMBOL, .text = type_strdup(trimmed)};
     free(trimmed);
     return true;
   }
   if (error) snprintf(error->message, sizeof(error->message), "%s", "invalid static value");
   free(trimmed);
   return false;
+}
+
+bool z_static_value_parse(const char *text, ZStaticValue *out, ZTypeParseError *error) {
+  return static_value_parse_inner(text, NULL, out, error);
+}
+
+bool z_static_value_parse_with_binders(const char *text, const ZTypeBinderScope *scope, ZStaticValue *out, ZTypeParseError *error) {
+  return static_value_parse_inner(text, scope, out, error);
 }
 
 char *z_static_value_format(const ZStaticValue *value) {
@@ -353,7 +431,7 @@ static bool parse_type(TypeParser *parser, ZTypeArena *arena, ZTypeId *out);
 
 static bool parser_parse_static_value(TypeParser *parser, const char *text, size_t start, ZStaticValue *out) {
   ZTypeParseError static_error = {0};
-  bool ok = z_static_value_parse(text, out, &static_error);
+  bool ok = z_static_value_parse_with_binders(text, parser ? parser->scope : NULL, out, &static_error);
   if (!ok && parser && parser->error) {
     *parser->error = static_error;
     parser->error->offset = start + static_error.offset;
@@ -364,6 +442,24 @@ static bool parser_parse_static_value(TypeParser *parser, const char *text, size
 static bool parse_type_arg(TypeParser *parser, ZTypeArena *arena, ZTypeArg *out) {
   parser_skip_ws(parser);
   size_t start = parser->cursor;
+  if (ident_start(parser->text[parser->cursor])) {
+    size_t ident_end = parser->cursor + 1;
+    while (ident_continue(parser->text[ident_end])) ident_end++;
+    char *name = type_strndup(parser->text + parser->cursor, ident_end - parser->cursor);
+    const ZTypeBinderDecl *static_binder = type_binder_lookup(parser->scope, name, Z_TYPE_BINDER_STATIC);
+    size_t after_name = ident_end;
+    while (isspace((unsigned char)parser->text[after_name])) after_name++;
+    if (static_binder && (parser->text[after_name] == ',' || parser->text[after_name] == '>')) {
+      parser->cursor = after_name;
+      ZStaticValue value = {0};
+      bool ok = static_value_from_binder(static_binder, &value);
+      free(name);
+      if (!ok) return false;
+      *out = (ZTypeArg){.kind = Z_TYPE_ARG_STATIC, .as.static_value = value};
+      return true;
+    }
+    free(name);
+  }
   if (isdigit((unsigned char)parser->text[parser->cursor]) ||
       parser_keyword(parser, "true") ||
       parser_keyword(parser, "false")) {
@@ -402,7 +498,7 @@ static bool parse_type(TypeParser *parser, ZTypeArena *arena, ZTypeId *out) {
     parser->cursor += 5;
     ZTypeId inner = Z_TYPE_ID_INVALID;
     if (!parse_type(parser, arena, &inner)) return false;
-    *out = type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_CONST, .as.constant = {.inner = inner}});
+    *out = z_type_make_const(arena, inner);
     return *out != Z_TYPE_ID_INVALID;
   }
   if (parser->text[parser->cursor] == '[') {
@@ -422,7 +518,12 @@ static bool parse_type(TypeParser *parser, ZTypeArena *arena, ZTypeId *out) {
   if (!name) return false;
   parser_skip_ws(parser);
   if (parser->text[parser->cursor] != '<') {
-    *out = type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_NAME, .as.name = name});
+    const ZTypeBinderDecl *binder = type_binder_lookup(parser->scope, name, Z_TYPE_BINDER_TYPE);
+    if (binder) {
+      *out = type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_BINDER, .as.binder = {.name = name, .binder = binder->id}});
+    } else {
+      *out = type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_NAME, .as.name = name});
+    }
     return *out != Z_TYPE_ID_INVALID;
   }
   parser->cursor++;
@@ -471,14 +572,14 @@ static bool parse_type(TypeParser *parser, ZTypeArena *arena, ZTypeId *out) {
   return false;
 }
 
-bool z_type_parse(ZTypeArena *arena, const char *text, ZTypeId *out, ZTypeParseError *error) {
+static bool type_parse_inner(ZTypeArena *arena, const char *text, const ZTypeBinderScope *scope, ZTypeId *out, ZTypeParseError *error) {
   if (out) *out = Z_TYPE_ID_INVALID;
   if (error) *error = (ZTypeParseError){0};
   if (!arena) {
     if (error) snprintf(error->message, sizeof(error->message), "%s", "type arena is required");
     return false;
   }
-  TypeParser parser = {.text = text ? text : "", .error = error};
+  TypeParser parser = {.text = text ? text : "", .scope = scope, .error = error};
   ZTypeId type = Z_TYPE_ID_INVALID;
   size_t start_len = arena->len;
   if (!parse_type(&parser, arena, &type)) {
@@ -493,6 +594,14 @@ bool z_type_parse(ZTypeArena *arena, const char *text, ZTypeId *out, ZTypeParseE
   }
   if (out) *out = type;
   return true;
+}
+
+bool z_type_parse(ZTypeArena *arena, const char *text, ZTypeId *out, ZTypeParseError *error) {
+  return type_parse_inner(arena, text, NULL, out, error);
+}
+
+bool z_type_parse_with_binders(ZTypeArena *arena, const char *text, const ZTypeBinderScope *scope, ZTypeId *out, ZTypeParseError *error) {
+  return type_parse_inner(arena, text, scope, out, error);
 }
 
 static void type_format_into(const ZTypeArena *arena, ZTypeId type, TypeBuf *buf);
@@ -515,6 +624,8 @@ static void type_format_into(const ZTypeArena *arena, ZTypeId type, TypeBuf *buf
   }
   if (node->kind == Z_TYPE_NODE_NAME) {
     type_buf_append(buf, node->as.name);
+  } else if (node->kind == Z_TYPE_NODE_BINDER) {
+    type_buf_append(buf, node->as.binder.name);
   } else if (node->kind == Z_TYPE_NODE_CONST) {
     type_buf_append(buf, "const ");
     type_format_into(arena, node->as.constant.inner, buf);
@@ -540,17 +651,18 @@ char *z_type_format(const ZTypeArena *arena, ZTypeId type) {
   return buf.data ? buf.data : type_strdup("");
 }
 
-static bool static_value_equal(const ZStaticValue *left, const ZStaticValue *right) {
+bool z_static_value_equal(const ZStaticValue *left, const ZStaticValue *right) {
   if (!left || !right || left->kind != right->kind) return false;
   if (left->kind == Z_STATIC_VALUE_NUMBER) return left->number == right->number;
   if (left->kind == Z_STATIC_VALUE_BOOL) return left->boolean == right->boolean;
+  if (left->kind == Z_STATIC_VALUE_BINDER) return left->binder == right->binder;
   return strcmp(left->text ? left->text : "", right->text ? right->text : "") == 0;
 }
 
 static bool type_arg_equal(const ZTypeArena *arena, const ZTypeArg *left, const ZTypeArg *right) {
   if (!left || !right || left->kind != right->kind) return false;
   if (left->kind == Z_TYPE_ARG_TYPE) return z_type_equal(arena, left->as.type, right->as.type);
-  return static_value_equal(&left->as.static_value, &right->as.static_value);
+  return z_static_value_equal(&left->as.static_value, &right->as.static_value);
 }
 
 bool z_type_equal(const ZTypeArena *arena, ZTypeId left, ZTypeId right) {
@@ -559,9 +671,10 @@ bool z_type_equal(const ZTypeArena *arena, ZTypeId left, ZTypeId right) {
   const ZTypeNode *right_node = type_node(arena, right);
   if (!left_node || !right_node || left_node->kind != right_node->kind) return false;
   if (left_node->kind == Z_TYPE_NODE_NAME) return strcmp(left_node->as.name, right_node->as.name) == 0;
+  if (left_node->kind == Z_TYPE_NODE_BINDER) return left_node->as.binder.binder == right_node->as.binder.binder;
   if (left_node->kind == Z_TYPE_NODE_CONST) return z_type_equal(arena, left_node->as.constant.inner, right_node->as.constant.inner);
   if (left_node->kind == Z_TYPE_NODE_ARRAY) {
-    return static_value_equal(&left_node->as.array.length, &right_node->as.array.length) &&
+    return z_static_value_equal(&left_node->as.array.length, &right_node->as.array.length) &&
            z_type_equal(arena, left_node->as.array.element, right_node->as.array.element);
   }
   if (left_node->kind == Z_TYPE_NODE_APPLY) {
@@ -598,6 +711,7 @@ static uint64_t static_value_hash(const ZStaticValue *value) {
   hash = hash_u64(hash, (uint64_t)value->kind);
   if (value->kind == Z_STATIC_VALUE_NUMBER) return hash_u64(hash, value->number);
   if (value->kind == Z_STATIC_VALUE_BOOL) return hash_u64(hash, value->boolean ? 1 : 0);
+  if (value->kind == Z_STATIC_VALUE_BINDER) return hash_u64(hash, value->binder);
   return hash_bytes(hash, value->text);
 }
 
@@ -615,6 +729,7 @@ uint64_t z_type_hash(const ZTypeArena *arena, ZTypeId type) {
   if (!node) return hash;
   hash = hash_u64(hash, (uint64_t)node->kind);
   if (node->kind == Z_TYPE_NODE_NAME) return hash_bytes(hash, node->as.name);
+  if (node->kind == Z_TYPE_NODE_BINDER) return hash_u64(hash, node->as.binder.binder);
   if (node->kind == Z_TYPE_NODE_CONST) return hash_u64(hash, z_type_hash(arena, node->as.constant.inner));
   if (node->kind == Z_TYPE_NODE_ARRAY) {
     hash = hash_u64(hash, static_value_hash(&node->as.array.length));
@@ -627,4 +742,49 @@ uint64_t z_type_hash(const ZTypeArena *arena, ZTypeId type) {
     return hash;
   }
   return hash;
+}
+
+ZTypeNodeKind z_type_kind(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node ? node->kind : Z_TYPE_NODE_INVALID;
+}
+
+const char *z_type_name(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  if (!node) return NULL;
+  if (node->kind == Z_TYPE_NODE_NAME) return node->as.name;
+  if (node->kind == Z_TYPE_NODE_BINDER) return node->as.binder.name;
+  if (node->kind == Z_TYPE_NODE_APPLY) return node->as.apply.name;
+  return NULL;
+}
+
+ZTypeBinderId z_type_binder(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node && node->kind == Z_TYPE_NODE_BINDER ? node->as.binder.binder : Z_TYPE_BINDER_ID_INVALID;
+}
+
+ZTypeId z_type_const_inner(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node && node->kind == Z_TYPE_NODE_CONST ? node->as.constant.inner : Z_TYPE_ID_INVALID;
+}
+
+const ZStaticValue *z_type_array_length(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node && node->kind == Z_TYPE_NODE_ARRAY ? &node->as.array.length : NULL;
+}
+
+ZTypeId z_type_array_element(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node && node->kind == Z_TYPE_NODE_ARRAY ? node->as.array.element : Z_TYPE_ID_INVALID;
+}
+
+size_t z_type_apply_arg_len(const ZTypeArena *arena, ZTypeId type) {
+  const ZTypeNode *node = type_node(arena, type);
+  return node && node->kind == Z_TYPE_NODE_APPLY ? node->as.apply.arg_len : 0;
+}
+
+const ZTypeArg *z_type_apply_arg(const ZTypeArena *arena, ZTypeId type, size_t index) {
+  const ZTypeNode *node = type_node(arena, type);
+  if (!node || node->kind != Z_TYPE_NODE_APPLY || index >= node->as.apply.arg_len) return NULL;
+  return &node->as.apply.args[index];
 }

--- a/native/zero-c/src/type_core.c
+++ b/native/zero-c/src/type_core.c
@@ -210,7 +210,7 @@ ZTypeId z_type_make_apply(ZTypeArena *arena, const char *name, const ZTypeArg *a
   return type_arena_add(arena, (ZTypeNode){.kind = Z_TYPE_NODE_APPLY, .as.apply = {.name = type_strdup(name), .args = arg_copy, .arg_len = arg_len}});
 }
 
-static void type_arena_rewind(ZTypeArena *arena, size_t len) {
+void z_type_arena_truncate(ZTypeArena *arena, size_t len) {
   if (!arena || len > arena->len) return;
   for (size_t i = len; i < arena->len; i++) type_node_free(&arena->nodes[i]);
   arena->len = len;
@@ -265,7 +265,7 @@ static void parser_restore(TypeParser *parser, ZTypeArena *arena, TypeParserMark
     parser->cursor = mark.cursor;
     if (parser->error) *parser->error = mark.error;
   }
-  type_arena_rewind(arena, mark.arena_len);
+  z_type_arena_truncate(arena, mark.arena_len);
 }
 
 static bool static_symbol_text(const char *text) {
@@ -589,13 +589,13 @@ static bool type_parse_inner(ZTypeArena *arena, const char *text, const ZTypeBin
   ZTypeId type = Z_TYPE_ID_INVALID;
   size_t start_len = arena->len;
   if (!parse_type(&parser, arena, &type)) {
-    type_arena_rewind(arena, start_len);
+    z_type_arena_truncate(arena, start_len);
     return false;
   }
   parser_skip_ws(&parser);
   if (parser.text[parser.cursor] != 0) {
     parser_error(&parser, "unexpected trailing type syntax");
-    type_arena_rewind(arena, start_len);
+    z_type_arena_truncate(arena, start_len);
     return false;
   }
   if (out) *out = type;

--- a/native/zero-c/src/type_core.h
+++ b/native/zero-c/src/type_core.h
@@ -39,6 +39,7 @@ typedef enum {
 typedef struct {
   ZStaticValueKind kind;
   char *text;
+  char *static_type;
   ZTypeBinderId binder;
   unsigned long long number;
   bool boolean;

--- a/native/zero-c/src/type_core.h
+++ b/native/zero-c/src/type_core.h
@@ -6,19 +6,40 @@
 #include <stdint.h>
 
 typedef uint32_t ZTypeId;
+typedef uint32_t ZTypeBinderId;
 
 #define Z_TYPE_ID_INVALID ((ZTypeId)0)
+#define Z_TYPE_BINDER_ID_INVALID ((ZTypeBinderId)0)
+
+typedef enum {
+  Z_TYPE_BINDER_TYPE,
+  Z_TYPE_BINDER_STATIC
+} ZTypeBinderKind;
+
+typedef struct {
+  const char *name;
+  ZTypeBinderKind kind;
+  ZTypeBinderId id;
+  const char *static_type;
+} ZTypeBinderDecl;
+
+typedef struct {
+  const ZTypeBinderDecl *items;
+  size_t len;
+} ZTypeBinderScope;
 
 typedef enum {
   Z_STATIC_VALUE_INVALID,
   Z_STATIC_VALUE_NUMBER,
   Z_STATIC_VALUE_BOOL,
-  Z_STATIC_VALUE_SYMBOL
+  Z_STATIC_VALUE_SYMBOL,
+  Z_STATIC_VALUE_BINDER
 } ZStaticValueKind;
 
 typedef struct {
   ZStaticValueKind kind;
   char *text;
+  ZTypeBinderId binder;
   unsigned long long number;
   bool boolean;
 } ZStaticValue;
@@ -26,6 +47,7 @@ typedef struct {
 typedef enum {
   Z_TYPE_NODE_INVALID,
   Z_TYPE_NODE_NAME,
+  Z_TYPE_NODE_BINDER,
   Z_TYPE_NODE_CONST,
   Z_TYPE_NODE_ARRAY,
   Z_TYPE_NODE_APPLY
@@ -61,12 +83,31 @@ void z_type_arena_init(ZTypeArena *arena);
 void z_type_arena_free(ZTypeArena *arena);
 
 bool z_static_value_parse(const char *text, ZStaticValue *out, ZTypeParseError *error);
+bool z_static_value_parse_with_binders(const char *text, const ZTypeBinderScope *scope, ZStaticValue *out, ZTypeParseError *error);
 char *z_static_value_format(const ZStaticValue *value);
+bool z_static_value_clone(const ZStaticValue *source, ZStaticValue *out);
+bool z_static_value_equal(const ZStaticValue *left, const ZStaticValue *right);
 void z_static_value_free(ZStaticValue *value);
 
 bool z_type_parse(ZTypeArena *arena, const char *text, ZTypeId *out, ZTypeParseError *error);
+bool z_type_parse_with_binders(ZTypeArena *arena, const char *text, const ZTypeBinderScope *scope, ZTypeId *out, ZTypeParseError *error);
 char *z_type_format(const ZTypeArena *arena, ZTypeId type);
 bool z_type_equal(const ZTypeArena *arena, ZTypeId left, ZTypeId right);
 uint64_t z_type_hash(const ZTypeArena *arena, ZTypeId type);
+
+ZTypeId z_type_make_name(ZTypeArena *arena, const char *name);
+ZTypeId z_type_make_binder(ZTypeArena *arena, const char *name, ZTypeBinderId binder);
+ZTypeId z_type_make_const(ZTypeArena *arena, ZTypeId inner);
+ZTypeId z_type_make_array(ZTypeArena *arena, const ZStaticValue *length, ZTypeId element);
+ZTypeId z_type_make_apply(ZTypeArena *arena, const char *name, const ZTypeArg *args, size_t arg_len);
+
+ZTypeNodeKind z_type_kind(const ZTypeArena *arena, ZTypeId type);
+const char *z_type_name(const ZTypeArena *arena, ZTypeId type);
+ZTypeBinderId z_type_binder(const ZTypeArena *arena, ZTypeId type);
+ZTypeId z_type_const_inner(const ZTypeArena *arena, ZTypeId type);
+const ZStaticValue *z_type_array_length(const ZTypeArena *arena, ZTypeId type);
+ZTypeId z_type_array_element(const ZTypeArena *arena, ZTypeId type);
+size_t z_type_apply_arg_len(const ZTypeArena *arena, ZTypeId type);
+const ZTypeArg *z_type_apply_arg(const ZTypeArena *arena, ZTypeId type, size_t index);
 
 #endif

--- a/native/zero-c/src/type_core.h
+++ b/native/zero-c/src/type_core.h
@@ -82,6 +82,7 @@ typedef struct {
 
 void z_type_arena_init(ZTypeArena *arena);
 void z_type_arena_free(ZTypeArena *arena);
+void z_type_arena_truncate(ZTypeArena *arena, size_t len);
 
 bool z_static_value_parse(const char *text, ZStaticValue *out, ZTypeParseError *error);
 bool z_static_value_parse_with_binders(const char *text, const ZTypeBinderScope *scope, ZStaticValue *out, ZTypeParseError *error);

--- a/native/zero-c/src/unify.c
+++ b/native/zero-c/src/unify.c
@@ -188,11 +188,47 @@ static bool static_binder_alias_resolves_to(const ZUnifyTrace *trace, const ZSta
   return static_binder_alias_resolves_to(trace, &binding->static_value, target, next_path, next_len);
 }
 
+static const char *static_type_or_default(const char *type) {
+  return type && type[0] ? type : "usize";
+}
+
+static const char *static_value_binder_type(const ZStaticValue *value) {
+  return static_type_or_default(value ? value->static_type : NULL);
+}
+
+static bool static_type_is_integer(const char *type) {
+  type = static_type_or_default(type);
+  return strcmp(type, "usize") == 0 || strcmp(type, "isize") == 0 ||
+         strcmp(type, "u8") == 0 || strcmp(type, "u16") == 0 || strcmp(type, "u32") == 0 || strcmp(type, "u64") == 0 ||
+         strcmp(type, "i8") == 0 || strcmp(type, "i16") == 0 || strcmp(type, "i32") == 0 || strcmp(type, "i64") == 0;
+}
+
+static bool static_type_compatible(const char *left, const char *right) {
+  return strcmp(static_type_or_default(left), static_type_or_default(right)) == 0;
+}
+
+static bool static_symbol_matches_type(const ZStaticValue *value, const char *type) {
+  if (!value || value->kind != Z_STATIC_VALUE_SYMBOL || !value->text) return false;
+  type = static_type_or_default(type);
+  size_t type_len = strlen(type);
+  return strncmp(value->text, type, type_len) == 0 && value->text[type_len] == '.' && value->text[type_len + 1] != 0;
+}
+
+static bool static_value_matches_type(const ZStaticValue *value, const char *type) {
+  if (!value) return false;
+  type = static_type_or_default(type);
+  if (value->kind == Z_STATIC_VALUE_BINDER) return static_type_compatible(type, static_value_binder_type(value));
+  if (static_type_is_integer(type)) return value->kind == Z_STATIC_VALUE_NUMBER;
+  if (strcmp(type, "Bool") == 0) return value->kind == Z_STATIC_VALUE_BOOL;
+  return static_symbol_matches_type(value, type);
+}
+
 static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *actual, ZUnifyTrace *trace);
 
-static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, const ZStaticValue *value) {
+static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, const char *static_type, const ZStaticValue *value) {
   if (binder == Z_TYPE_BINDER_ID_INVALID || !value) return unify_fail(trace, "invalid static binding");
   if (value->kind == Z_STATIC_VALUE_BINDER && value->binder == binder) return true;
+  if (!static_value_matches_type(value, static_type)) return unify_fail(trace, "static value does not match binder type");
   ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_STATIC);
   if (existing) return static_value_unify(&existing->static_value, value, trace);
   if (static_binder_alias_resolves_to(trace, value, binder, NULL, 0)) return true;
@@ -207,8 +243,8 @@ static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId bind
 
 static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *actual, ZUnifyTrace *trace) {
   if (!pattern || !actual) return unify_fail(trace, "missing static value");
-  if (pattern->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, pattern->text, pattern->binder, actual);
-  if (actual->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, actual->text, actual->binder, pattern);
+  if (pattern->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, pattern->text, pattern->binder, pattern->static_type, actual);
+  if (actual->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, actual->text, actual->binder, actual->static_type, pattern);
   if (z_static_value_equal(pattern, actual)) return true;
   return unify_fail(trace, "static values do not unify");
 }
@@ -350,15 +386,11 @@ static bool type_unify_inner(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual,
 
 bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {
   size_t start_len = trace ? trace->len : 0;
-  char prior_message[sizeof(trace->message)];
-  if (trace) {
-    memcpy(prior_message, trace->message, sizeof(prior_message));
-    trace->message[0] = 0;
-  }
+  if (trace) trace->message[0] = 0;
 
   bool ok = type_unify_inner(arena, pattern, actual, trace);
   if (ok) {
-    if (trace) memcpy(trace->message, prior_message, sizeof(prior_message));
+    if (trace) trace->message[0] = 0;
     return true;
   }
 

--- a/native/zero-c/src/unify.c
+++ b/native/zero-c/src/unify.c
@@ -4,6 +4,8 @@
 #include <stdlib.h>
 #include <string.h>
 
+#define UNIFY_BINDER_PATH_MAX 64
+
 static void *unify_reallocarray(void *ptr, size_t count, size_t size) {
   if (size != 0 && count > ((size_t)-1) / size) abort();
   void *next = realloc(ptr, count * size);
@@ -93,12 +95,66 @@ bool z_type_occurs(const ZTypeArena *arena, ZTypeId type, ZTypeBinderId binder) 
   return false;
 }
 
+static bool binder_path_contains(const ZTypeBinderId *path, size_t len, ZTypeBinderId binder) {
+  for (size_t i = 0; i < len; i++) {
+    if (path[i] == binder) return true;
+  }
+  return false;
+}
+
+static bool binder_path_push(const ZTypeBinderId *path, size_t path_len, ZTypeBinderId binder, ZTypeBinderId out[UNIFY_BINDER_PATH_MAX], size_t *out_len) {
+  if (path_len >= UNIFY_BINDER_PATH_MAX) return false;
+  for (size_t i = 0; i < path_len; i++) out[i] = path[i];
+  out[path_len] = binder;
+  if (out_len) *out_len = path_len + 1;
+  return true;
+}
+
+static bool binder_alias_resolves_to(const ZTypeArena *arena, const ZUnifyTrace *trace, ZTypeId type, ZTypeBinderId target, const ZTypeBinderId *path, size_t path_len) {
+  if (target == Z_TYPE_BINDER_ID_INVALID || z_type_kind(arena, type) != Z_TYPE_NODE_BINDER) return false;
+  ZTypeBinderId binder = z_type_binder(arena, type);
+  if (binder == target) return true;
+  if (binder_path_contains(path, path_len, binder)) return false;
+  const ZUnifyBinding *binding = z_unify_trace_lookup(trace, binder, Z_UNIFY_BINDING_TYPE);
+  if (!binding || z_type_kind(arena, binding->type) != Z_TYPE_NODE_BINDER) return false;
+  ZTypeBinderId next_path[UNIFY_BINDER_PATH_MAX];
+  size_t next_len = 0;
+  if (!binder_path_push(path, path_len, binder, next_path, &next_len)) return false;
+  return binder_alias_resolves_to(arena, trace, binding->type, target, next_path, next_len);
+}
+
+static bool type_binding_occurs_resolved(const ZTypeArena *arena, const ZUnifyTrace *trace, ZTypeId type, ZTypeBinderId binder, const ZTypeBinderId *path, size_t path_len) {
+  if (binder == Z_TYPE_BINDER_ID_INVALID) return false;
+  ZTypeNodeKind kind = z_type_kind(arena, type);
+  if (kind == Z_TYPE_NODE_BINDER) {
+    ZTypeBinderId found = z_type_binder(arena, type);
+    if (found == binder) return true;
+    if (binder_path_contains(path, path_len, found)) return false;
+    const ZUnifyBinding *binding = z_unify_trace_lookup(trace, found, Z_UNIFY_BINDING_TYPE);
+    if (!binding) return false;
+    ZTypeBinderId next_path[UNIFY_BINDER_PATH_MAX];
+    size_t next_len = 0;
+    if (!binder_path_push(path, path_len, found, next_path, &next_len)) return true;
+    return type_binding_occurs_resolved(arena, trace, binding->type, binder, next_path, next_len);
+  }
+  if (kind == Z_TYPE_NODE_CONST) return type_binding_occurs_resolved(arena, trace, z_type_const_inner(arena, type), binder, path, path_len);
+  if (kind == Z_TYPE_NODE_ARRAY) return type_binding_occurs_resolved(arena, trace, z_type_array_element(arena, type), binder, path, path_len);
+  if (kind == Z_TYPE_NODE_APPLY) {
+    for (size_t i = 0; i < z_type_apply_arg_len(arena, type); i++) {
+      const ZTypeArg *arg = z_type_apply_arg(arena, type, i);
+      if (arg && arg->kind == Z_TYPE_ARG_TYPE && type_binding_occurs_resolved(arena, trace, arg->as.type, binder, path, path_len)) return true;
+    }
+  }
+  return false;
+}
+
 static bool bind_type(ZTypeArena *arena, ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, ZTypeId type) {
   if (binder == Z_TYPE_BINDER_ID_INVALID || type == Z_TYPE_ID_INVALID) return unify_fail(trace, "invalid type binding");
   if (z_type_kind(arena, type) == Z_TYPE_NODE_BINDER && z_type_binder(arena, type) == binder) return true;
   ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_TYPE);
   if (existing) return z_type_unify(arena, existing->type, type, trace);
-  if (z_type_occurs(arena, type, binder)) return unify_fail(trace, "recursive type binding rejected by occurs check");
+  if (binder_alias_resolves_to(arena, trace, type, binder, NULL, 0)) return true;
+  if (type_binding_occurs_resolved(arena, trace, type, binder, NULL, 0)) return unify_fail(trace, "recursive type binding rejected by occurs check");
   ZUnifyBinding *binding = unify_trace_push(trace);
   if (!binding) return unify_fail(trace, "unification trace is required");
   binding->binder = binder;
@@ -108,14 +164,26 @@ static bool bind_type(ZTypeArena *arena, ZUnifyTrace *trace, const char *name, Z
   return true;
 }
 
+static bool static_binder_alias_resolves_to(const ZUnifyTrace *trace, const ZStaticValue *value, ZTypeBinderId target, const ZTypeBinderId *path, size_t path_len) {
+  if (target == Z_TYPE_BINDER_ID_INVALID || !value || value->kind != Z_STATIC_VALUE_BINDER) return false;
+  if (value->binder == target) return true;
+  if (binder_path_contains(path, path_len, value->binder)) return false;
+  const ZUnifyBinding *binding = z_unify_trace_lookup(trace, value->binder, Z_UNIFY_BINDING_STATIC);
+  if (!binding || binding->static_value.kind != Z_STATIC_VALUE_BINDER) return false;
+  ZTypeBinderId next_path[UNIFY_BINDER_PATH_MAX];
+  size_t next_len = 0;
+  if (!binder_path_push(path, path_len, value->binder, next_path, &next_len)) return false;
+  return static_binder_alias_resolves_to(trace, &binding->static_value, target, next_path, next_len);
+}
+
+static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *actual, ZUnifyTrace *trace);
+
 static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, const ZStaticValue *value) {
   if (binder == Z_TYPE_BINDER_ID_INVALID || !value) return unify_fail(trace, "invalid static binding");
   if (value->kind == Z_STATIC_VALUE_BINDER && value->binder == binder) return true;
   ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_STATIC);
-  if (existing) {
-    if (z_static_value_equal(&existing->static_value, value)) return true;
-    return unify_fail(trace, "conflicting static generic binding");
-  }
+  if (existing) return static_value_unify(&existing->static_value, value, trace);
+  if (static_binder_alias_resolves_to(trace, value, binder, NULL, 0)) return true;
   ZUnifyBinding *binding = unify_trace_push(trace);
   if (!binding) return unify_fail(trace, "unification trace is required");
   binding->binder = binder;
@@ -132,13 +200,23 @@ static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *
   return unify_fail(trace, "static values do not unify");
 }
 
-static bool substitute_static_value(const ZStaticValue *source, const ZUnifyTrace *trace, ZStaticValue *out) {
+static bool substitute_static_value_inner(const ZStaticValue *source, const ZUnifyTrace *trace, ZStaticValue *out, const ZTypeBinderId *path, size_t path_len) {
   if (!source || !out) return false;
   if (source->kind == Z_STATIC_VALUE_BINDER) {
+    if (binder_path_contains(path, path_len, source->binder)) return false;
     const ZUnifyBinding *binding = z_unify_trace_lookup(trace, source->binder, Z_UNIFY_BINDING_STATIC);
-    if (binding) return z_static_value_clone(&binding->static_value, out);
+    if (binding) {
+      ZTypeBinderId next_path[UNIFY_BINDER_PATH_MAX];
+      size_t next_len = 0;
+      if (!binder_path_push(path, path_len, source->binder, next_path, &next_len)) return false;
+      return substitute_static_value_inner(&binding->static_value, trace, out, next_path, next_len);
+    }
   }
   return z_static_value_clone(source, out);
+}
+
+static bool substitute_static_value(const ZStaticValue *source, const ZUnifyTrace *trace, ZStaticValue *out) {
+  return substitute_static_value_inner(source, trace, out, NULL, 0);
 }
 
 static void free_type_arg_copy(ZTypeArg *args, size_t len) {
@@ -149,16 +227,19 @@ static void free_type_arg_copy(ZTypeArg *args, size_t len) {
   free(args);
 }
 
-bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out) {
+static bool type_substitute_inner(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out, const ZTypeBinderId *path, size_t path_len) {
   if (out) *out = Z_TYPE_ID_INVALID;
   ZTypeNodeKind kind = z_type_kind(arena, source);
   if (kind == Z_TYPE_NODE_INVALID) return false;
   if (kind == Z_TYPE_NODE_BINDER) {
     ZTypeBinderId binder = z_type_binder(arena, source);
+    if (binder_path_contains(path, path_len, binder)) return false;
     const ZUnifyBinding *binding = z_unify_trace_lookup(trace, binder, Z_UNIFY_BINDING_TYPE);
     if (binding) {
-      if (out) *out = binding->type;
-      return true;
+      ZTypeBinderId next_path[UNIFY_BINDER_PATH_MAX];
+      size_t next_len = 0;
+      if (!binder_path_push(path, path_len, binder, next_path, &next_len)) return false;
+      return type_substitute_inner(arena, binding->type, trace, out, next_path, next_len);
     }
     ZTypeId clone = z_type_make_binder(arena, z_type_name(arena, source), binder);
     if (out) *out = clone;
@@ -171,7 +252,7 @@ bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *tra
   }
   if (kind == Z_TYPE_NODE_CONST) {
     ZTypeId inner = Z_TYPE_ID_INVALID;
-    if (!z_type_substitute(arena, z_type_const_inner(arena, source), trace, &inner)) return false;
+    if (!type_substitute_inner(arena, z_type_const_inner(arena, source), trace, &inner, path, path_len)) return false;
     ZTypeId clone = z_type_make_const(arena, inner);
     if (out) *out = clone;
     return clone != Z_TYPE_ID_INVALID;
@@ -180,7 +261,7 @@ bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *tra
     ZStaticValue length = {0};
     ZTypeId element = Z_TYPE_ID_INVALID;
     if (!substitute_static_value(z_type_array_length(arena, source), trace, &length)) return false;
-    bool ok = z_type_substitute(arena, z_type_array_element(arena, source), trace, &element);
+    bool ok = type_substitute_inner(arena, z_type_array_element(arena, source), trace, &element, path, path_len);
     if (!ok) {
       z_static_value_free(&length);
       return false;
@@ -199,7 +280,7 @@ bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *tra
       args[i] = *arg;
       if (arg->kind == Z_TYPE_ARG_TYPE) {
         args[i].as.type = Z_TYPE_ID_INVALID;
-        ok = z_type_substitute(arena, arg->as.type, trace, &args[i].as.type);
+        ok = type_substitute_inner(arena, arg->as.type, trace, &args[i].as.type, path, path_len);
       } else {
         args[i].as.static_value = (ZStaticValue){0};
         ok = substitute_static_value(&arg->as.static_value, trace, &args[i].as.static_value);
@@ -211,6 +292,10 @@ bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *tra
     return clone != Z_TYPE_ID_INVALID;
   }
   return false;
+}
+
+bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out) {
+  return type_substitute_inner(arena, source, trace, out, NULL, 0);
 }
 
 bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {

--- a/native/zero-c/src/unify.c
+++ b/native/zero-c/src/unify.c
@@ -1,0 +1,250 @@
+#include "unify.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static void *unify_reallocarray(void *ptr, size_t count, size_t size) {
+  if (size != 0 && count > ((size_t)-1) / size) abort();
+  void *next = realloc(ptr, count * size);
+  if (!next) abort();
+  return next;
+}
+
+static char *unify_strdup(const char *text) {
+  size_t len = strlen(text ? text : "");
+  char *out = malloc(len + 1);
+  if (!out) abort();
+  memcpy(out, text ? text : "", len);
+  out[len] = 0;
+  return out;
+}
+
+static bool unify_fail(ZUnifyTrace *trace, const char *message) {
+  if (trace && !trace->message[0]) snprintf(trace->message, sizeof(trace->message), "%s", message ? message : "types do not unify");
+  return false;
+}
+
+void z_unify_trace_init(ZUnifyTrace *trace) {
+  if (trace) *trace = (ZUnifyTrace){0};
+}
+
+void z_unify_trace_free(ZUnifyTrace *trace) {
+  if (!trace) return;
+  for (size_t i = 0; i < trace->len; i++) {
+    free(trace->items[i].name);
+    if (trace->items[i].kind == Z_UNIFY_BINDING_STATIC) z_static_value_free(&trace->items[i].static_value);
+  }
+  free(trace->items);
+  *trace = (ZUnifyTrace){0};
+}
+
+const ZUnifyBinding *z_unify_trace_lookup(const ZUnifyTrace *trace, ZTypeBinderId binder, ZUnifyBindingKind kind) {
+  if (!trace || binder == Z_TYPE_BINDER_ID_INVALID) return NULL;
+  for (size_t i = 0; i < trace->len; i++) {
+    if (trace->items[i].binder == binder && trace->items[i].kind == kind) return &trace->items[i];
+  }
+  return NULL;
+}
+
+static ZUnifyBinding *unify_trace_lookup_mut(ZUnifyTrace *trace, ZTypeBinderId binder, ZUnifyBindingKind kind) {
+  if (!trace || binder == Z_TYPE_BINDER_ID_INVALID) return NULL;
+  for (size_t i = 0; i < trace->len; i++) {
+    if (trace->items[i].binder == binder && trace->items[i].kind == kind) return &trace->items[i];
+  }
+  return NULL;
+}
+
+static ZUnifyBinding *unify_trace_push(ZUnifyTrace *trace) {
+  if (!trace) return NULL;
+  if (trace->len + 1 > trace->cap) {
+    size_t next = trace->cap ? trace->cap * 2 : 8;
+    trace->items = unify_reallocarray(trace->items, next, sizeof(ZUnifyBinding));
+    trace->cap = next;
+  }
+  trace->items[trace->len] = (ZUnifyBinding){0};
+  return &trace->items[trace->len++];
+}
+
+static bool static_value_occurs(const ZStaticValue *value, ZTypeBinderId binder) {
+  return value && value->kind == Z_STATIC_VALUE_BINDER && value->binder == binder;
+}
+
+static bool type_arg_occurs(const ZTypeArena *arena, const ZTypeArg *arg, ZTypeBinderId binder) {
+  if (!arg) return false;
+  if (arg->kind == Z_TYPE_ARG_STATIC) return static_value_occurs(&arg->as.static_value, binder);
+  return z_type_occurs(arena, arg->as.type, binder);
+}
+
+bool z_type_occurs(const ZTypeArena *arena, ZTypeId type, ZTypeBinderId binder) {
+  if (binder == Z_TYPE_BINDER_ID_INVALID) return false;
+  ZTypeNodeKind kind = z_type_kind(arena, type);
+  if (kind == Z_TYPE_NODE_BINDER) return z_type_binder(arena, type) == binder;
+  if (kind == Z_TYPE_NODE_CONST) return z_type_occurs(arena, z_type_const_inner(arena, type), binder);
+  if (kind == Z_TYPE_NODE_ARRAY) {
+    return static_value_occurs(z_type_array_length(arena, type), binder) ||
+           z_type_occurs(arena, z_type_array_element(arena, type), binder);
+  }
+  if (kind == Z_TYPE_NODE_APPLY) {
+    for (size_t i = 0; i < z_type_apply_arg_len(arena, type); i++) {
+      if (type_arg_occurs(arena, z_type_apply_arg(arena, type, i), binder)) return true;
+    }
+  }
+  return false;
+}
+
+static bool bind_type(ZTypeArena *arena, ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, ZTypeId type) {
+  if (binder == Z_TYPE_BINDER_ID_INVALID || type == Z_TYPE_ID_INVALID) return unify_fail(trace, "invalid type binding");
+  if (z_type_kind(arena, type) == Z_TYPE_NODE_BINDER && z_type_binder(arena, type) == binder) return true;
+  ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_TYPE);
+  if (existing) return z_type_unify(arena, existing->type, type, trace);
+  if (z_type_occurs(arena, type, binder)) return unify_fail(trace, "recursive type binding rejected by occurs check");
+  ZUnifyBinding *binding = unify_trace_push(trace);
+  if (!binding) return unify_fail(trace, "unification trace is required");
+  binding->binder = binder;
+  binding->kind = Z_UNIFY_BINDING_TYPE;
+  binding->name = unify_strdup(name ? name : "");
+  binding->type = type;
+  return true;
+}
+
+static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, const ZStaticValue *value) {
+  if (binder == Z_TYPE_BINDER_ID_INVALID || !value) return unify_fail(trace, "invalid static binding");
+  if (value->kind == Z_STATIC_VALUE_BINDER && value->binder == binder) return true;
+  ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_STATIC);
+  if (existing) {
+    if (z_static_value_equal(&existing->static_value, value)) return true;
+    return unify_fail(trace, "conflicting static generic binding");
+  }
+  ZUnifyBinding *binding = unify_trace_push(trace);
+  if (!binding) return unify_fail(trace, "unification trace is required");
+  binding->binder = binder;
+  binding->kind = Z_UNIFY_BINDING_STATIC;
+  binding->name = unify_strdup(name ? name : "");
+  if (!z_static_value_clone(value, &binding->static_value)) return unify_fail(trace, "could not copy static binding");
+  return true;
+}
+
+static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *actual, ZUnifyTrace *trace) {
+  if (!pattern || !actual) return unify_fail(trace, "missing static value");
+  if (pattern->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, pattern->text, pattern->binder, actual);
+  if (z_static_value_equal(pattern, actual)) return true;
+  return unify_fail(trace, "static values do not unify");
+}
+
+static bool substitute_static_value(const ZStaticValue *source, const ZUnifyTrace *trace, ZStaticValue *out) {
+  if (!source || !out) return false;
+  if (source->kind == Z_STATIC_VALUE_BINDER) {
+    const ZUnifyBinding *binding = z_unify_trace_lookup(trace, source->binder, Z_UNIFY_BINDING_STATIC);
+    if (binding) return z_static_value_clone(&binding->static_value, out);
+  }
+  return z_static_value_clone(source, out);
+}
+
+static void free_type_arg_copy(ZTypeArg *args, size_t len) {
+  if (!args) return;
+  for (size_t i = 0; i < len; i++) {
+    if (args[i].kind == Z_TYPE_ARG_STATIC) z_static_value_free(&args[i].as.static_value);
+  }
+  free(args);
+}
+
+bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out) {
+  if (out) *out = Z_TYPE_ID_INVALID;
+  ZTypeNodeKind kind = z_type_kind(arena, source);
+  if (kind == Z_TYPE_NODE_INVALID) return false;
+  if (kind == Z_TYPE_NODE_BINDER) {
+    ZTypeBinderId binder = z_type_binder(arena, source);
+    const ZUnifyBinding *binding = z_unify_trace_lookup(trace, binder, Z_UNIFY_BINDING_TYPE);
+    if (binding) {
+      if (out) *out = binding->type;
+      return true;
+    }
+    ZTypeId clone = z_type_make_binder(arena, z_type_name(arena, source), binder);
+    if (out) *out = clone;
+    return clone != Z_TYPE_ID_INVALID;
+  }
+  if (kind == Z_TYPE_NODE_NAME) {
+    ZTypeId clone = z_type_make_name(arena, z_type_name(arena, source));
+    if (out) *out = clone;
+    return clone != Z_TYPE_ID_INVALID;
+  }
+  if (kind == Z_TYPE_NODE_CONST) {
+    ZTypeId inner = Z_TYPE_ID_INVALID;
+    if (!z_type_substitute(arena, z_type_const_inner(arena, source), trace, &inner)) return false;
+    ZTypeId clone = z_type_make_const(arena, inner);
+    if (out) *out = clone;
+    return clone != Z_TYPE_ID_INVALID;
+  }
+  if (kind == Z_TYPE_NODE_ARRAY) {
+    ZStaticValue length = {0};
+    ZTypeId element = Z_TYPE_ID_INVALID;
+    if (!substitute_static_value(z_type_array_length(arena, source), trace, &length)) return false;
+    bool ok = z_type_substitute(arena, z_type_array_element(arena, source), trace, &element);
+    if (!ok) {
+      z_static_value_free(&length);
+      return false;
+    }
+    ZTypeId clone = z_type_make_array(arena, &length, element);
+    z_static_value_free(&length);
+    if (out) *out = clone;
+    return clone != Z_TYPE_ID_INVALID;
+  }
+  if (kind == Z_TYPE_NODE_APPLY) {
+    size_t arg_len = z_type_apply_arg_len(arena, source);
+    ZTypeArg *args = arg_len ? unify_reallocarray(NULL, arg_len, sizeof(ZTypeArg)) : NULL;
+    bool ok = true;
+    for (size_t i = 0; i < arg_len && ok; i++) {
+      const ZTypeArg *arg = z_type_apply_arg(arena, source, i);
+      args[i] = *arg;
+      if (arg->kind == Z_TYPE_ARG_TYPE) {
+        args[i].as.type = Z_TYPE_ID_INVALID;
+        ok = z_type_substitute(arena, arg->as.type, trace, &args[i].as.type);
+      } else {
+        args[i].as.static_value = (ZStaticValue){0};
+        ok = substitute_static_value(&arg->as.static_value, trace, &args[i].as.static_value);
+      }
+    }
+    ZTypeId clone = ok ? z_type_make_apply(arena, z_type_name(arena, source), args, arg_len) : Z_TYPE_ID_INVALID;
+    free_type_arg_copy(args, arg_len);
+    if (out) *out = clone;
+    return clone != Z_TYPE_ID_INVALID;
+  }
+  return false;
+}
+
+bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {
+  ZTypeNodeKind pattern_kind = z_type_kind(arena, pattern);
+  ZTypeNodeKind actual_kind = z_type_kind(arena, actual);
+  if (pattern_kind == Z_TYPE_NODE_INVALID || actual_kind == Z_TYPE_NODE_INVALID) return unify_fail(trace, "invalid type id");
+  if (pattern_kind == Z_TYPE_NODE_BINDER) return bind_type(arena, trace, z_type_name(arena, pattern), z_type_binder(arena, pattern), actual);
+  if (pattern_kind != actual_kind) return unify_fail(trace, "type shapes do not match");
+  if (pattern_kind == Z_TYPE_NODE_NAME) {
+    return strcmp(z_type_name(arena, pattern), z_type_name(arena, actual)) == 0 ? true : unify_fail(trace, "type names do not match");
+  }
+  if (pattern_kind == Z_TYPE_NODE_CONST) {
+    return z_type_unify(arena, z_type_const_inner(arena, pattern), z_type_const_inner(arena, actual), trace);
+  }
+  if (pattern_kind == Z_TYPE_NODE_ARRAY) {
+    return static_value_unify(z_type_array_length(arena, pattern), z_type_array_length(arena, actual), trace) &&
+           z_type_unify(arena, z_type_array_element(arena, pattern), z_type_array_element(arena, actual), trace);
+  }
+  if (pattern_kind == Z_TYPE_NODE_APPLY) {
+    if (strcmp(z_type_name(arena, pattern), z_type_name(arena, actual)) != 0 ||
+        z_type_apply_arg_len(arena, pattern) != z_type_apply_arg_len(arena, actual)) {
+      return unify_fail(trace, "generic type heads do not match");
+    }
+    for (size_t i = 0; i < z_type_apply_arg_len(arena, pattern); i++) {
+      const ZTypeArg *pattern_arg = z_type_apply_arg(arena, pattern, i);
+      const ZTypeArg *actual_arg = z_type_apply_arg(arena, actual, i);
+      if (!pattern_arg || !actual_arg || pattern_arg->kind != actual_arg->kind) return unify_fail(trace, "generic type argument kinds do not match");
+      if (pattern_arg->kind == Z_TYPE_ARG_TYPE) {
+        if (!z_type_unify(arena, pattern_arg->as.type, actual_arg->as.type, trace)) return false;
+      } else if (!static_value_unify(&pattern_arg->as.static_value, &actual_arg->as.static_value, trace)) {
+        return false;
+      }
+    }
+    return true;
+  }
+  return unify_fail(trace, "unsupported type node");
+}

--- a/native/zero-c/src/unify.c
+++ b/native/zero-c/src/unify.c
@@ -27,16 +27,26 @@ static bool unify_fail(ZUnifyTrace *trace, const char *message) {
   return false;
 }
 
+static void unify_binding_free(ZUnifyBinding *binding) {
+  if (!binding) return;
+  free(binding->name);
+  if (binding->kind == Z_UNIFY_BINDING_STATIC) z_static_value_free(&binding->static_value);
+  *binding = (ZUnifyBinding){0};
+}
+
+static void unify_trace_truncate(ZUnifyTrace *trace, size_t len) {
+  if (!trace || len > trace->len) return;
+  for (size_t i = len; i < trace->len; i++) unify_binding_free(&trace->items[i]);
+  trace->len = len;
+}
+
 void z_unify_trace_init(ZUnifyTrace *trace) {
   if (trace) *trace = (ZUnifyTrace){0};
 }
 
 void z_unify_trace_free(ZUnifyTrace *trace) {
   if (!trace) return;
-  for (size_t i = 0; i < trace->len; i++) {
-    free(trace->items[i].name);
-    if (trace->items[i].kind == Z_UNIFY_BINDING_STATIC) z_static_value_free(&trace->items[i].static_value);
-  }
+  unify_trace_truncate(trace, 0);
   free(trace->items);
   *trace = (ZUnifyTrace){0};
 }
@@ -148,11 +158,13 @@ static bool type_binding_occurs_resolved(const ZTypeArena *arena, const ZUnifyTr
   return false;
 }
 
+static bool type_unify_inner(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace);
+
 static bool bind_type(ZTypeArena *arena, ZUnifyTrace *trace, const char *name, ZTypeBinderId binder, ZTypeId type) {
   if (binder == Z_TYPE_BINDER_ID_INVALID || type == Z_TYPE_ID_INVALID) return unify_fail(trace, "invalid type binding");
   if (z_type_kind(arena, type) == Z_TYPE_NODE_BINDER && z_type_binder(arena, type) == binder) return true;
   ZUnifyBinding *existing = unify_trace_lookup_mut(trace, binder, Z_UNIFY_BINDING_TYPE);
-  if (existing) return z_type_unify(arena, existing->type, type, trace);
+  if (existing) return type_unify_inner(arena, existing->type, type, trace);
   if (binder_alias_resolves_to(arena, trace, type, binder, NULL, 0)) return true;
   if (type_binding_occurs_resolved(arena, trace, type, binder, NULL, 0)) return unify_fail(trace, "recursive type binding rejected by occurs check");
   ZUnifyBinding *binding = unify_trace_push(trace);
@@ -196,6 +208,7 @@ static bool bind_static(ZUnifyTrace *trace, const char *name, ZTypeBinderId bind
 static bool static_value_unify(const ZStaticValue *pattern, const ZStaticValue *actual, ZUnifyTrace *trace) {
   if (!pattern || !actual) return unify_fail(trace, "missing static value");
   if (pattern->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, pattern->text, pattern->binder, actual);
+  if (actual->kind == Z_STATIC_VALUE_BINDER) return bind_static(trace, actual->text, actual->binder, pattern);
   if (z_static_value_equal(pattern, actual)) return true;
   return unify_fail(trace, "static values do not unify");
 }
@@ -298,21 +311,22 @@ bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *tra
   return type_substitute_inner(arena, source, trace, out, NULL, 0);
 }
 
-bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {
+static bool type_unify_inner(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {
   ZTypeNodeKind pattern_kind = z_type_kind(arena, pattern);
   ZTypeNodeKind actual_kind = z_type_kind(arena, actual);
   if (pattern_kind == Z_TYPE_NODE_INVALID || actual_kind == Z_TYPE_NODE_INVALID) return unify_fail(trace, "invalid type id");
   if (pattern_kind == Z_TYPE_NODE_BINDER) return bind_type(arena, trace, z_type_name(arena, pattern), z_type_binder(arena, pattern), actual);
+  if (actual_kind == Z_TYPE_NODE_BINDER) return bind_type(arena, trace, z_type_name(arena, actual), z_type_binder(arena, actual), pattern);
   if (pattern_kind != actual_kind) return unify_fail(trace, "type shapes do not match");
   if (pattern_kind == Z_TYPE_NODE_NAME) {
     return strcmp(z_type_name(arena, pattern), z_type_name(arena, actual)) == 0 ? true : unify_fail(trace, "type names do not match");
   }
   if (pattern_kind == Z_TYPE_NODE_CONST) {
-    return z_type_unify(arena, z_type_const_inner(arena, pattern), z_type_const_inner(arena, actual), trace);
+    return type_unify_inner(arena, z_type_const_inner(arena, pattern), z_type_const_inner(arena, actual), trace);
   }
   if (pattern_kind == Z_TYPE_NODE_ARRAY) {
     return static_value_unify(z_type_array_length(arena, pattern), z_type_array_length(arena, actual), trace) &&
-           z_type_unify(arena, z_type_array_element(arena, pattern), z_type_array_element(arena, actual), trace);
+           type_unify_inner(arena, z_type_array_element(arena, pattern), z_type_array_element(arena, actual), trace);
   }
   if (pattern_kind == Z_TYPE_NODE_APPLY) {
     if (strcmp(z_type_name(arena, pattern), z_type_name(arena, actual)) != 0 ||
@@ -324,7 +338,7 @@ bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrac
       const ZTypeArg *actual_arg = z_type_apply_arg(arena, actual, i);
       if (!pattern_arg || !actual_arg || pattern_arg->kind != actual_arg->kind) return unify_fail(trace, "generic type argument kinds do not match");
       if (pattern_arg->kind == Z_TYPE_ARG_TYPE) {
-        if (!z_type_unify(arena, pattern_arg->as.type, actual_arg->as.type, trace)) return false;
+        if (!type_unify_inner(arena, pattern_arg->as.type, actual_arg->as.type, trace)) return false;
       } else if (!static_value_unify(&pattern_arg->as.static_value, &actual_arg->as.static_value, trace)) {
         return false;
       }
@@ -332,4 +346,27 @@ bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrac
     return true;
   }
   return unify_fail(trace, "unsupported type node");
+}
+
+bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {
+  size_t start_len = trace ? trace->len : 0;
+  char prior_message[sizeof(trace->message)];
+  if (trace) {
+    memcpy(prior_message, trace->message, sizeof(prior_message));
+    trace->message[0] = 0;
+  }
+
+  bool ok = type_unify_inner(arena, pattern, actual, trace);
+  if (ok) {
+    if (trace) memcpy(trace->message, prior_message, sizeof(prior_message));
+    return true;
+  }
+
+  if (trace) {
+    char failure_message[sizeof(trace->message)];
+    snprintf(failure_message, sizeof(failure_message), "%s", trace->message[0] ? trace->message : "types do not unify");
+    unify_trace_truncate(trace, start_len);
+    snprintf(trace->message, sizeof(trace->message), "%s", failure_message);
+  }
+  return false;
 }

--- a/native/zero-c/src/unify.c
+++ b/native/zero-c/src/unify.c
@@ -323,6 +323,7 @@ static bool type_substitute_inner(ZTypeArena *arena, ZTypeId source, const ZUnif
   if (kind == Z_TYPE_NODE_APPLY) {
     size_t arg_len = z_type_apply_arg_len(arena, source);
     ZTypeArg *args = arg_len ? unify_reallocarray(NULL, arg_len, sizeof(ZTypeArg)) : NULL;
+    if (args) memset(args, 0, arg_len * sizeof(ZTypeArg));
     bool ok = true;
     for (size_t i = 0; i < arg_len && ok; i++) {
       const ZTypeArg *arg = z_type_apply_arg(arena, source, i);
@@ -344,7 +345,15 @@ static bool type_substitute_inner(ZTypeArena *arena, ZTypeId source, const ZUnif
 }
 
 bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out) {
-  return type_substitute_inner(arena, source, trace, out, NULL, 0);
+  if (out) *out = Z_TYPE_ID_INVALID;
+  size_t start_len = arena ? arena->len : 0;
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  if (type_substitute_inner(arena, source, trace, &substituted, NULL, 0)) {
+    if (out) *out = substituted;
+    return true;
+  }
+  z_type_arena_truncate(arena, start_len);
+  return false;
 }
 
 static bool type_unify_inner(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace) {

--- a/native/zero-c/src/unify.h
+++ b/native/zero-c/src/unify.h
@@ -1,0 +1,34 @@
+#ifndef ZERO_C_UNIFY_H
+#define ZERO_C_UNIFY_H
+
+#include "type_core.h"
+
+typedef enum {
+  Z_UNIFY_BINDING_TYPE,
+  Z_UNIFY_BINDING_STATIC
+} ZUnifyBindingKind;
+
+typedef struct {
+  ZTypeBinderId binder;
+  ZUnifyBindingKind kind;
+  char *name;
+  ZTypeId type;
+  ZStaticValue static_value;
+} ZUnifyBinding;
+
+typedef struct {
+  ZUnifyBinding *items;
+  size_t len;
+  size_t cap;
+  char message[160];
+} ZUnifyTrace;
+
+void z_unify_trace_init(ZUnifyTrace *trace);
+void z_unify_trace_free(ZUnifyTrace *trace);
+const ZUnifyBinding *z_unify_trace_lookup(const ZUnifyTrace *trace, ZTypeBinderId binder, ZUnifyBindingKind kind);
+
+bool z_type_occurs(const ZTypeArena *arena, ZTypeId type, ZTypeBinderId binder);
+bool z_type_substitute(ZTypeArena *arena, ZTypeId source, const ZUnifyTrace *trace, ZTypeId *out);
+bool z_type_unify(ZTypeArena *arena, ZTypeId pattern, ZTypeId actual, ZUnifyTrace *trace);
+
+#endif

--- a/scripts/type-core-smoke.mts
+++ b/scripts/type-core-smoke.mts
@@ -343,6 +343,33 @@ static void expect_concrete_first_static_substitution(void) {
   z_type_arena_free(&arena);
 }
 
+static void expect_static_binder_types_are_checked(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 64, .static_type = "usize"},
+    {.name = "Flag", .kind = Z_TYPE_BINDER_STATIC, .id = 65, .static_type = "Bool"},
+    {.name = "ModeValue", .kind = Z_TYPE_BINDER_STATIC, .id = 66, .static_type = "Mode"},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 3};
+  ZTypeId integer_pattern = parse_with_binders_or_die(&arena, "FixedVec<u8,N>", &scope);
+  ZTypeId bool_actual = parse_or_die(&arena, "FixedVec<u8,true>");
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(!z_type_unify(&arena, integer_pattern, bool_actual, &trace), "static integer binder accepted a Bool value");
+  expect(strstr(trace.message, "static value") != NULL, "static type failure did not leave a trace message");
+
+  ZTypeId alias_pattern = parse_with_binders_or_die(&arena, "Pair<N,N>", &scope);
+  ZTypeId alias_actual = parse_with_binders_or_die(&arena, "Pair<Flag,N>", &scope);
+  expect(!z_type_unify(&arena, alias_pattern, alias_actual, &trace), "static binders with different declared types unified");
+
+  ZTypeId enum_pattern = parse_with_binders_or_die(&arena, "Gate<ModeValue>", &scope);
+  ZTypeId enum_actual = parse_or_die(&arena, "Gate<Mode.tiny>");
+  expect(z_type_unify(&arena, enum_pattern, enum_actual, &trace), "enum-like static binder rejected matching symbol value");
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
 static void expect_failed_unify_rolls_back_trace(void) {
   ZTypeArena arena;
   z_type_arena_init(&arena);
@@ -367,6 +394,7 @@ static void expect_failed_unify_rolls_back_trace(void) {
 
   ZTypeId good = parse_or_die(&arena, "Pair<u8,u8>");
   expect(z_type_unify(&arena, pattern, good, &trace), "trace was poisoned after failed unification rollback");
+  expect(trace.message[0] == 0, "successful retry left a stale unification failure message");
   expect(trace.len == 2, "successful retry did not commit expected binding count");
   const ZUnifyBinding *type_binding = z_unify_trace_lookup(&trace, 70, Z_UNIFY_BINDING_TYPE);
   expect(type_binding != NULL, "successful retry did not bind T");
@@ -416,6 +444,7 @@ int main(void) {
   expect_chained_static_substitution();
   expect_concrete_first_type_substitution();
   expect_concrete_first_static_substitution();
+  expect_static_binder_types_are_checked();
   expect_failed_unify_rolls_back_trace();
 
   expect_invalid_type("");

--- a/scripts/type-core-smoke.mts
+++ b/scripts/type-core-smoke.mts
@@ -215,6 +215,90 @@ static void expect_occurs_check_rejects_recursive_binding(void) {
   z_type_arena_free(&arena);
 }
 
+static void expect_occurs_check_follows_trace_bindings(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 30},
+    {.name = "U", .kind = Z_TYPE_BINDER_TYPE, .id = 31},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<T,U>", &scope);
+  ZTypeId recursive = parse_with_binders_or_die(&arena, "Pair<U,Maybe<T>>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(!z_type_unify(&arena, pattern, recursive, &trace), "transitive recursive type binding passed occurs check");
+  expect(strstr(trace.message, "occurs") != NULL, "transitive occurs check failure did not leave a trace message");
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_binder_alias_swap_unifies(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 40},
+    {.name = "U", .kind = Z_TYPE_BINDER_TYPE, .id = 41},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<T,U>", &scope);
+  ZTypeId actual = parse_with_binders_or_die(&arena, "Pair<U,T>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "plain binder alias swap did not unify");
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, pattern, &trace, &substituted), "alias substitution failed");
+  char *formatted = z_type_format(&arena, substituted);
+  expect(formatted && strcmp(formatted, "Pair<U,U>") == 0, "alias substitution did not use canonical binder");
+  free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_chained_type_substitution(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 50},
+    {.name = "U", .kind = Z_TYPE_BINDER_TYPE, .id = 51},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<T,T>", &scope);
+  ZTypeId actual = parse_with_binders_or_die(&arena, "Pair<U,i32>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "chained type binder pattern did not unify");
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, pattern, &trace, &substituted), "chained type substitution failed");
+  char *formatted = z_type_format(&arena, substituted);
+  expect(formatted && strcmp(formatted, "Pair<i32,i32>") == 0, "chained type substitution left an unresolved binder");
+  free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_chained_static_substitution(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 60, .static_type = "usize"},
+    {.name = "M", .kind = Z_TYPE_BINDER_STATIC, .id = 61, .static_type = "usize"},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<FixedVec<u8,N>,FixedVec<u8,N>>", &scope);
+  ZTypeId actual = parse_with_binders_or_die(&arena, "Pair<FixedVec<u8,M>,FixedVec<u8,4>>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "chained static binder pattern did not unify");
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, pattern, &trace, &substituted), "chained static substitution failed");
+  char *formatted = z_type_format(&arena, substituted);
+  expect(formatted && strcmp(formatted, "Pair<FixedVec<u8,4>,FixedVec<u8,4>>") == 0, "chained static substitution left an unresolved binder");
+  free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
 int main(void) {
   expect_roundtrip("i32", "i32");
   expect_roundtrip("const i32", "const i32");
@@ -248,6 +332,10 @@ int main(void) {
   expect_binder_identity();
   expect_unify_and_substitute();
   expect_occurs_check_rejects_recursive_binding();
+  expect_occurs_check_follows_trace_bindings();
+  expect_binder_alias_swap_unifies();
+  expect_chained_type_substitution();
+  expect_chained_static_substitution();
 
   expect_invalid_type("");
   expect_invalid_type("Span<");

--- a/scripts/type-core-smoke.mts
+++ b/scripts/type-core-smoke.mts
@@ -277,6 +277,28 @@ static void expect_chained_type_substitution(void) {
   z_type_arena_free(&arena);
 }
 
+static void expect_concrete_first_type_substitution(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 52},
+    {.name = "U", .kind = Z_TYPE_BINDER_TYPE, .id = 53},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<Box<T>,Box<T>>", &scope);
+  ZTypeId actual = parse_with_binders_or_die(&arena, "Pair<Box<i32>,Box<U>>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "concrete-first type binder pattern did not unify");
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, actual, &trace, &substituted), "concrete-first actual substitution failed");
+  char *formatted = z_type_format(&arena, substituted);
+  expect(formatted && strcmp(formatted, "Pair<Box<i32>,Box<i32>>") == 0, "concrete-first type substitution left an unresolved binder");
+  free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
 static void expect_chained_static_substitution(void) {
   ZTypeArena arena;
   z_type_arena_init(&arena);
@@ -295,6 +317,62 @@ static void expect_chained_static_substitution(void) {
   char *formatted = z_type_format(&arena, substituted);
   expect(formatted && strcmp(formatted, "Pair<FixedVec<u8,4>,FixedVec<u8,4>>") == 0, "chained static substitution left an unresolved binder");
   free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_concrete_first_static_substitution(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 62, .static_type = "usize"},
+    {.name = "M", .kind = Z_TYPE_BINDER_STATIC, .id = 63, .static_type = "usize"},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<FixedVec<u8,N>,FixedVec<u8,N>>", &scope);
+  ZTypeId actual = parse_with_binders_or_die(&arena, "Pair<FixedVec<u8,4>,FixedVec<u8,M>>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "concrete-first static binder pattern did not unify");
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, actual, &trace, &substituted), "concrete-first static substitution failed");
+  char *formatted = z_type_format(&arena, substituted);
+  expect(formatted && strcmp(formatted, "Pair<FixedVec<u8,4>,FixedVec<u8,4>>") == 0, "concrete-first static substitution left an unresolved binder");
+  free(formatted);
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_failed_unify_rolls_back_trace(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 70},
+    {.name = "U", .kind = Z_TYPE_BINDER_TYPE, .id = 71},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "Pair<T,T>", &scope);
+  ZTypeId bad = parse_or_die(&arena, "Pair<i32,String>");
+  ZTypeId prior_pattern = parse_with_binders_or_die(&arena, "U", &scope);
+  ZTypeId prior_actual = parse_or_die(&arena, "u8");
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, prior_pattern, prior_actual, &trace), "prior trace binding did not unify");
+  expect(trace.len == 1, "prior trace binding was not committed");
+  expect(!z_type_unify(&arena, pattern, bad, &trace), "conflicting type binder pattern unified successfully");
+  expect(trace.len == 1, "failed unification did not roll back to the prior trace length");
+  const ZUnifyBinding *prior_binding = z_unify_trace_lookup(&trace, 71, Z_UNIFY_BINDING_TYPE);
+  expect(prior_binding != NULL, "failed unification dropped a prior trace binding");
+  expect(trace.message[0] != 0, "failed unification did not preserve a diagnostic message");
+
+  ZTypeId good = parse_or_die(&arena, "Pair<u8,u8>");
+  expect(z_type_unify(&arena, pattern, good, &trace), "trace was poisoned after failed unification rollback");
+  expect(trace.len == 2, "successful retry did not commit expected binding count");
+  const ZUnifyBinding *type_binding = z_unify_trace_lookup(&trace, 70, Z_UNIFY_BINDING_TYPE);
+  expect(type_binding != NULL, "successful retry did not bind T");
+  char *bound_type = z_type_format(&arena, type_binding->type);
+  expect(bound_type && strcmp(bound_type, "u8") == 0, "successful retry bound T to the wrong type");
+  free(bound_type);
   z_unify_trace_free(&trace);
   z_type_arena_free(&arena);
 }
@@ -336,6 +414,9 @@ int main(void) {
   expect_binder_alias_swap_unifies();
   expect_chained_type_substitution();
   expect_chained_static_substitution();
+  expect_concrete_first_type_substitution();
+  expect_concrete_first_static_substitution();
+  expect_failed_unify_rolls_back_trace();
 
   expect_invalid_type("");
   expect_invalid_type("Span<");

--- a/scripts/type-core-smoke.mts
+++ b/scripts/type-core-smoke.mts
@@ -12,6 +12,7 @@ const exePath = process.platform === "win32" ? `${tmpBase}.exe` : tmpBase;
 
 const source = String.raw`
 #include "type_core.h"
+#include "unify.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -28,6 +29,16 @@ static ZTypeId parse_or_die(ZTypeArena *arena, const char *text) {
   ZTypeParseError error = {0};
   if (!z_type_parse(arena, text, &type, &error)) {
     fprintf(stderr, "failed to parse '%s': %s at %zu\n", text, error.message, error.offset);
+    exit(1);
+  }
+  return type;
+}
+
+static ZTypeId parse_with_binders_or_die(ZTypeArena *arena, const char *text, const ZTypeBinderScope *scope) {
+  ZTypeId type = Z_TYPE_ID_INVALID;
+  ZTypeParseError error = {0};
+  if (!z_type_parse_with_binders(arena, text, scope, &type, &error)) {
+    fprintf(stderr, "failed to parse '%s' with binders: %s at %zu\n", text, error.message, error.offset);
     exit(1);
   }
   return type;
@@ -133,6 +144,77 @@ static void expect_speculative_arg_rewinds(void) {
   z_type_arena_free(&arena);
 }
 
+static void expect_binder_identity(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl left_decl[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 1},
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 2, .static_type = "usize"},
+  };
+  ZTypeBinderDecl right_decl[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 3},
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 4, .static_type = "usize"},
+  };
+  ZTypeBinderScope left_scope = {.items = left_decl, .len = 2};
+  ZTypeBinderScope right_scope = {.items = right_decl, .len = 2};
+  ZTypeId left = parse_with_binders_or_die(&arena, "FixedVec<T,N>", &left_scope);
+  ZTypeId right = parse_with_binders_or_die(&arena, "FixedVec<T,N>", &right_scope);
+  expect(!z_type_equal(&arena, left, right), "binder identity collapsed to names");
+  char *formatted = z_type_format(&arena, left);
+  expect(formatted && strcmp(formatted, "FixedVec<T,N>") == 0, "binder formatting changed public type text");
+  free(formatted);
+  z_type_arena_free(&arena);
+}
+
+static void expect_unify_and_substitute(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 10},
+    {.name = "N", .kind = Z_TYPE_BINDER_STATIC, .id = 11, .static_type = "usize"},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 2};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "FixedVec<T,N>", &scope);
+  ZTypeId actual = parse_or_die(&arena, "FixedVec<u8,0x4>");
+
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(z_type_unify(&arena, pattern, actual, &trace), "binder pattern did not unify with concrete type");
+  const ZUnifyBinding *type_binding = z_unify_trace_lookup(&trace, 10, Z_UNIFY_BINDING_TYPE);
+  const ZUnifyBinding *static_binding = z_unify_trace_lookup(&trace, 11, Z_UNIFY_BINDING_STATIC);
+  expect(type_binding && static_binding && trace.len == 2, "unification trace missed binder facts");
+  char *bound_type = z_type_format(&arena, type_binding->type);
+  expect(bound_type && strcmp(bound_type, "u8") == 0, "type binder bound to wrong type");
+  free(bound_type);
+  expect(static_binding->static_value.kind == Z_STATIC_VALUE_NUMBER && static_binding->static_value.number == 4, "static binder bound to wrong value");
+
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(z_type_substitute(&arena, pattern, &trace, &substituted), "substitution failed");
+  expect(z_type_equal(&arena, substituted, actual), "substitution result differs from concrete type");
+  expect(z_type_occurs(&arena, pattern, 10), "occurs check did not find type binder");
+  expect(z_type_occurs(&arena, pattern, 11), "occurs check did not find static binder");
+  expect(!z_type_occurs(&arena, actual, 10), "occurs check found binder in concrete type");
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
+static void expect_occurs_check_rejects_recursive_binding(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 20},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 1};
+  ZTypeId pattern = parse_with_binders_or_die(&arena, "T", &scope);
+  ZTypeId recursive = parse_with_binders_or_die(&arena, "Maybe<T>", &scope);
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  expect(!z_type_unify(&arena, pattern, recursive, &trace), "recursive type binding passed occurs check");
+  expect(strstr(trace.message, "occurs") != NULL, "occurs check failure did not leave a trace message");
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
 int main(void) {
   expect_roundtrip("i32", "i32");
   expect_roundtrip("const i32", "const i32");
@@ -163,6 +245,9 @@ int main(void) {
 
   expect_failed_parse_rewinds();
   expect_speculative_arg_rewinds();
+  expect_binder_identity();
+  expect_unify_and_substitute();
+  expect_occurs_check_rejects_recursive_binding();
 
   expect_invalid_type("");
   expect_invalid_type("Span<");
@@ -205,6 +290,7 @@ try {
       path.join(repoRoot, "native/zero-c/src"),
       sourcePath,
       path.join(repoRoot, "native/zero-c/src/type_core.c"),
+      path.join(repoRoot, "native/zero-c/src/unify.c"),
       "-o",
       exePath,
     ],

--- a/scripts/type-core-smoke.mts
+++ b/scripts/type-core-smoke.mts
@@ -405,6 +405,34 @@ static void expect_failed_unify_rolls_back_trace(void) {
   z_type_arena_free(&arena);
 }
 
+static void expect_failed_substitute_rolls_back_arena(void) {
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeBinderDecl decls[] = {
+    {.name = "T", .kind = Z_TYPE_BINDER_TYPE, .id = 80},
+  };
+  ZTypeBinderScope scope = {.items = decls, .len = 1};
+  ZTypeId source = parse_with_binders_or_die(&arena, "Tuple<i32,T,u8>", &scope);
+  ZTypeId recursive = parse_with_binders_or_die(&arena, "T", &scope);
+  size_t before = arena.len;
+
+  ZUnifyTrace trace;
+  z_unify_trace_init(&trace);
+  trace.items = calloc(1, sizeof(ZUnifyBinding));
+  expect(trace.items != NULL, "failed to allocate regression trace");
+  trace.len = 1;
+  trace.cap = 1;
+  trace.items[0] = (ZUnifyBinding){.binder = 80, .kind = Z_UNIFY_BINDING_TYPE, .type = recursive};
+
+  ZTypeId substituted = Z_TYPE_ID_INVALID;
+  expect(!z_type_substitute(&arena, source, &trace, &substituted), "recursive substitution unexpectedly succeeded");
+  expect(substituted == Z_TYPE_ID_INVALID, "failed substitution returned a type id");
+  expect(arena.len == before, "failed substitution did not roll back arena");
+
+  z_unify_trace_free(&trace);
+  z_type_arena_free(&arena);
+}
+
 int main(void) {
   expect_roundtrip("i32", "i32");
   expect_roundtrip("const i32", "const i32");
@@ -446,6 +474,7 @@ int main(void) {
   expect_concrete_first_static_substitution();
   expect_static_binder_types_are_checked();
   expect_failed_unify_rolls_back_trace();
+  expect_failed_substitute_rolls_back_arena();
 
   expect_invalid_type("");
   expect_invalid_type("Span<");


### PR DESCRIPTION
- Track generic binders in type core

- Add unification and substitution helpers

- Cover binder identity and occurs checks