### PR TITLE
Align installer and docs defaults with vercel-labs/zerolang

### DIFF
--- a/docs/app/api/docs-chat/route.ts
+++ b/docs/app/api/docs-chat/route.ts
@@ -16,7 +16,7 @@ const DEFAULT_MODEL = "anthropic/claude-haiku-4.5";
 
 const SYSTEM_PROMPT = `You are a helpful documentation assistant for Zero, a pre-1 experimental programming language project exploring agent-first design. Zero intentionally makes breaking changes while searching for the language, library, and tooling patterns that work best for agents. Security vulnerabilities should be expected; Zero should be run or developed only in safe, non-production environments.
 
-GitHub repository: https://github.com/vercel-labs/zero
+GitHub repository: https://github.com/vercel-labs/zerolang
 Documentation: https://zerolang.ai
 
 You have access to the full Zero documentation via the bash and readFile tools. The docs are available as markdown files in the /workspace/ directory. The file layout matches each page's URL slug — e.g. /workspace/index.md is the home, /workspace/getting-started.md is /getting-started, /workspace/modules/parse.md is /modules/parse.

--- a/docs/articles/install.md
+++ b/docs/articles/install.md
@@ -9,7 +9,7 @@ zero --version
 ```
 
 The installer downloads the latest matching binary from
-`github.com/vercel-labs/zero`, verifies it against the release checksum file,
+`github.com/vercel-labs/zerolang`, verifies it against the release checksum file,
 and writes it to `$HOME/.zero/bin/zero`. Set `ZERO_INSTALL_DIR` to choose a
 different install directory. On Linux it installs the static musl build by
 default; set `ZERO_LINUX_FLAVOR=gnu` to install the glibc-targeted build.

--- a/docs/components/install-copy.tsx
+++ b/docs/components/install-copy.tsx
@@ -11,7 +11,7 @@ const TABS = [
   {
     id: "agents",
     label: "For agents",
-    command: "npx skills add vercel-labs/zero",
+    command: "npx skills add vercel-labs/zerolang",
   },
 ] as const;
 

--- a/docs/components/site-header.tsx
+++ b/docs/components/site-header.tsx
@@ -24,7 +24,7 @@ export function SiteHeader({ stars }: { stars: string }) {
           </Link>
           <Search />
           <a
-            href={`https://github.com/${process.env.NEXT_PUBLIC_GITHUB_REPO || "vercel-labs/zero"}`}
+            href={`https://github.com/${process.env.NEXT_PUBLIC_GITHUB_REPO || "vercel-labs/zerolang"}`}
             target="_blank"
             rel="noopener noreferrer"
             className="flex items-center gap-1.5 text-sm text-neutral-500 transition-colors hover:text-neutral-900 dark:text-neutral-400 dark:hover:text-neutral-100"

--- a/docs/lib/github.ts
+++ b/docs/lib/github.ts
@@ -1,4 +1,4 @@
-const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO || "vercel-labs/zero";
+const REPO = process.env.NEXT_PUBLIC_GITHUB_REPO || "vercel-labs/zerolang";
 const REVALIDATE = 86400;
 
 export async function getStarCount(): Promise<string> {

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 set -eu
 
-repo="${ZERO_REPO:-vercel-labs/zero}"
+repo="${ZERO_REPO:-vercel-labs/zerolang}"
 install_dir="${ZERO_INSTALL_DIR:-${HOME:-}/.zero/bin}"
 version="${ZERO_VERSION:-latest}"
 linux_flavor="${ZERO_LINUX_FLAVOR:-musl}"


### PR DESCRIPTION
## Summary

- Default `ZERO_REPO` in `docs/public/install.sh` to `vercel-labs/zerolang`.
- Update docs site GitHub fallbacks, install article, docs-chat prompt, and skills copy command to the canonical repo name.

## Test plan

- [x] `pnpm run docs:test`

Fixes #167 