### PR TITLE
Strengthen generic direct specialization

### DIFF
--- a/conformance/native/pass/generic-inferred-specialized-call.0
+++ b/conformance/native/pass/generic-inferred-specialized-call.0
@@ -1,0 +1,16 @@
+fun identity<T>(value: T) -> T {
+  return value
+}
+
+fun forward<T>(value: T) -> T {
+  return identity(value)
+}
+
+pub fun main(world: World) -> Void raises {
+  let value: i32 = forward<i32>(42)
+  if value == 42 {
+    check world.out.write("generic inferred specialized call ok\n")
+  } else {
+    check world.out.write("generic inferred specialized call broke\n")
+  }
+}

--- a/conformance/native/pass/generic-nested-local-specialization.0
+++ b/conformance/native/pass/generic-nested-local-specialization.0
@@ -1,0 +1,12 @@
+fun has_none<T>(value: T) -> Bool {
+    let maybe: Maybe<T> = null
+    return maybe.has == false
+}
+
+pub fun main(world: World) -> Void raises {
+    if has_none<i32>(1) {
+        check world.out.write("generic nested local specialization ok\n")
+    } else {
+        check world.out.write("generic nested local specialization broke\n")
+    }
+}

--- a/conformance/native/pass/generic-static-array-specialization.0
+++ b/conformance/native/pass/generic-static-array-specialization.0
@@ -1,0 +1,12 @@
+fun array_len<static N: usize>() -> usize {
+    let bytes: [N]u8 = [1_u8; N]
+    return std.mem.len(bytes)
+}
+
+pub fun main(world: World) -> Void raises {
+    if array_len<4>() == 4 {
+        check world.out.write("generic static array specialization ok\n")
+    } else {
+        check world.out.write("generic static array specialization broke\n")
+    }
+}

--- a/conformance/native/pass/generic-static-forwarded-array-specialization.0
+++ b/conformance/native/pass/generic-static-forwarded-array-specialization.0
@@ -1,0 +1,16 @@
+fun inner<static N: usize>() -> usize {
+    let bytes: [N]u8 = [1_u8; N]
+    return std.mem.len(bytes)
+}
+
+fun outer<static N: usize>() -> usize {
+    return inner<N>()
+}
+
+pub fun main(world: World) -> Void raises {
+    if outer<4>() == 4 {
+        check world.out.write("generic static forwarded array specialization ok\n")
+    } else {
+        check world.out.write("generic static forwarded array specialization broke\n")
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -354,6 +354,7 @@ for (const fixture of [
   "conformance/native/pass/generic-inferred-specialized-call.0",
   "conformance/native/pass/generic-nested-local-specialization.0",
   "conformance/native/pass/generic-static-array-specialization.0",
+  "conformance/native/pass/generic-static-forwarded-array-specialization.0",
   "conformance/native/pass/generic-shape-basic.0",
   "conformance/native/pass/generic-shape-multi.0",
   "conformance/native/pass/generic-shape-methods.0",
@@ -429,6 +430,7 @@ for (const fixture of [
   "conformance/native/pass/generic-inferred-specialized-call.0",
   "conformance/native/pass/generic-nested-local-specialization.0",
   "conformance/native/pass/generic-static-array-specialization.0",
+  "conformance/native/pass/generic-static-forwarded-array-specialization.0",
   "conformance/check/pass/generic-shape-basic.0",
   "conformance/check/pass/generic-shape-multi.0",
   "conformance/check/pass/generic-shape-methods.0",
@@ -2604,6 +2606,8 @@ for (const runtimeFixture of [
 await assertDirectRuntimeRequired("conformance/native/pass/generic-function-basic.0", "generic-function-basic-required", { stdout: "generic function ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-nested-calls.0", "generic-nested-calls-required", { stdout: "generic nested calls ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-inferred-specialized-call.0", "generic-inferred-specialized-call-required", { stdout: "generic inferred specialized call ok\n" });
+await assertDirectRuntimeRequired("conformance/native/pass/generic-static-array-specialization.0", "generic-static-array-specialization-required", { stdout: "generic static array specialization ok\n" });
+await assertDirectRuntimeRequired("conformance/native/pass/generic-static-forwarded-array-specialization.0", "generic-static-forwarded-array-specialization-required", { stdout: "generic static forwarded array specialization ok\n" });
 
 const abiDump = await execFileAsync(zero, ["abi", "dump", "--json", "conformance/native/pass/const-layout.0"]);
 const abiDumpBody = JSON.parse(abiDump.stdout);
@@ -2635,6 +2639,7 @@ for (const runtimeFixture of [
   ["conformance/native/pass/generic-inferred-specialized-call.0", "generic-inferred-specialized-call", { stdout: "generic inferred specialized call ok\n" }],
   ["conformance/native/pass/generic-nested-local-specialization.0", "generic-nested-local-specialization", { stdout: "generic nested local specialization ok\n" }],
   ["conformance/native/pass/generic-static-array-specialization.0", "generic-static-array-specialization", { stdout: "generic static array specialization ok\n" }],
+  ["conformance/native/pass/generic-static-forwarded-array-specialization.0", "generic-static-forwarded-array-specialization", { stdout: "generic static forwarded array specialization ok\n" }],
   ["conformance/native/pass/static-interface-mutref.0", "static-interface-mutref", { stdout: "static interface mutref ok\n" }],
   ["conformance/native/pass/owned-transfer.0", "owned-transfer", { stdout: "owned transfer ok\n" }],
   ["conformance/native/pass/owned-drop-cleanup.0", "owned-drop-cleanup", { stdout: "owned drop cleanup ok\n" }],

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -2162,6 +2162,18 @@ const genericPairSizeBody = JSON.parse(genericPairSize.stdout);
 assert(genericPairSizeBody.genericSpecializations.some((item) => item.name === "z_Pair_i32_u8_"));
 assert(genericPairSizeBody.genericSpecializations.some((item) => item.name === "z_makePair__i32__u8"));
 
+const genericInferredSize = await execFileAsync(zero, ["size", "--json", "conformance/native/pass/generic-inferred-specialized-call.0"]);
+const genericInferredSizeBody = JSON.parse(genericInferredSize.stdout);
+assert(genericInferredSizeBody.genericSpecializations.some((item) => item.name === "z_forward__i32"));
+assert(genericInferredSizeBody.genericSpecializations.some((item) => item.name === "z_identity__i32"));
+assert(!genericInferredSizeBody.genericSpecializations.some((item) => item.name === "z_identity__T"));
+
+const genericStaticForwardedSize = await execFileAsync(zero, ["size", "--json", "conformance/native/pass/generic-static-forwarded-array-specialization.0"]);
+const genericStaticForwardedSizeBody = JSON.parse(genericStaticForwardedSize.stdout);
+assert(genericStaticForwardedSizeBody.genericSpecializations.some((item) => item.name === "z_outer__4"));
+assert(genericStaticForwardedSizeBody.genericSpecializations.some((item) => item.name === "z_inner__4"));
+assert(!genericStaticForwardedSizeBody.genericSpecializations.some((item) => item.name === "z_inner__N"));
+
 const targetsJson = await execFileAsync(zero, ["targets"]);
 const targetsBody = JSON.parse(targetsJson.stdout);
 const linuxMuslTarget = targetsBody.targets.find((item) => item.name === "linux-musl-x64");
@@ -2606,6 +2618,7 @@ for (const runtimeFixture of [
 await assertDirectRuntimeRequired("conformance/native/pass/generic-function-basic.0", "generic-function-basic-required", { stdout: "generic function ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-nested-calls.0", "generic-nested-calls-required", { stdout: "generic nested calls ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-inferred-specialized-call.0", "generic-inferred-specialized-call-required", { stdout: "generic inferred specialized call ok\n" });
+await assertDirectRuntimeRequired("conformance/native/pass/generic-nested-local-specialization.0", "generic-nested-local-specialization-required", { stdout: "generic nested local specialization ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-static-array-specialization.0", "generic-static-array-specialization-required", { stdout: "generic static array specialization ok\n" });
 await assertDirectRuntimeRequired("conformance/native/pass/generic-static-forwarded-array-specialization.0", "generic-static-forwarded-array-specialization-required", { stdout: "generic static forwarded array specialization ok\n" });
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -62,6 +62,20 @@ async function assertDirectRuntimeOrUnsupported(fixture, name, expected) {
   if (expected.file) assert.equal(await readFile(`${outDir}/${expected.file.name}`, "utf8"), expected.file.text);
 }
 
+async function assertDirectRuntimeRequired(fixture, name, expected) {
+  const target = runnableDirectTarget ?? "linux-musl-x64";
+  const out = `${outDir}/${name}`;
+  const build = await execFileAsync(zero, ["build", "--json", "--emit", "exe", "--target", target, fixture, "--out", out]);
+  const body = JSON.parse(build.stdout);
+  assert.equal(body.generatedCBytes, 0);
+  assert.equal(body.legacy, false);
+  if (!runnableDirectTarget) return;
+  const run = await execFileAsync(out, expected.args ?? [], expected.env ? { env: { ...process.env, ...expected.env } } : {});
+  if (expected.stdout instanceof RegExp) assert.match(run.stdout, expected.stdout);
+  else assert.equal(run.stdout, expected.stdout);
+  if (expected.stderr !== undefined) assert.equal(run.stderr, expected.stderr);
+}
+
 async function assertCommonRuntimeOrUnsupported(fixture, name, expected) {
   const target = runnableDirectTarget ?? "linux-musl-x64";
   const out = `${outDir}/${name}`;
@@ -337,6 +351,9 @@ for (const fixture of [
   "conformance/native/pass/generic-nested-calls.0",
   "conformance/native/pass/generic-specialization-reuse.0",
   "conformance/native/pass/generic-multi-specialization.0",
+  "conformance/native/pass/generic-inferred-specialized-call.0",
+  "conformance/native/pass/generic-nested-local-specialization.0",
+  "conformance/native/pass/generic-static-array-specialization.0",
   "conformance/native/pass/generic-shape-basic.0",
   "conformance/native/pass/generic-shape-multi.0",
   "conformance/native/pass/generic-shape-methods.0",
@@ -409,6 +426,9 @@ for (const fixture of [
   "conformance/native/pass/generic-nested-calls.0",
   "conformance/native/pass/generic-specialization-reuse.0",
   "conformance/native/pass/generic-multi-specialization.0",
+  "conformance/native/pass/generic-inferred-specialized-call.0",
+  "conformance/native/pass/generic-nested-local-specialization.0",
+  "conformance/native/pass/generic-static-array-specialization.0",
   "conformance/check/pass/generic-shape-basic.0",
   "conformance/check/pass/generic-shape-multi.0",
   "conformance/check/pass/generic-shape-methods.0",
@@ -2581,6 +2601,10 @@ for (const runtimeFixture of [
   await assertDirectRuntimeOrUnsupported(...runtimeFixture);
 }
 
+await assertDirectRuntimeRequired("conformance/native/pass/generic-function-basic.0", "generic-function-basic-required", { stdout: "generic function ok\n" });
+await assertDirectRuntimeRequired("conformance/native/pass/generic-nested-calls.0", "generic-nested-calls-required", { stdout: "generic nested calls ok\n" });
+await assertDirectRuntimeRequired("conformance/native/pass/generic-inferred-specialized-call.0", "generic-inferred-specialized-call-required", { stdout: "generic inferred specialized call ok\n" });
+
 const abiDump = await execFileAsync(zero, ["abi", "dump", "--json", "conformance/native/pass/const-layout.0"]);
 const abiDumpBody = JSON.parse(abiDump.stdout);
 assert.equal(abiDumpBody.schemaVersion, 1);
@@ -2608,6 +2632,9 @@ for (const runtimeFixture of [
   ["conformance/native/pass/generic-mem.0", "generic-mem", { stdout: "generic mem ok\n" }],
   ["conformance/native/pass/generic-nested-calls.0", "generic-nested-calls", { stdout: "generic nested calls ok\n" }],
   ["conformance/native/pass/generic-multi-specialization.0", "generic-multi-specialization", { stdout: "generic multi specialization ok\n" }],
+  ["conformance/native/pass/generic-inferred-specialized-call.0", "generic-inferred-specialized-call", { stdout: "generic inferred specialized call ok\n" }],
+  ["conformance/native/pass/generic-nested-local-specialization.0", "generic-nested-local-specialization", { stdout: "generic nested local specialization ok\n" }],
+  ["conformance/native/pass/generic-static-array-specialization.0", "generic-static-array-specialization", { stdout: "generic static array specialization ok\n" }],
   ["conformance/native/pass/static-interface-mutref.0", "static-interface-mutref", { stdout: "static interface mutref ok\n" }],
   ["conformance/native/pass/owned-transfer.0", "owned-transfer", { stdout: "owned transfer ok\n" }],
   ["conformance/native/pass/owned-drop-cleanup.0", "owned-drop-cleanup", { stdout: "owned drop cleanup ok\n" }],

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -141,6 +141,7 @@ struct Expr {
   Expr *right;
   ExprVec args;
   TypeArgVec type_args;
+  TypeArgVec checked_type_args;
   FieldInitVec fields;
   int line;
   int column;

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -1880,6 +1880,7 @@ static const Choice *find_choice(const Program *program, const char *name);
 static const Param *find_case(const ParamVec *cases, const char *name);
 static const Function *find_shape_method_decl(const Shape *shape, const char *name);
 static void set_expr_resolved_type(const Expr *expr, const char *type);
+static void set_expr_checked_type_args(const Expr *expr, GenericBinding *bindings, size_t binding_len);
 static const Function *find_namespace_shape_method(const Program *program, const Expr *callee, const Shape **out_shape);
 static const Function *find_constrained_interface_method_in_function(const Program *program, const Function *fun, const Expr *callee, const InterfaceDecl **out_interface);
 static void strip_ref_like_type(const char *type, char *out, size_t out_len);
@@ -4843,6 +4844,32 @@ static void set_expr_resolved_type(const Expr *expr, const char *type) {
   mutable_expr->resolved_type = z_strdup(type ? type : "Unknown");
 }
 
+static void type_arg_vec_free_shallow(TypeArgVec *args) {
+  if (!args) return;
+  for (size_t i = 0; i < args->len; i++) free(args->items[i].type);
+  free(args->items);
+  *args = (TypeArgVec){0};
+}
+
+static void type_arg_vec_push_copy(TypeArgVec *args, const char *type, int line, int column) {
+  if (!args) return;
+  args->items = z_checked_reallocarray(args->items, args->len + 1, sizeof(TypeArg));
+  args->items[args->len++] = (TypeArg){
+    .type = z_strdup(type ? type : "Unknown"),
+    .line = line,
+    .column = column
+  };
+}
+
+static void set_expr_checked_type_args(const Expr *expr, GenericBinding *bindings, size_t binding_len) {
+  if (!expr) return;
+  Expr *mutable_expr = (Expr *)expr;
+  type_arg_vec_free_shallow(&mutable_expr->checked_type_args);
+  for (size_t i = 0; bindings && i < binding_len; i++) {
+    type_arg_vec_push_copy(&mutable_expr->checked_type_args, bindings[i].type, expr->line, expr->column);
+  }
+}
+
 static void set_stmt_resolved_type(const Stmt *stmt, const char *type) {
   if (!stmt) return;
   Stmt *mutable_stmt = (Stmt *)stmt;
@@ -5704,6 +5731,7 @@ static bool check_named_function_call_expected(CheckContext *ctx, const Program 
     mark_owned_move_if_needed(expr->args.items[i], scope, expected_type);
     free(expected_type);
   }
+  if (generic) set_expr_checked_type_args(expr, bindings, binding_len);
 
   if (generic && function_has_error_flow(ctx, program, fun)) {
     char actual[160];
@@ -6891,9 +6919,9 @@ static bool check_expr_expected(CheckContext *ctx, const Program *program, const
         if (!count || (count->kind != EXPR_NUMBER && count->kind != EXPR_IDENT)) {
           return set_diag_detail(diag, 3006, "array repeat count must be a compile-time integer", count ? count->line : expr->line, count ? count->column : expr->column, "integer literal or static const", count ? "non-integer expression" : "missing count", "use a literal count such as [0_u8; 16]");
         }
-        char *actual_static = canonical_static_arg(program, count->text);
+        char *actual_static = canonical_static_arg_for_type_in_scope(program, scope, count->text, "usize");
         if (!actual_static) {
-          return set_diag_detail(diag, 3006, "array repeat count must be a compile-time integer", count->line, count->column, "integer literal or static const", count->text ? count->text : "<unknown>", "use a literal count or a top-level integer const");
+          return set_diag_detail(diag, 3006, "array repeat count must be a compile-time integer", count->line, count->column, "integer literal, static const, or static parameter", count->text ? count->text : "<unknown>", "use a literal count, top-level integer const, or integer static parameter");
         }
         snprintf(actual_len_text, sizeof(actual_len_text), "%s", actual_static);
         free(actual_static);

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -3242,6 +3242,20 @@ static const char *ir_specialization_arg_for_binder(const Function *fun, const T
   return type_args->items[index].type;
 }
 
+static ZTypeBinderDecl *ir_specialization_binder_decls(const Function *fun) {
+  if (!fun || fun->type_params.len == 0) return NULL;
+  ZTypeBinderDecl *decls = z_checked_calloc(fun->type_params.len, sizeof(ZTypeBinderDecl));
+  for (size_t i = 0; i < fun->type_params.len; i++) {
+    decls[i] = (ZTypeBinderDecl){
+      .name = fun->type_params.items[i].name,
+      .kind = fun->type_params.items[i].is_static ? Z_TYPE_BINDER_STATIC : Z_TYPE_BINDER_TYPE,
+      .id = (ZTypeBinderId)(i + 1),
+      .static_type = fun->type_params.items[i].type ? fun->type_params.items[i].type : "usize"
+    };
+  }
+  return decls;
+}
+
 static void ir_specialize_type_core_into(ZBuf *buf, const ZTypeArena *arena, ZTypeId type, const Function *fun, const TypeArgVec *type_args);
 
 static void ir_specialize_static_value_into(ZBuf *buf, const ZStaticValue *value, const Function *fun, const TypeArgVec *type_args) {
@@ -3294,18 +3308,31 @@ static void ir_specialize_type_core_into(ZBuf *buf, const ZTypeArena *arena, ZTy
   }
 }
 
+static char *ir_specialize_static_arg_text(const char *text, const Function *fun, const TypeArgVec *type_args) {
+  if (!text || !fun || !type_args || fun->type_params.len == 0) return NULL;
+  ZTypeBinderDecl *decls = ir_specialization_binder_decls(fun);
+  ZTypeBinderScope scope = {.items = decls, .len = fun->type_params.len};
+  ZStaticValue value = {0};
+  ZTypeParseError error = {0};
+  if (!z_static_value_parse_with_binders(text, &scope, &value, &error) || value.kind != Z_STATIC_VALUE_BINDER) {
+    z_static_value_free(&value);
+    free(decls);
+    return NULL;
+  }
+  ZBuf buf;
+  zbuf_init(&buf);
+  ir_specialize_static_value_into(&buf, &value, fun, type_args);
+  z_static_value_free(&value);
+  free(decls);
+  return buf.data ? buf.data : z_strdup("");
+}
+
 static char *ir_specialize_type_text(const char *type, const Function *fun, const TypeArgVec *type_args) {
   if (!type) return z_strdup("Unknown");
   if (!fun || !type_args || fun->type_params.len == 0) return z_strdup(type);
-  ZTypeBinderDecl *decls = z_checked_calloc(fun->type_params.len, sizeof(ZTypeBinderDecl));
-  for (size_t i = 0; i < fun->type_params.len; i++) {
-    decls[i] = (ZTypeBinderDecl){
-      .name = fun->type_params.items[i].name,
-      .kind = fun->type_params.items[i].is_static ? Z_TYPE_BINDER_STATIC : Z_TYPE_BINDER_TYPE,
-      .id = (ZTypeBinderId)(i + 1),
-      .static_type = fun->type_params.items[i].type ? fun->type_params.items[i].type : "usize"
-    };
-  }
+  char *static_arg = ir_specialize_static_arg_text(type, fun, type_args);
+  if (static_arg) return static_arg;
+  ZTypeBinderDecl *decls = ir_specialization_binder_decls(fun);
   ZTypeBinderScope scope = {.items = decls, .len = fun->type_params.len};
   ZTypeArena arena;
   z_type_arena_init(&arena);

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -1,5 +1,6 @@
 #include "zero.h"
 #include "specialize.h"
+#include "type_core.h"
 
 #include <limits.h>
 #include <stdint.h>
@@ -90,6 +91,7 @@ static Expr *clone_expr(const Expr *expr) {
   copy->right = clone_expr(expr->right);
   for (size_t i = 0; i < expr->args.len; i++) push_expr_clone(&copy->args, expr->args.items[i]);
   for (size_t i = 0; i < expr->type_args.len; i++) push_type_arg_clone(&copy->type_args, &expr->type_args.items[i]);
+  for (size_t i = 0; i < expr->checked_type_args.len; i++) push_type_arg_clone(&copy->checked_type_args, &expr->checked_type_args.items[i]);
   for (size_t i = 0; i < expr->fields.len; i++) push_field_clone(&copy->fields, &expr->fields.items[i]);
   copy->line = expr->line;
   copy->column = expr->column;
@@ -213,6 +215,17 @@ static bool ir_type_is_direct_fallible_value(IrTypeKind type) {
   return type == IR_TYPE_VOID || type == IR_TYPE_BOOL || type == IR_TYPE_U8 ||
          type == IR_TYPE_U16 || type == IR_TYPE_USIZE || type == IR_TYPE_I32 ||
          type == IR_TYPE_U32;
+}
+
+static IrTypeKind ir_maybe_scalar_element_type(const char *type) {
+  const char *prefix = "Maybe<";
+  size_t prefix_len = strlen(prefix);
+  size_t len = type ? strlen(type) : 0;
+  if (len <= prefix_len + 1 || strncmp(type, prefix, prefix_len) != 0 || type[len - 1] != '>') return IR_TYPE_UNSUPPORTED;
+  char *inner = z_strndup(type + prefix_len, len - prefix_len - 1);
+  IrTypeKind element = ir_type_kind(inner);
+  free(inner);
+  return ir_type_is_value(element) ? element : IR_TYPE_UNSUPPORTED;
 }
 
 static unsigned ir_error_code_for_name(const char *name) {
@@ -547,6 +560,44 @@ static void ir_mark_unsupported(IrProgram *ir, const char *message, int line, in
   snprintf(ir->mir_actual, sizeof(ir->mir_actual), "%s", actual ? actual : "unsupported construct");
   snprintf(ir->mir_help, sizeof(ir->mir_help), "restrict this program to exported primitive arithmetic functions or choose another supported direct target");
   z_backend_blocker_set(&ir->backend_blocker, NULL, NULL, NULL, "lower", ir->mir_actual);
+}
+
+static bool ir_verify_direct_call_value(IrProgram *ir, const IrValue *value) {
+  if (!ir || !ir->mir_valid) return false;
+  if (!value) return true;
+  if (value->kind == IR_VALUE_CALL && value->callee_index >= ir->function_len) {
+    char actual[128];
+    snprintf(actual, sizeof(actual), "callee index %u with %zu MIR function(s)", value->callee_index, ir->function_len);
+    ir_mark_unsupported(ir, "MIR verifier found direct call target outside the function table", value->line, value->column, actual);
+    return false;
+  }
+  for (size_t i = 0; i < value->arg_len; i++) {
+    if (!ir_verify_direct_call_value(ir, value->args[i])) return false;
+  }
+  if (!ir_verify_direct_call_value(ir, value->index)) return false;
+  if (!ir_verify_direct_call_value(ir, value->left)) return false;
+  if (!ir_verify_direct_call_value(ir, value->right)) return false;
+  return true;
+}
+
+static bool ir_verify_direct_call_instrs(IrProgram *ir, const IrInstr *instrs, size_t len) {
+  if (!ir || !ir->mir_valid) return false;
+  for (size_t i = 0; i < len; i++) {
+    const IrInstr *instr = &instrs[i];
+    if (!ir_verify_direct_call_value(ir, instr->value)) return false;
+    if (!ir_verify_direct_call_value(ir, instr->index)) return false;
+    if (!ir_verify_direct_call_instrs(ir, instr->then_instrs, instr->then_len)) return false;
+    if (!ir_verify_direct_call_instrs(ir, instr->else_instrs, instr->else_len)) return false;
+  }
+  return true;
+}
+
+static bool ir_verify_direct_call_targets(IrProgram *ir) {
+  if (!ir || !ir->mir_valid) return false;
+  for (size_t i = 0; i < ir->function_len; i++) {
+    if (!ir_verify_direct_call_instrs(ir, ir->functions[i].instrs, ir->functions[i].instr_len)) return false;
+  }
+  return true;
 }
 
 static bool ir_parse_integer_literal(const char *text, unsigned long long *out) {
@@ -1078,7 +1129,9 @@ static bool ir_compare_op(const char *text, IrCompareOp *out) {
 
 static const TypeArgVec *ir_call_type_args(const Expr *call) {
   if (!call) return NULL;
+  if (call->checked_type_args.len > 0) return &call->checked_type_args;
   if (call->type_args.len > 0) return &call->type_args;
+  if (call->kind == EXPR_CALL && call->left && call->left->checked_type_args.len > 0) return &call->left->checked_type_args;
   if (call->kind == EXPR_CALL && call->left && call->left->type_args.len > 0) return &call->left->type_args;
   return &call->type_args;
 }
@@ -1086,6 +1139,8 @@ static const TypeArgVec *ir_call_type_args(const Expr *call) {
 static char *ir_specialized_function_name(const Function *fun, const TypeArgVec *type_args) {
   return z_specialized_function_name(fun, type_args);
 }
+
+static char *ir_specialize_type_text(const char *type, const Function *fun, const TypeArgVec *type_args);
 
 static const char *ir_substitute_type_param(const Function *fun, const TypeArgVec *type_args, const char *type) {
   if (!fun || !type_args || !type) return type;
@@ -1164,6 +1219,16 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
       value->int_value = parsed;
       *out = value;
       return true;
+    }
+    case EXPR_NULL: {
+      if (ir_type_kind(expr->resolved_type) == IR_TYPE_MAYBE_SCALAR) {
+        IrTypeKind element = ir_maybe_scalar_element_type(expr->resolved_type);
+        if (element == IR_TYPE_UNSUPPORTED) element = IR_TYPE_I32;
+        *out = ir_new_maybe_scalar_literal(ir, false, element, 0, expr->line, expr->column);
+        return true;
+      }
+      ir_mark_unsupported(ir, "direct backend null expression type is unsupported", expr->line, expr->column, expr->resolved_type ? expr->resolved_type : "unknown null type");
+      return false;
     }
     case EXPR_IDENT: {
       const IrLocal *local = ir_function_find_local(fun, expr->text);
@@ -2440,14 +2505,17 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         ir_mark_unsupported(ir, "direct backend call argument count does not match callee", expr->line, expr->column, callee->name);
         return false;
       }
-      const char *return_type_text = generic_call ? ir_substitute_type_param(callee, type_args, callee->return_type) : callee->return_type;
+      char *specialized_return_type = generic_call ? ir_specialize_type_text(callee->return_type, callee, type_args) : NULL;
+      const char *return_type_text = generic_call ? specialized_return_type : callee->return_type;
       IrTypeKind type = ir_type_kind(return_type_text);
       if (callee->raises && !ir_type_is_direct_fallible_value(type)) {
+        free(specialized_return_type);
         free(specialized_name);
         ir_mark_unsupported(ir, "direct backend fallible call return type is unsupported", expr->line, expr->column, callee->return_type);
         return false;
       }
       if (!callee->raises && type != IR_TYPE_VOID && !ir_type_is_direct_abi(type)) {
+        free(specialized_return_type);
         free(specialized_name);
         ir_mark_unsupported(ir, "direct backend call return type is unsupported", expr->line, expr->column, callee->return_type);
         return false;
@@ -2456,9 +2524,12 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
       value->callee_index = callee_index;
       value->element_type = type;
       for (size_t i = 0; i < expr->args.len; i++) {
-        const char *param_type_text = generic_call ? ir_substitute_type_param(callee, type_args, callee->params.items[i].type) : callee->params.items[i].type;
+        char *specialized_param_type = generic_call ? ir_specialize_type_text(callee->params.items[i].type, callee, type_args) : NULL;
+        const char *param_type_text = generic_call ? specialized_param_type : callee->params.items[i].type;
         IrTypeKind expected = ir_type_kind(param_type_text);
         if (!ir_type_is_direct_abi(expected)) {
+          free(specialized_param_type);
+          free(specialized_return_type);
           free(specialized_name);
           ir_free_value(value);
           ir_mark_unsupported(ir, "direct backend call parameter type is unsupported", callee->params.items[i].line, callee->params.items[i].column, callee->params.items[i].type);
@@ -2466,6 +2537,8 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         }
         IrValue *arg = NULL;
         if (!ir_lower_expr(program, ir, fun, expr->args.items[i], &arg)) {
+          free(specialized_param_type);
+          free(specialized_return_type);
           free(specialized_name);
           ir_free_value(value);
           return false;
@@ -2473,12 +2546,16 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         if (arg->type != expected) {
           ir_free_value(arg);
           ir_free_value(value);
+          free(specialized_param_type);
+          free(specialized_return_type);
           free(specialized_name);
           ir_mark_unsupported(ir, "direct backend call argument type does not match parameter", expr->args.items[i]->line, expr->args.items[i]->column, callee->params.items[i].type);
           return false;
         }
         ir_value_push_arg(ir, value, arg);
+        free(specialized_param_type);
       }
+      free(specialized_return_type);
       free(specialized_name);
       *out = value;
       return true;
@@ -3158,8 +3235,93 @@ static void ir_free_param_vec_shallow(ParamVec *params) {
   if (params) *params = (ParamVec){0};
 }
 
+static const char *ir_specialization_arg_for_binder(const Function *fun, const TypeArgVec *type_args, ZTypeBinderId binder) {
+  if (!fun || !type_args || binder == Z_TYPE_BINDER_ID_INVALID) return NULL;
+  size_t index = (size_t)binder - 1;
+  if (index >= fun->type_params.len || index >= type_args->len) return NULL;
+  return type_args->items[index].type;
+}
+
+static void ir_specialize_type_core_into(ZBuf *buf, const ZTypeArena *arena, ZTypeId type, const Function *fun, const TypeArgVec *type_args);
+
+static void ir_specialize_static_value_into(ZBuf *buf, const ZStaticValue *value, const Function *fun, const TypeArgVec *type_args) {
+  if (value && value->kind == Z_STATIC_VALUE_BINDER) {
+    const char *arg = ir_specialization_arg_for_binder(fun, type_args, value->binder);
+    if (arg) {
+      zbuf_append(buf, arg);
+      return;
+    }
+  }
+  char *formatted = z_static_value_format(value);
+  zbuf_append(buf, formatted ? formatted : "Unknown");
+  free(formatted);
+}
+
+static void ir_specialize_type_arg_into(ZBuf *buf, const ZTypeArena *arena, const ZTypeArg *arg, const Function *fun, const TypeArgVec *type_args) {
+  if (!arg) return;
+  if (arg->kind == Z_TYPE_ARG_STATIC) {
+    ir_specialize_static_value_into(buf, &arg->as.static_value, fun, type_args);
+  } else {
+    ir_specialize_type_core_into(buf, arena, arg->as.type, fun, type_args);
+  }
+}
+
+static void ir_specialize_type_core_into(ZBuf *buf, const ZTypeArena *arena, ZTypeId type, const Function *fun, const TypeArgVec *type_args) {
+  ZTypeNodeKind kind = z_type_kind(arena, type);
+  if (kind == Z_TYPE_NODE_NAME) {
+    zbuf_append(buf, z_type_name(arena, type) ? z_type_name(arena, type) : "Unknown");
+  } else if (kind == Z_TYPE_NODE_BINDER) {
+    const char *arg = ir_specialization_arg_for_binder(fun, type_args, z_type_binder(arena, type));
+    zbuf_append(buf, arg ? arg : (z_type_name(arena, type) ? z_type_name(arena, type) : "Unknown"));
+  } else if (kind == Z_TYPE_NODE_CONST) {
+    zbuf_append(buf, "const ");
+    ir_specialize_type_core_into(buf, arena, z_type_const_inner(arena, type), fun, type_args);
+  } else if (kind == Z_TYPE_NODE_ARRAY) {
+    zbuf_append_char(buf, '[');
+    ir_specialize_static_value_into(buf, z_type_array_length(arena, type), fun, type_args);
+    zbuf_append_char(buf, ']');
+    ir_specialize_type_core_into(buf, arena, z_type_array_element(arena, type), fun, type_args);
+  } else if (kind == Z_TYPE_NODE_APPLY) {
+    zbuf_append(buf, z_type_name(arena, type) ? z_type_name(arena, type) : "Unknown");
+    zbuf_append_char(buf, '<');
+    for (size_t i = 0; i < z_type_apply_arg_len(arena, type); i++) {
+      if (i > 0) zbuf_append_char(buf, ',');
+      ir_specialize_type_arg_into(buf, arena, z_type_apply_arg(arena, type, i), fun, type_args);
+    }
+    zbuf_append_char(buf, '>');
+  } else {
+    zbuf_append(buf, "Unknown");
+  }
+}
+
 static char *ir_specialize_type_text(const char *type, const Function *fun, const TypeArgVec *type_args) {
-  return z_strdup(ir_substitute_type_param(fun, type_args, type));
+  if (!type) return z_strdup("Unknown");
+  if (!fun || !type_args || fun->type_params.len == 0) return z_strdup(type);
+  ZTypeBinderDecl *decls = z_checked_calloc(fun->type_params.len, sizeof(ZTypeBinderDecl));
+  for (size_t i = 0; i < fun->type_params.len; i++) {
+    decls[i] = (ZTypeBinderDecl){
+      .name = fun->type_params.items[i].name,
+      .kind = fun->type_params.items[i].is_static ? Z_TYPE_BINDER_STATIC : Z_TYPE_BINDER_TYPE,
+      .id = (ZTypeBinderId)(i + 1),
+      .static_type = fun->type_params.items[i].type ? fun->type_params.items[i].type : "usize"
+    };
+  }
+  ZTypeBinderScope scope = {.items = decls, .len = fun->type_params.len};
+  ZTypeArena arena;
+  z_type_arena_init(&arena);
+  ZTypeId parsed = Z_TYPE_ID_INVALID;
+  ZTypeParseError error = {0};
+  if (!z_type_parse_with_binders(&arena, type, &scope, &parsed, &error)) {
+    z_type_arena_free(&arena);
+    free(decls);
+    return z_strdup(ir_substitute_type_param(fun, type_args, type));
+  }
+  ZBuf buf;
+  zbuf_init(&buf);
+  ir_specialize_type_core_into(&buf, &arena, parsed, fun, type_args);
+  z_type_arena_free(&arena);
+  free(decls);
+  return buf.data ? buf.data : z_strdup("");
 }
 
 static void ir_specialize_stmt_types(StmtVec *body, const Function *fun, const TypeArgVec *type_args);
@@ -3175,6 +3337,11 @@ static void ir_specialize_expr_types(Expr *expr, const Function *fun, const Type
     char *substituted = ir_specialize_type_text(expr->type_args.items[i].type, fun, type_args);
     free(expr->type_args.items[i].type);
     expr->type_args.items[i].type = substituted;
+  }
+  for (size_t i = 0; i < expr->checked_type_args.len; i++) {
+    char *substituted = ir_specialize_type_text(expr->checked_type_args.items[i].type, fun, type_args);
+    free(expr->checked_type_args.items[i].type);
+    expr->checked_type_args.items[i].type = substituted;
   }
   ir_specialize_expr_types(expr->left, fun, type_args);
   ir_specialize_expr_types(expr->right, fun, type_args);
@@ -3345,6 +3512,16 @@ static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program
       z_free_program(&temp_program);
       return;
     }
+  }
+  if (!ir_verify_direct_call_targets(ir)) {
+    free(order);
+    for (size_t stable_index = 0; stable_index < direct_functions.len; stable_index++) free(stable_ids[stable_index]);
+    free(stable_ids);
+    z_specialization_plan_free(&specialization_plan);
+    Program temp_program = {0};
+    temp_program.functions = direct_functions;
+    z_free_program(&temp_program);
+    return;
   }
   free(order);
   for (size_t stable_index = 0; stable_index < direct_functions.len; stable_index++) free(stable_ids[stable_index]);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -7441,7 +7441,9 @@ static bool direct_bindings_complete(const DirectGenericBinding *bindings, size_
 
 static const TypeArgVec *direct_call_type_args(const Expr *call) {
   if (!call) return NULL;
+  if (call->checked_type_args.len > 0) return &call->checked_type_args;
   if (call->type_args.len > 0) return &call->type_args;
+  if (call->kind == EXPR_CALL && call->left && call->left->checked_type_args.len > 0) return &call->left->checked_type_args;
   if (call->left && call->left->type_args.len > 0) return &call->left->type_args;
   return NULL;
 }
@@ -7617,8 +7619,8 @@ static void append_direct_generic_specializations_json(ZBuf *buf, const Program 
           direct_collect_shape_specializations_from_type(buf, &state, program, fun->params.items[param_index].type, NULL, 0);
         }
         direct_collect_shape_specializations_from_stmt_vec(buf, &state, program, &fun->body, NULL, 0);
+        direct_collect_generic_function_specializations_from_stmt_vec(buf, &state, program, &fun->body, NULL, 0);
       }
-      direct_collect_generic_function_specializations_from_stmt_vec(buf, &state, program, &fun->body, NULL, 0);
     }
   }
   zbuf_append(buf, "]");

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -1055,6 +1055,8 @@ static void free_expr(Expr *expr) {
   free(expr->args.items);
   for (size_t i = 0; i < expr->type_args.len; i++) free(expr->type_args.items[i].type);
   free(expr->type_args.items);
+  for (size_t i = 0; i < expr->checked_type_args.len; i++) free(expr->checked_type_args.items[i].type);
+  free(expr->checked_type_args.items);
   for (size_t i = 0; i < expr->fields.len; i++) {
     free(expr->fields.items[i].name);
     free_expr(expr->fields.items[i].value);


### PR DESCRIPTION
- Record checked generic bindings for inferred calls
- Substitute nested generic and static types structurally
- Require direct runtime coverage for generic specialization