### PR TITLE
[Draft] Prototype `decreases` clause + TER001 termination check (RFC for #149)

### DIFF
--- a/conformance/check/fail/decreases-no-progress.0
+++ b/conformance/check/fail/decreases-no-progress.0
@@ -1,0 +1,6 @@
+pub fun main(world: World) -> Void raises {
+    let mut i: u32 = 3
+    while i > 0 decreases i {
+        check world.out.write("tick\n")
+    }
+}

--- a/conformance/check/pass/decreases-countdown.0
+++ b/conformance/check/pass/decreases-countdown.0
@@ -1,0 +1,7 @@
+pub fun main(world: World) -> Void raises {
+    let mut i: u32 = 3
+    while i > 0 decreases i {
+        check world.out.write("tick\n")
+        i = i - 1
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -416,6 +416,7 @@ for (const fixture of [
   "conformance/native/pass/match-choice-fallback.0",
   "conformance/check/pass/memory-types.0",
   "conformance/check/pass/checker-type-forms.0",
+  "conformance/check/pass/decreases-countdown.0",
   "conformance/check/pass/package",
   "conformance/check/pass/imports",
   "examples/memory-package",
@@ -932,6 +933,20 @@ for (const [fixture, message] of [
   assert.equal(parseFailureBody.diagnostics[0].fixSafety, "requires-human-review");
   assert.equal(parseFailureBody.diagnostics[0].repair.id, "repair-syntax");
 }
+
+const decreasesFailJson = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/decreases-no-progress.0"]).catch((error) => error);
+assert.notEqual(decreasesFailJson.code, 0);
+const decreasesFailBody = JSON.parse(decreasesFailJson.stdout);
+assert.equal(decreasesFailBody.diagnostics[0].code, "TER001");
+assert.match(decreasesFailBody.diagnostics[0].message, /strictly decreases/);
+assert.equal(decreasesFailBody.diagnostics[0].fixSafety, "behavior-preserving");
+assert.equal(decreasesFailBody.diagnostics[0].repair.id, "ensure-decreasing-measure");
+
+const explainTer001 = await execFileAsync(zero, ["explain", "--json", "TER001"]);
+const explainTer001Body = JSON.parse(explainTer001.stdout);
+assert.equal(explainTer001Body.code, "TER001");
+assert.equal(explainTer001Body.category, "termination");
+assert.equal(explainTer001Body.repair.id, "ensure-decreasing-measure");
 
 const missingImportJson = await execFileAsync(zero, ["check", "--json", "conformance/check/fail/missing-import"]).catch((error) => error);
 assert.notEqual(missingImportJson.code, 0);

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -211,6 +211,7 @@ struct Stmt {
   Expr *target;
   Expr *expr;
   Expr *range_end;
+  Expr *decreases;
   StmtVec then_body;
   StmtVec else_body;
   MatchArmVec match_arms;

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -7637,6 +7637,64 @@ static bool check_scalar_match(CheckContext *ctx, const Program *program, const 
   return true;
 }
 
+static bool expr_is_positive_int_literal(const Expr *expr) {
+  if (!expr || expr->kind != EXPR_NUMBER || !expr->text) return false;
+  for (const char *cursor = expr->text; *cursor; cursor++) {
+    if (*cursor == '_') continue;
+    if (*cursor < '0' || *cursor > '9') return false;
+  }
+  for (const char *cursor = expr->text; *cursor; cursor++) {
+    if (*cursor >= '1' && *cursor <= '9') return true;
+  }
+  return false;
+}
+
+static bool expr_is_int_literal_gt_one(const Expr *expr) {
+  if (!expr_is_positive_int_literal(expr)) return false;
+  size_t digits = 0;
+  char first = 0;
+  for (const char *cursor = expr->text; *cursor; cursor++) {
+    if (*cursor == '_') continue;
+    if (digits == 0) first = *cursor;
+    digits++;
+  }
+  if (digits > 1) return true;
+  return first > '1';
+}
+
+static bool expr_is_strict_decrease(const Expr *expr, const char *measure) {
+  if (!expr || expr->kind != EXPR_BINARY || !expr->text || !expr->left || !expr->right) return false;
+  if (expr->left->kind != EXPR_IDENT || !expr->left->text) return false;
+  if (strcmp(expr->left->text, measure) != 0) return false;
+  if (strcmp(expr->text, "-") == 0) return expr_is_positive_int_literal(expr->right);
+  if (strcmp(expr->text, "/") == 0) return expr_is_int_literal_gt_one(expr->right);
+  return false;
+}
+
+static bool stmt_vec_has_strict_decrease(const StmtVec *body, const char *measure);
+
+static bool stmt_has_strict_decrease(const Stmt *stmt, const char *measure) {
+  if (!stmt) return false;
+  if (stmt->kind == STMT_ASSIGN && stmt->target && stmt->target->kind == EXPR_IDENT && stmt->target->text &&
+      strcmp(stmt->target->text, measure) == 0 && expr_is_strict_decrease(stmt->expr, measure)) {
+    return true;
+  }
+  if (stmt_vec_has_strict_decrease(&stmt->then_body, measure)) return true;
+  if (stmt_vec_has_strict_decrease(&stmt->else_body, measure)) return true;
+  for (size_t i = 0; i < stmt->match_arms.len; i++) {
+    if (stmt_vec_has_strict_decrease(&stmt->match_arms.items[i].body, measure)) return true;
+  }
+  return false;
+}
+
+static bool stmt_vec_has_strict_decrease(const StmtVec *body, const char *measure) {
+  if (!body) return false;
+  for (size_t i = 0; i < body->len; i++) {
+    if (stmt_has_strict_decrease(body->items[i], measure)) return true;
+  }
+  return false;
+}
+
 static bool check_stmt(CheckContext *ctx, const Program *program, const Function *fun, const Stmt *stmt, Scope *scope, ZDiag *diag, int loop_depth) {
   diag = check_context_diag(ctx, diag);
   if (stmt->kind == STMT_LET) {
@@ -7771,6 +7829,21 @@ static bool check_stmt(CheckContext *ctx, const Program *program, const Function
     if (!check_expr_expected(ctx, program, stmt->expr, scope, diag, "Bool")) return false;
     const char *condition_type = expr_type(ctx, program, stmt->expr, scope);
     if (!is_bool_type(condition_type)) return set_diag_detail(diag, 3016, "condition must be Bool", stmt->expr->line, stmt->expr->column, "Bool", condition_type, "compare explicitly or produce a Bool value");
+    if (stmt->decreases) {
+      if (!check_expr(ctx, program, stmt->decreases, scope, diag)) return false;
+      if (stmt->decreases->kind != EXPR_IDENT || !stmt->decreases->text) {
+        return set_diag_detail(diag, 11001, "decreases measure must be a single mutable binding", stmt->decreases->line, stmt->decreases->column, "identifier of a let mut binding", "non-identifier expression", "use a single mutable integer binding as the decreases measure");
+      }
+      const char *measure_type = expr_type(ctx, program, stmt->decreases, scope);
+      if (!is_int_type(measure_type)) {
+        return set_diag_detail(diag, 11001, "decreases measure must be an integer", stmt->decreases->line, stmt->decreases->column, "integer-typed binding", measure_type ? measure_type : "unknown", "use a mutable integer binding as the decreases measure");
+      }
+      if (!stmt_vec_has_strict_decrease(&stmt->then_body, stmt->decreases->text)) {
+        char message[256];
+        snprintf(message, sizeof(message), "could not prove the decreases measure '%s' strictly decreases on every iteration", stmt->decreases->text);
+        return set_diag_detail(diag, 11001, message, stmt->decreases->line, stmt->decreases->column, "an assignment such as <var> = <var> - K or <var> = <var> / N inside the loop body", "no recognized decreasing assignment in the loop body", "assign the measure to a strictly smaller value before the next iteration");
+      }
+    }
     ProvenanceScopeSnapshot *before = provenance_scope_snapshot_capture(scope);
     Scope body_scope = {.parent = scope};
     bool ok = check_stmt_vec_with_loop(ctx, program, fun, &stmt->then_body, &body_scope, diag, loop_depth + 1);

--- a/native/zero-c/src/lexer.c
+++ b/native/zero-c/src/lexer.c
@@ -19,7 +19,7 @@ static Token make_token(TokenKind kind, char *text, int line, int column, size_t
 
 static bool is_keyword(const char *text) {
   const char *keywords[] = {
-    "as", "break", "check", "choice", "const", "continue", "defer", "else", "enum", "export", "extern", "false", "for", "fun",
+    "as", "break", "check", "choice", "const", "continue", "decreases", "defer", "else", "enum", "export", "extern", "false", "for", "fun",
     "if", "import", "in", "let", "match", "meta", "mut", "null", "packed", "pub",
     "raise", "raises", "rescue", "return", "shape", "static", "test", "true", "type",
     "use", "var", "while", NULL

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -158,6 +158,7 @@ static const char *diag_code(int code) {
     case 9002: return "PKG002";
     case 9003: return "PKG003";
     case 9004: return "PKG004";
+    case 11001: return "TER001";
     default: return "PAR100";
   }
 }
@@ -2543,6 +2544,7 @@ static const char *diag_fix_safety(int code) {
     case 3047:
     case 3048:
     case 3049:
+    case 11001:
       return "behavior-preserving";
     default:
       return "requires-human-review";
@@ -2596,6 +2598,7 @@ static const char *diag_repair_id(int code) {
     case 9002: return "break-package-dependency-cycle";
     case 9003: return "choose-one-package-version";
     case 9004: return "choose-target-compatible-package";
+    case 11001: return "ensure-decreasing-measure";
     default: return code == 0 ? "repair-syntax" : "manual-review";
   }
 }
@@ -2647,6 +2650,7 @@ static const char *diag_repair_summary(int code) {
     case 9002: return "Remove the package cycle or move shared code into an acyclic dependency.";
     case 9003: return "Resolve the graph to one version of each package name.";
     case 9004: return "Select a target supported by the dependency or gate the dependency behind a compatible target.";
+    case 11001: return "Assign the decreases measure to a strictly smaller value on every loop iteration, for example with `m = m - 1` or `m = m / 2`.";
     default: return code == 0 ? "Repair the syntax at the reported parser span, then rerun zero check." : "Inspect the diagnostic fields and choose a repair manually.";
   }
 }
@@ -2979,6 +2983,16 @@ static const ExplainInfo explain_infos[] = {
     "zero build --emit obj --target linux-arm64 examples/direct-call-add.0",
     "zero build --emit obj --target linux-x64 examples/direct-call-add.0",
   },
+  {
+    "TER001",
+    "termination",
+    "Decreases measure does not strictly decrease",
+    "A `while` loop annotated with `decreases <measure>` does not have an assignment that strictly decreases the measure inside its body.",
+    "Zero treats `decreases` as a per-loop termination contract, so the checker must be able to point at a strictly decreasing assignment before allowing the loop to compile.",
+    "Assign the decreases measure to a strictly smaller value on every iteration, such as `m = m - 1` or `m = m / 2`.",
+    "let mut i: u32 = 3\nwhile i > 0 decreases i {\n    check world.out.write(\"tick\\n\")\n}",
+    "let mut i: u32 = 3\nwhile i > 0 decreases i {\n    check world.out.write(\"tick\\n\")\n    i = i - 1\n}",
+  },
   {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
 };
 
@@ -3031,7 +3045,8 @@ static void print_explain_json(const ExplainInfo *info) {
                                          strcmp(info->code, "ERR002") == 0 ? 1002 :
                                          strcmp(info->code, "ERR003") == 0 ? 1003 :
                                          strcmp(info->code, "STD003") == 0 ? 3012 :
-                                         strcmp(info->code, "CGEN004") == 0 ? 4004 : 0));
+                                         strcmp(info->code, "CGEN004") == 0 ? 4004 :
+                                         strcmp(info->code, "TER001") == 0 ? 11001 : 0));
   zbuf_append(&buf, ", \"summary\": ");
   append_json_string(&buf, info->canonical_repair);
   zbuf_append(&buf, "},\n  \"examples\": {\"bad\": ");

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -628,6 +628,9 @@ static Stmt *parse_statement(Parser *parser) {
   if (match(parser, "while")) {
     Stmt *stmt = new_stmt(STMT_WHILE, start);
     stmt->expr = parse_expr(parser);
+    if (match(parser, "decreases")) {
+      stmt->decreases = parse_expr(parser);
+    }
     stmt->then_body = parse_block(parser);
     return stmt;
   }
@@ -1072,6 +1075,7 @@ static void free_stmt_vec(StmtVec *vec) {
     free_expr(stmt->target);
     free_expr(stmt->expr);
     free_expr(stmt->range_end);
+    free_expr(stmt->decreases);
     free_stmt_vec(&stmt->then_body);
     free_stmt_vec(&stmt->else_body);
     for (size_t arm_index = 0; arm_index < stmt->match_arms.len; arm_index++) {


### PR DESCRIPTION
> **Draft, not for merge.** Discussion artifact for #149 — wanted to put a concrete shape on the table rather than argue in the abstract.

## What this is

A minimal syntactic prototype of Verus-style termination annotations on `while` loops.

```zero
let mut i: u32 = 3
while i > 0 decreases i {
    check world.out.write("tick\n")
    i = i - 1
}
```

The compiler accepts the loop if and only if it can identify an assignment to the decreases measure that strictly decreases it. Failure looks like a normal Zero diagnostic:

```
$ bin/zero check --json examples/loop.0
{
  "code": "TER001",
  "message": "could not prove the decreases measure 'i' strictly decreases on every iteration",
  "expected": "an assignment such as <var> = <var> - K or <var> = <var> / N inside the loop body",
  "actual": "no recognized decreasing assignment in the loop body",
  "fixSafety": "behavior-preserving",
  "repair": { "id": "ensure-decreasing-measure", ... }
}
```

`zero explain TER001` returns the full ExplainInfo entry, same shape as TYP009 / BOR001.

## Soundness boundary (read this first)

This PR is deliberately the smallest demo that gives the surface real teeth, **not** a full termination checker. What it does:

- Recognizes `m = m - K` for positive integer literal `K`.
- Recognizes `m = m / N` for integer literal `N > 1`.
- Walks into nested `if` / `else` / `match` branches so a decreasing assignment behind a branch still counts.

What it explicitly does **not** do:

- No SMT. Verus reaches for Z3 here; this prototype is pure AST pattern matching.
- No path sensitivity: a single decreasing assignment anywhere in the body satisfies the check, even if a sibling branch makes the measure stay constant or grow. **This is unsound** in the strict sense and is the first thing a real implementation would have to fix.
- No lexicographic measures (`decreases a, b`).
- No recursive-function termination.
- No interaction with the borrow checker, which would matter once the measure can be a field or an indexed place.

Trade-off is deliberate: keep the compiler delta small enough to discuss the *language surface and diagnostic surface* without committing the project to a Z3 dependency.

## What the patch actually touches

- `native/zero-c/src/lexer.c` — `decreases` keyword.
- `native/zero-c/include/zero.h` — one new field `Expr *decreases` on `Stmt`.
- `native/zero-c/src/parser.c` — `while <expr> decreases <expr> { ... }` syntax; frees the new expr.
- `native/zero-c/src/checker.c` — three small AST predicates (`expr_is_positive_int_literal`, `expr_is_int_literal_gt_one`, `expr_is_strict_decrease`), a mutually-recursive `stmt_vec_has_strict_decrease` walker, and the actual emit site inside the existing `STMT_WHILE` branch of `check_stmt`.
- `native/zero-c/src/main.c` — TER001 wired through `diag_code`, `diag_fix_safety` (`behavior-preserving`), `diag_repair_id` (`ensure-decreasing-measure`), `diag_repair_summary`, `explain_infos`, and the explain JSON repair-id map. New integer code is 11001 — leaves room for a TER family without colliding with existing prefixes.
- `conformance/check/pass/decreases-countdown.0` and `conformance/check/fail/decreases-no-progress.0` — minimal fixtures, plus assertions in `conformance/run.mjs` that lock the diagnostic shape and the `zero explain --json TER001` payload.

123 insertions, 2 deletions.

## Why a draft, why now

Opening this as a draft because the question in #149 is whether Zero wants to be in this territory *at all*. A native `decreases` is one of the smaller cuts of that surface — no proof obligations, no refinement types, no spec language — but it already requires a new keyword and a new diagnostic family. If the answer in #149 is "out of scope by design", close this and the branch goes away cleanly. If the answer is "interesting, but the design needs to look different", this PR is a place to argue against, not a place to merge.

If there's appetite to keep going, the obvious next slices in roughly increasing order of difficulty:

1. Path sensitivity (every loop-completing path must decrease).
2. Lexicographic measures.
3. Recursion termination on calls to the same function.
4. SMT-backed checks for non-literal decrement expressions.
5. `requires` / `ensures` (a much larger commitment).

## Validation

Local, macOS arm64:

- `make -C native/zero-c`
- `bin/zero check` on the new pass fixture — exit 0
- `bin/zero check --json` on the new fail fixture — `TER001`, `behavior-preserving`, `ensure-decreasing-measure`
- `bin/zero explain --json TER001` — full payload
- `pnpm run conformance:local`
- `pnpm run command-contracts:local`
- `pnpm run native:smoke`
- `pnpm run agent:demo`

Related: #149 (open question on whether this whole direction is in scope).