### PR TITLE
Add explain coverage for TYP001, TYP002, STD002, IMP001

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1768,6 +1768,30 @@ assert.equal(explainTar002Body.schemaVersion, 1);
 assert.equal(explainTar002Body.code, "TAR002");
 assert.equal(explainTar002Body.repair.id, "choose-target-with-required-capability");
 
+const explainTyp001 = await execFileAsync(zero, ["explain", "--json", "TYP001"]);
+const explainTyp001Body = JSON.parse(explainTyp001.stdout);
+assert.equal(explainTyp001Body.code, "TYP001");
+assert.equal(explainTyp001Body.category, "type");
+assert.equal(explainTyp001Body.repair.id, "provide-runtime-value");
+
+const explainTyp002 = await execFileAsync(zero, ["explain", "--json", "TYP002"]);
+const explainTyp002Body = JSON.parse(explainTyp002.stdout);
+assert.equal(explainTyp002Body.code, "TYP002");
+assert.equal(explainTyp002Body.category, "type");
+assert.equal(explainTyp002Body.repair.id, "match-expected-type");
+
+const explainStd002 = await execFileAsync(zero, ["explain", "--json", "STD002"]);
+const explainStd002Body = JSON.parse(explainStd002.stdout);
+assert.equal(explainStd002Body.code, "STD002");
+assert.equal(explainStd002Body.category, "stdlib");
+assert.equal(explainStd002Body.repair.id, "use-known-stdlib-helper");
+
+const explainImp001 = await execFileAsync(zero, ["explain", "--json", "IMP001"]);
+const explainImp001Body = JSON.parse(explainImp001.stdout);
+assert.equal(explainImp001Body.code, "IMP001");
+assert.equal(explainImp001Body.category, "import");
+assert.equal(explainImp001Body.repair.id, "fix-import-path");
+
 const explainText = await execFileAsync(zero, ["explain", "TYP009"]);
 assert.match(explainText.stdout, /Mutable storage required/);
 

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2558,6 +2558,8 @@ static const char *diag_repair_id(int code) {
     case 7001: return "fix-import-path";
     case 7002: return "break-import-cycle";
     case 3003: return "declare-missing-symbol";
+    case 3005: return "provide-runtime-value";
+    case 3006: return "match-expected-type";
     case 3007: return "match-return-type";
     case 3010: return "make-binding-mutable";
     case 3011: return "use-known-stdlib-helper";
@@ -2609,6 +2611,8 @@ static const char *diag_repair_summary(int code) {
     case 7001: return "Change the import to a package-local module path that resolves under src/.";
     case 7002: return "Break the import cycle by moving shared declarations into a third module or removing one import edge.";
     case 3003: return "Declare the referenced symbol, import the module that provides it, or correct the identifier spelling.";
+    case 3005: return "Replace the type, function, or namespace name with a runtime expression such as a call, a constructor, or a member access.";
+    case 3006: return "Change the value or the annotation so both sides use the same type, or insert an explicit as cast for supported primitive conversions.";
     case 3007: return "Change the returned expression or the function return annotation so both types agree.";
     case 3010: return "Change the root binding to let mut before passing it to a mutable API.";
     case 3011: return "Use one of the supported std helpers or add compiler support for the new helper.";
@@ -2979,6 +2983,46 @@ static const ExplainInfo explain_infos[] = {
     "zero build --emit obj --target linux-arm64 examples/direct-call-add.0",
     "zero build --emit obj --target linux-x64 examples/direct-call-add.0",
   },
+  {
+    "TYP001",
+    "type",
+    "Type or namespace used as value",
+    "A type name, function name without a call, or builtin namespace appeared where a runtime value was required.",
+    "Zero keeps the value and type planes separate so calls, members, and constructors lower to direct code without runtime reflection.",
+    "Replace the type, function, or namespace name with a runtime expression such as a call, a constructor, or a member access.",
+    "let host = std.fs",
+    "let host = std.fs.host()",
+  },
+  {
+    "TYP002",
+    "type",
+    "Type mismatch",
+    "An assignment, return, comparison, arithmetic, literal, shape field, or shape default used values whose types do not match the expected shape.",
+    "Zero does not implicitly widen, narrow, or coerce between types, so each position carries the exact type the checker recorded.",
+    "Change the value or the annotation so both sides use the same type, or insert an explicit `as` cast for supported primitive conversions.",
+    "let count: u32 = 1_i32",
+    "let count: u32 = 1_u32",
+  },
+  {
+    "STD002",
+    "stdlib",
+    "Unknown or misused std helper",
+    "A `std.*` call referenced a helper the bootstrap stdlib does not provide, or invoked a known helper with the wrong argument count.",
+    "The native stdlib surface is intentionally narrow so direct emission can keep std helpers small, predictable, and target-aware.",
+    "Use one of the documented std helpers listed by `zero skills get zero-stdlib`, or adjust the call to match the helper's argument list.",
+    "let _ = std.mem.copyAll(dst, src)",
+    "let _ = std.mem.copy(dst, src)",
+  },
+  {
+    "IMP001",
+    "import",
+    "Unknown package-local import",
+    "A `use` declaration referenced a module path that does not resolve under the current package's `src/`.",
+    "Zero imports are package-local paths rather than ambient names, so each `use` must point at a file the package actually owns.",
+    "Change the import to a package-local module path that resolves under `src/`, or add the missing module file to the package.",
+    "use missing",
+    "use helpers",
+  },
   {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -3007,6 +3051,8 @@ static void print_explain_json(const ExplainInfo *info) {
   append_json_string(&buf, diag_repair_id(strcmp(info->code, "TAR001") == 0 ? 6001 :
                                          strcmp(info->code, "TAR002") == 0 ? 6002 :
                                          strcmp(info->code, "BLD003") == 0 ? 2003 :
+                                         strcmp(info->code, "TYP001") == 0 ? 3005 :
+                                         strcmp(info->code, "TYP002") == 0 ? 3006 :
                                          strcmp(info->code, "TYP009") == 0 ? 3010 :
                                          strcmp(info->code, "TYP023") == 0 ? 3032 :
                                          strcmp(info->code, "TYP024") == 0 ? 3033 :
@@ -3030,7 +3076,9 @@ static void print_explain_json(const ExplainInfo *info) {
                                          strcmp(info->code, "BOR001") == 0 ? 3029 :
                                          strcmp(info->code, "ERR002") == 0 ? 1002 :
                                          strcmp(info->code, "ERR003") == 0 ? 1003 :
+                                         strcmp(info->code, "STD002") == 0 ? 3011 :
                                          strcmp(info->code, "STD003") == 0 ? 3012 :
+                                         strcmp(info->code, "IMP001") == 0 ? 7001 :
                                          strcmp(info->code, "CGEN004") == 0 ? 4004 : 0));
   zbuf_append(&buf, ", \"summary\": ");
   append_json_string(&buf, info->canonical_repair);


### PR DESCRIPTION
## Summary

Adds `zero explain` coverage for four diagnostic codes the native compiler already emits but `zero explain` currently rejects as unknown: `TYP001`, `TYP002`, `STD002`, `IMP001`.

Follow-on to #92, which closed the PAR100 / APP001 / NAM003 / CIMP001 slice. These four codes are the next-priority cluster from the benchmark comment on #111 — STD002 (15 occurrences), TYP002 (7), TYP001 (5), plus IMP001 from the related #104 corpus.

## Changes

- `native/zero-c/src/main.c`
  - Four new `explain_infos[]` entries with `category`, `title`, `summary`, `why`, repair text, and bad/good examples.
  - `print_explain_json` code→repair-id map extended with the four codes.
  - `diag_repair_id` / `diag_repair_summary` get `3005` (`provide-runtime-value`) and `3006` (`match-expected-type`) so TYP001 / TYP002 no longer fall through to `manual-review`. STD002 and IMP001 already had repair ids.
- `conformance/run.mjs`: four `explain --json` assertions mirroring the existing TAR002 check.

The underlying diagnostics, fix-safety classifications, and the unknown-code help text suggestion list are untouched.

## Validation

Local, macOS arm64:

- ``make -C native/zero-c``
- ``bin/zero explain --json {TYP001,TYP002,STD002,IMP001}`` — all return the expected shape
- ``bin/zero explain TYP001`` — text mode renders title / summary / why / repair / bad / good
- ``pnpm run conformance:local``
- ``pnpm run command-contracts:local``
- ``pnpm run native:smoke``
- ``pnpm run agent:demo``