### PR TITLE
Add direct generic specialization table

### DIFF
--- a/conformance/agent-surface/classification.json
+++ b/conformance/agent-surface/classification.json
@@ -75,6 +75,14 @@
       "runner": "assert-target-ready"
     },
     {
+      "id": "direct-generic-specialization-name-collision",
+      "path": "conformance/agent-surface/fixtures/direct-generic-specialization-name-collision.0",
+      "classification": "unsupported-program-shape",
+      "currentBehavior": "check-pass-target-blocked-CGEN004",
+      "followUp": "Keep direct generic specialization names from silently resolving to unrelated concrete functions.",
+      "runner": "assert-target-blocked"
+    },
+    {
       "id": "polymorphic-recursion-growth",
       "path": "conformance/agent-surface/fixtures/polymorphic-recursion-growth.0",
       "classification": "unsupported-language-feature",

--- a/conformance/agent-surface/fixtures/direct-generic-specialization-name-collision.0
+++ b/conformance/agent-surface/fixtures/direct-generic-specialization-name-collision.0
@@ -1,0 +1,16 @@
+fun identity<T>(value: T) -> T {
+    return value
+}
+
+fun identity__i32(value: i32) -> i32 {
+    return value + 1
+}
+
+pub fun main(world: World) -> Void raises {
+    let value: i32 = identity<i32>(1)
+    if value == 1 {
+        check world.out.write("direct specialization collision avoided\n")
+    } else {
+        check world.out.write("direct specialization collision reached wrong target\n")
+    }
+}

--- a/conformance/native/pass/generic-multi-specialization.0
+++ b/conformance/native/pass/generic-multi-specialization.0
@@ -1,0 +1,17 @@
+fun first<A, B>(left: A, right: B) -> A {
+    return left
+}
+
+fun second<A, B>(left: A, right: B) -> B {
+    return right
+}
+
+pub fun main(world: World) -> Void raises {
+    let a: i32 = first<i32, u8>(21, 7)
+    let b: u8 = second<i32, u8>(a, 6)
+    if a == 21 && b == 6 {
+        check world.out.write("generic multi specialization ok\n")
+    } else {
+        check world.out.write("generic multi specialization broke\n")
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -336,6 +336,7 @@ for (const fixture of [
   "conformance/native/pass/generic-function-basic.0",
   "conformance/native/pass/generic-nested-calls.0",
   "conformance/native/pass/generic-specialization-reuse.0",
+  "conformance/native/pass/generic-multi-specialization.0",
   "conformance/native/pass/generic-shape-basic.0",
   "conformance/native/pass/generic-shape-multi.0",
   "conformance/native/pass/generic-shape-methods.0",
@@ -407,6 +408,7 @@ for (const fixture of [
   "conformance/check/pass/generic-method-outer-param-inference.0",
   "conformance/native/pass/generic-nested-calls.0",
   "conformance/native/pass/generic-specialization-reuse.0",
+  "conformance/native/pass/generic-multi-specialization.0",
   "conformance/check/pass/generic-shape-basic.0",
   "conformance/check/pass/generic-shape-multi.0",
   "conformance/check/pass/generic-shape-methods.0",
@@ -472,6 +474,7 @@ assert.deepEqual(agentSurfaceClassification.fixtures.map((item) => item.id), [
   "method-generic-self-shadowing",
   "interface-method-generic-binding",
   "direct-generic-recursion",
+  "direct-generic-specialization-name-collision",
   "polymorphic-recursion-growth",
   "mutual-polymorphic-recursion-growth",
   "mutual-polymorphic-recursion-inferred-growth",
@@ -523,6 +526,22 @@ assert.equal(agentSurfaceDirectGenericReadinessBody.ok, true);
 assert.equal(agentSurfaceDirectGenericReadinessBody.targetReadiness.ok, true);
 assert.equal(agentSurfaceDirectGenericReadinessBody.targetReadiness.buildable, true);
 assert.equal(agentSurfaceDirectGenericReadinessBody.targetReadiness.diagnostics.length, 0);
+
+const agentSurfaceDirectGenericCollisionReadiness = await execFileAsync(zero, [
+  "check",
+  "--json",
+  "--emit",
+  "obj",
+  "--target",
+  "linux-musl-x64",
+  "conformance/agent-surface/fixtures/direct-generic-specialization-name-collision.0",
+]);
+const agentSurfaceDirectGenericCollisionReadinessBody = JSON.parse(agentSurfaceDirectGenericCollisionReadiness.stdout);
+assert.equal(agentSurfaceDirectGenericCollisionReadinessBody.ok, true);
+assert.equal(agentSurfaceDirectGenericCollisionReadinessBody.targetReadiness.ok, false);
+assert.equal(agentSurfaceDirectGenericCollisionReadinessBody.targetReadiness.buildable, false);
+assert.equal(agentSurfaceDirectGenericCollisionReadinessBody.targetReadiness.diagnostics[0].code, "CGEN004");
+assert.match(agentSurfaceDirectGenericCollisionReadinessBody.targetReadiness.diagnostics[0].message, /specialization name collides/);
 
 const agentSurfacePolymorphicRecursion = await execFileAsync(zero, ["check", "--json", "conformance/agent-surface/fixtures/polymorphic-recursion-growth.0"]).catch((error) => error);
 assert.notEqual(agentSurfacePolymorphicRecursion.code, 0);
@@ -2588,6 +2607,7 @@ for (const runtimeFixture of [
   ["conformance/native/pass/mutref-indexed-lvalues.0", "mutref-indexed-lvalues", { stdout: "mutref indexed lvalues ok\n" }],
   ["conformance/native/pass/generic-mem.0", "generic-mem", { stdout: "generic mem ok\n" }],
   ["conformance/native/pass/generic-nested-calls.0", "generic-nested-calls", { stdout: "generic nested calls ok\n" }],
+  ["conformance/native/pass/generic-multi-specialization.0", "generic-multi-specialization", { stdout: "generic multi specialization ok\n" }],
   ["conformance/native/pass/static-interface-mutref.0", "static-interface-mutref", { stdout: "static interface mutref ok\n" }],
   ["conformance/native/pass/owned-transfer.0", "owned-transfer", { stdout: "owned transfer ok\n" }],
   ["conformance/native/pass/owned-drop-cleanup.0", "owned-drop-cleanup", { stdout: "owned drop cleanup ok\n" }],

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -1,4 +1,5 @@
 #include "zero.h"
+#include "specialize.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -8,6 +9,7 @@
 
 #define IR_READONLY_DATA_BASE 1024u
 #define IR_READONLY_DATA_LIMIT 65536u
+#define IR_SPECIALIZATION_PLAN_LIMIT 1024u
 
 static Expr *clone_expr(const Expr *expr);
 static Stmt *clone_stmt(const Stmt *stmt);
@@ -1082,19 +1084,7 @@ static const TypeArgVec *ir_call_type_args(const Expr *call) {
 }
 
 static char *ir_specialized_function_name(const Function *fun, const TypeArgVec *type_args) {
-  ZBuf buf;
-  zbuf_init(&buf);
-  zbuf_append(&buf, fun && fun->name ? fun->name : "");
-  for (size_t i = 0; type_args && i < type_args->len; i++) {
-    zbuf_append(&buf, "__");
-    const char *type = type_args->items[i].type ? type_args->items[i].type : "Unknown";
-    for (const char *p = type; *p; p++) {
-      char c = *p;
-      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') zbuf_append_char(&buf, c);
-      else zbuf_append_char(&buf, '_');
-    }
-  }
-  return buf.data;
+  return z_specialized_function_name(fun, type_args);
 }
 
 static const char *ir_substitute_type_param(const Function *fun, const TypeArgVec *type_args, const char *type) {
@@ -2445,11 +2435,6 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
           return false;
         }
       }
-      if (callee->type_params.len > 1) {
-        free(specialized_name);
-        ir_mark_unsupported(ir, "direct backend generic calls currently support one type parameter", expr->line, expr->column, callee->name);
-        return false;
-      }
       if (callee->params.len != expr->args.len) {
         free(specialized_name);
         ir_mark_unsupported(ir, "direct backend call argument count does not match callee", expr->line, expr->column, callee->name);
@@ -3249,38 +3234,62 @@ static bool ir_function_vec_has_name(const FunctionVec *functions, const char *n
   return false;
 }
 
-static void ir_collect_generic_specializations_from_expr(FunctionVec *functions, const Program *program, const Expr *expr);
+static bool ir_collect_generic_specializations_from_expr(FunctionVec *functions, ZSpecializationPlan *plan, IrProgram *ir, const Program *program, const Expr *expr);
 
-static void ir_collect_generic_specializations_from_stmt_vec(FunctionVec *functions, const Program *program, const StmtVec *body) {
+static bool ir_collect_generic_specializations_from_stmt_vec(FunctionVec *functions, ZSpecializationPlan *plan, IrProgram *ir, const Program *program, const StmtVec *body) {
   for (size_t i = 0; body && i < body->len; i++) {
     const Stmt *stmt = body->items[i];
     if (!stmt) continue;
-    ir_collect_generic_specializations_from_expr(functions, program, stmt->target);
-    ir_collect_generic_specializations_from_expr(functions, program, stmt->expr);
-    ir_collect_generic_specializations_from_expr(functions, program, stmt->range_end);
-    ir_collect_generic_specializations_from_stmt_vec(functions, program, &stmt->then_body);
-    ir_collect_generic_specializations_from_stmt_vec(functions, program, &stmt->else_body);
+    if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, stmt->target)) return false;
+    if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, stmt->expr)) return false;
+    if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, stmt->range_end)) return false;
+    if (!ir_collect_generic_specializations_from_stmt_vec(functions, plan, ir, program, &stmt->then_body)) return false;
+    if (!ir_collect_generic_specializations_from_stmt_vec(functions, plan, ir, program, &stmt->else_body)) return false;
     for (size_t arm_index = 0; arm_index < stmt->match_arms.len; arm_index++) {
-      ir_collect_generic_specializations_from_stmt_vec(functions, program, &stmt->match_arms.items[arm_index].body);
+      if (!ir_collect_generic_specializations_from_stmt_vec(functions, plan, ir, program, &stmt->match_arms.items[arm_index].body)) return false;
     }
   }
+  return true;
 }
 
-static void ir_collect_generic_specializations_from_expr(FunctionVec *functions, const Program *program, const Expr *expr) {
-  if (!expr) return;
+static bool ir_collect_generic_specializations_from_expr(FunctionVec *functions, ZSpecializationPlan *plan, IrProgram *ir, const Program *program, const Expr *expr) {
+  if (!expr) return true;
   if (expr->kind == EXPR_CALL && expr->left && expr->left->kind == EXPR_IDENT) {
     const Function *callee = ir_find_source_function(program, expr->left->text, NULL);
     const TypeArgVec *type_args = ir_call_type_args(expr);
-    if (callee && callee->type_params.len > 0 && type_args && type_args->len == callee->type_params.len && callee->type_params.len == 1) {
-      char *specialized_name = ir_specialized_function_name(callee, type_args);
-      if (!ir_function_vec_has_name(functions, specialized_name)) ir_push_specialized_function(functions, callee, type_args);
+    if (callee && callee->type_params.len > 0 && type_args && type_args->len == callee->type_params.len) {
+      char *specialized_name = NULL;
+      ZSpecializationAddResult add_result = z_specialization_plan_add(plan, callee, type_args, &specialized_name);
+      if (add_result == Z_SPECIALIZATION_ADD_LIMIT) {
+        free(specialized_name);
+        ir_mark_unsupported(ir, "direct backend generic specialization plan exceeded its instantiation limit", expr->line, expr->column, callee->name);
+        return false;
+      }
+      if (add_result == Z_SPECIALIZATION_ADD_NAME_COLLISION) {
+        free(specialized_name);
+        ir_mark_unsupported(ir, "direct backend generic specialization name is ambiguous", expr->line, expr->column, callee->name);
+        return false;
+      }
+      if (add_result == Z_SPECIALIZATION_ADD_ADDED) {
+        if (ir_function_vec_has_name(functions, specialized_name)) {
+          free(specialized_name);
+          ir_mark_unsupported(ir, "direct backend generic specialization name collides with an existing function", expr->line, expr->column, callee->name);
+          return false;
+        }
+        ir_push_specialized_function(functions, callee, type_args);
+      }
       free(specialized_name);
     }
   }
-  ir_collect_generic_specializations_from_expr(functions, program, expr->left);
-  ir_collect_generic_specializations_from_expr(functions, program, expr->right);
-  for (size_t i = 0; i < expr->args.len; i++) ir_collect_generic_specializations_from_expr(functions, program, expr->args.items[i]);
-  for (size_t i = 0; i < expr->fields.len; i++) ir_collect_generic_specializations_from_expr(functions, program, expr->fields.items[i].value);
+  if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, expr->left)) return false;
+  if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, expr->right)) return false;
+  for (size_t i = 0; i < expr->args.len; i++) {
+    if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, expr->args.items[i])) return false;
+  }
+  for (size_t i = 0; i < expr->fields.len; i++) {
+    if (!ir_collect_generic_specializations_from_expr(functions, plan, ir, program, expr->fields.items[i].value)) return false;
+  }
+  return true;
 }
 
 static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program, const SourceInput *input) {
@@ -3299,8 +3308,16 @@ static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program
   for (size_t i = 0; i < program->functions.len; i++) {
     if (!program->functions.items[i].is_test && program->functions.items[i].type_params.len == 0) push_function_clone(&direct_functions, &program->functions.items[i]);
   }
+  ZSpecializationPlan specialization_plan;
+  z_specialization_plan_init(&specialization_plan, IR_SPECIALIZATION_PLAN_LIMIT);
   for (size_t i = 0; i < direct_functions.len; i++) {
-    ir_collect_generic_specializations_from_stmt_vec(&direct_functions, program, &direct_functions.items[i].body);
+    if (!ir_collect_generic_specializations_from_stmt_vec(&direct_functions, &specialization_plan, ir, program, &direct_functions.items[i].body)) {
+      z_specialization_plan_free(&specialization_plan);
+      Program temp_program = {0};
+      temp_program.functions = direct_functions;
+      z_free_program(&temp_program);
+      return;
+    }
   }
   IrFunctionOrder *order = z_checked_calloc(direct_functions.len ? direct_functions.len : 1, sizeof(IrFunctionOrder));
   char **stable_ids = z_checked_calloc(direct_functions.len ? direct_functions.len : 1, sizeof(char *));
@@ -3322,6 +3339,7 @@ static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program
       free(order);
       for (size_t stable_index = 0; stable_index < direct_functions.len; stable_index++) free(stable_ids[stable_index]);
       free(stable_ids);
+      z_specialization_plan_free(&specialization_plan);
       Program temp_program = {0};
       temp_program.functions = direct_functions;
       z_free_program(&temp_program);
@@ -3331,6 +3349,7 @@ static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program
   free(order);
   for (size_t stable_index = 0; stable_index < direct_functions.len; stable_index++) free(stable_ids[stable_index]);
   free(stable_ids);
+  z_specialization_plan_free(&specialization_plan);
   Program temp_program = {0};
   temp_program.functions = direct_functions;
   z_free_program(&temp_program);

--- a/native/zero-c/src/specialize.c
+++ b/native/zero-c/src/specialize.c
@@ -1,0 +1,108 @@
+#include "specialize.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static void z_specialization_type_args_free(TypeArgVec *args) {
+  if (!args) return;
+  for (size_t i = 0; i < args->len; i++) free(args->items[i].type);
+  free(args->items);
+  *args = (TypeArgVec){0};
+}
+
+static void z_specialization_type_args_push_clone(TypeArgVec *vec, const TypeArg *arg) {
+  if (vec->len + 1 > vec->cap) {
+    vec->cap = z_grow_capacity(vec->cap, vec->len + 1, 4);
+    vec->items = z_checked_reallocarray(vec->items, vec->cap, sizeof(TypeArg));
+  }
+  vec->items[vec->len++] = (TypeArg){
+    .type = arg && arg->type ? z_strdup(arg->type) : NULL,
+    .line = arg ? arg->line : 0,
+    .column = arg ? arg->column : 0
+  };
+}
+
+static TypeArgVec z_specialization_type_args_clone(const TypeArgVec *source) {
+  TypeArgVec copy = {0};
+  for (size_t i = 0; source && i < source->len; i++) z_specialization_type_args_push_clone(&copy, &source->items[i]);
+  return copy;
+}
+
+static bool z_specialization_type_args_equal(const TypeArgVec *left, const TypeArgVec *right) {
+  size_t left_len = left ? left->len : 0;
+  size_t right_len = right ? right->len : 0;
+  if (left_len != right_len) return false;
+  for (size_t i = 0; i < left_len; i++) {
+    const char *left_type = left->items[i].type ? left->items[i].type : "";
+    const char *right_type = right->items[i].type ? right->items[i].type : "";
+    if (strcmp(left_type, right_type) != 0) return false;
+  }
+  return true;
+}
+
+void z_specialization_plan_init(ZSpecializationPlan *plan, size_t limit) {
+  if (!plan) return;
+  *plan = (ZSpecializationPlan){.limit = limit};
+}
+
+void z_specialization_plan_free(ZSpecializationPlan *plan) {
+  if (!plan) return;
+  for (size_t i = 0; i < plan->len; i++) {
+    free(plan->items[i].name);
+    z_specialization_type_args_free(&plan->items[i].type_args);
+  }
+  free(plan->items);
+  *plan = (ZSpecializationPlan){0};
+}
+
+char *z_specialized_function_name(const Function *fun, const TypeArgVec *type_args) {
+  ZBuf buf;
+  zbuf_init(&buf);
+  zbuf_append(&buf, fun && fun->name ? fun->name : "");
+  for (size_t i = 0; type_args && i < type_args->len; i++) {
+    zbuf_append(&buf, "__");
+    const char *type = type_args->items[i].type ? type_args->items[i].type : "Unknown";
+    for (const char *p = type; *p; p++) {
+      char c = *p;
+      if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '_') zbuf_append_char(&buf, c);
+      else zbuf_append_char(&buf, '_');
+    }
+  }
+  return buf.data;
+}
+
+ZSpecializationAddResult z_specialization_plan_add(ZSpecializationPlan *plan, const Function *source, const TypeArgVec *type_args, char **out_name) {
+  char *name = z_specialized_function_name(source, type_args);
+  if (out_name) *out_name = z_strdup(name);
+  if (plan) {
+    for (size_t i = 0; i < plan->len; i++) {
+      if (plan->items[i].source == source && z_specialization_type_args_equal(&plan->items[i].type_args, type_args)) {
+        free(name);
+        return Z_SPECIALIZATION_ADD_PRESENT;
+      }
+      if (plan->items[i].name && strcmp(plan->items[i].name, name) == 0) {
+        free(name);
+        return Z_SPECIALIZATION_ADD_NAME_COLLISION;
+      }
+    }
+  }
+  if (plan && plan->limit > 0 && plan->len >= plan->limit) {
+    plan->hit_limit = true;
+    free(name);
+    return Z_SPECIALIZATION_ADD_LIMIT;
+  }
+  if (!plan) {
+    free(name);
+    return Z_SPECIALIZATION_ADD_LIMIT;
+  }
+  if (plan->len + 1 > plan->cap) {
+    plan->cap = z_grow_capacity(plan->cap, plan->len + 1, 8);
+    plan->items = z_checked_reallocarray(plan->items, plan->cap, sizeof(ZSpecializationEntry));
+  }
+  plan->items[plan->len++] = (ZSpecializationEntry){
+    .source = source,
+    .type_args = z_specialization_type_args_clone(type_args),
+    .name = name
+  };
+  return Z_SPECIALIZATION_ADD_ADDED;
+}

--- a/native/zero-c/src/specialize.h
+++ b/native/zero-c/src/specialize.h
@@ -1,0 +1,32 @@
+#ifndef ZERO_C_SPECIALIZE_H
+#define ZERO_C_SPECIALIZE_H
+
+#include "zero.h"
+
+typedef enum {
+  Z_SPECIALIZATION_ADD_ADDED,
+  Z_SPECIALIZATION_ADD_PRESENT,
+  Z_SPECIALIZATION_ADD_NAME_COLLISION,
+  Z_SPECIALIZATION_ADD_LIMIT
+} ZSpecializationAddResult;
+
+typedef struct {
+  const Function *source;
+  TypeArgVec type_args;
+  char *name;
+} ZSpecializationEntry;
+
+typedef struct {
+  ZSpecializationEntry *items;
+  size_t len;
+  size_t cap;
+  size_t limit;
+  bool hit_limit;
+} ZSpecializationPlan;
+
+void z_specialization_plan_init(ZSpecializationPlan *plan, size_t limit);
+void z_specialization_plan_free(ZSpecializationPlan *plan);
+char *z_specialized_function_name(const Function *fun, const TypeArgVec *type_args);
+ZSpecializationAddResult z_specialization_plan_add(ZSpecializationPlan *plan, const Function *source, const TypeArgVec *type_args, char **out_name);
+
+#endif


### PR DESCRIPTION
- Track direct generic instantiations before MIR lowering
- Reject ambiguous specialization targets before codegen
- Cover multi-argument generics and collision readiness