### PR TITLE
Teach zero test direct runner f64 literals and std.mem accessors

### DIFF
--- a/conformance/native/pass/test-float-div.0
+++ b/conformance/native/pass/test-float-div.0
@@ -1,0 +1,16 @@
+test "frame time is positive" {
+    let frame_time: f64 = 1.0 / 60.0
+    let threshold: f64 = 1.0 / 65.0
+    expect(frame_time> threshold)
+}
+
+test "float comparison ordering" {
+    let half: f64 = 1.0 / 2.0
+    let third: f64 = 1.0 / 3.0
+    expect(half> third)
+}
+
+test "float arithmetic identities" {
+    let a: f64 = 2.5 + 1.5
+    expect(a == 4.0)
+}

--- a/conformance/native/pass/test-span-roundtrip.0
+++ b/conformance/native/pass/test-span-roundtrip.0
@@ -1,0 +1,16 @@
+test "span len matches source bytes" {
+    let bytes = std.mem.span("zero-memory")
+    expect(std.mem.len(bytes) == 11)
+}
+
+test "span eqlBytes matches identical source" {
+    let left = std.mem.span("abc")
+    let right = std.mem.span("abc")
+    expect(std.mem.eqlBytes(left, right))
+}
+
+test "span eqlBytes rejects different sources" {
+    let left = std.mem.span("abc")
+    let right = std.mem.span("abd")
+    expect(std.mem.eqlBytes(left, right) == false)
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -2413,6 +2413,19 @@ assert.equal(zeroTestJsonBody.passedTests, 1);
 assert.equal(zeroTestJsonBody.testDiscovery.filter, "addition");
 assert.equal(zeroTestJsonBody.fixtures.snapshotKey, "zero-test-direct-frontend-v1");
 assert.equal(zeroTestJsonBody.results[0].status, "passed");
+assert.equal(zeroTestJsonBody.engine, "interpreter");
+
+const zeroTestSpanRun = await execFileAsync(zero, ["test", "--json", "conformance/native/pass/test-span-roundtrip.0"]);
+const zeroTestSpanBody = JSON.parse(zeroTestSpanRun.stdout);
+assert.equal(zeroTestSpanBody.ok, true);
+assert.equal(zeroTestSpanBody.passedTests, 3);
+assert.equal(zeroTestSpanBody.engine, "interpreter");
+
+const zeroTestFloatRun = await execFileAsync(zero, ["test", "--json", "conformance/native/pass/test-float-div.0"]);
+const zeroTestFloatBody = JSON.parse(zeroTestFloatRun.stdout);
+assert.equal(zeroTestFloatBody.ok, true);
+assert.equal(zeroTestFloatBody.passedTests, 3);
+assert.equal(zeroTestFloatBody.engine, "interpreter");
 
 const zeroPackageTestJsonRun = await execFileAsync(zero, ["test", "--json", "conformance/packages/test-app"]);
 const zeroPackageTestBody = JSON.parse(zeroPackageTestJsonRun.stdout);

--- a/docs/articles/testing.md
+++ b/docs/articles/testing.md
@@ -34,6 +34,7 @@ ok
 sourceFile
 target
 testBackend
+engine
 selectedTests
 discoveredTests
 passedTests
@@ -48,6 +49,19 @@ fixtures
 targetFacts
 results
 ```
+
+`engine` records which test driver evaluated the program. The current direct
+runner is a tree-walking interpreter (`"interpreter"`); CI and editors that need
+to anticipate richer language coverage should treat `engine` as forward-compatible
+with a future `"native"` value once the test-host compile path lands.
+
+The interpreter recognises the float literal forms `1.0`, `1.5e3`, etc. for `f64`
+and `f32` typed bindings, and resolves the following stdlib accessors when they
+appear in test bodies:
+
+- `std.mem.span(literal)` returns the literal bytes as a span.
+- `std.mem.len(span_or_string)` returns the byte length.
+- `std.mem.eqlBytes(a, b)` compares two spans byte-for-byte.
 
 `testDiscovery` records how the test set was found:
 

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -6114,9 +6114,10 @@ typedef struct {
 } TestFieldValue;
 
 struct TestValue {
-  enum { TEST_VALUE_VOID, TEST_VALUE_BOOL, TEST_VALUE_INT, TEST_VALUE_STRING, TEST_VALUE_SHAPE } kind;
+  enum { TEST_VALUE_VOID, TEST_VALUE_BOOL, TEST_VALUE_INT, TEST_VALUE_FLOAT, TEST_VALUE_STRING, TEST_VALUE_SHAPE } kind;
   bool bool_value;
   long long int_value;
+  double float_value;
   char *string_value;
   TestFieldValue *fields;
   size_t field_len;
@@ -6158,6 +6159,7 @@ static TestValue test_value_copy(const TestValue *value) {
   copy.kind = value->kind;
   copy.bool_value = value->bool_value;
   copy.int_value = value->int_value;
+  copy.float_value = value->float_value;
   copy.string_value = value->string_value ? z_strdup(value->string_value) : NULL;
   copy.field_len = value->field_len;
   if (copy.field_len > 0) {
@@ -6248,7 +6250,21 @@ static bool test_value_truthy(const TestValue *value) {
   if (!value) return false;
   if (value->kind == TEST_VALUE_BOOL) return value->bool_value;
   if (value->kind == TEST_VALUE_INT) return value->int_value != 0;
+  if (value->kind == TEST_VALUE_FLOAT) return value->float_value != 0.0;
   return false;
+}
+
+static bool test_value_is_numeric(const TestValue *v) {
+  if (!v) return false;
+  return v->kind == TEST_VALUE_INT || v->kind == TEST_VALUE_BOOL || v->kind == TEST_VALUE_FLOAT;
+}
+
+static double test_value_as_double(const TestValue *v) {
+  if (!v) return 0.0;
+  if (v->kind == TEST_VALUE_FLOAT) return v->float_value;
+  if (v->kind == TEST_VALUE_BOOL) return v->bool_value ? 1.0 : 0.0;
+  if (v->kind == TEST_VALUE_INT) return (double)v->int_value;
+  return 0.0;
 }
 
 static bool test_value_equals(const TestValue *left, const TestValue *right) {
@@ -6257,8 +6273,12 @@ static bool test_value_equals(const TestValue *left, const TestValue *right) {
     return strcmp(left->string_value ? left->string_value : "", right->string_value ? right->string_value : "") == 0;
   }
   if (left->kind == TEST_VALUE_BOOL && right->kind == TEST_VALUE_BOOL) return left->bool_value == right->bool_value;
-  if ((left->kind == TEST_VALUE_INT || left->kind == TEST_VALUE_BOOL) &&
-      (right->kind == TEST_VALUE_INT || right->kind == TEST_VALUE_BOOL)) {
+  bool left_numeric = test_value_is_numeric(left);
+  bool right_numeric = test_value_is_numeric(right);
+  if (left_numeric && right_numeric) {
+    if (left->kind == TEST_VALUE_FLOAT || right->kind == TEST_VALUE_FLOAT) {
+      return test_value_as_double(left) == test_value_as_double(right);
+    }
     long long a = left->kind == TEST_VALUE_BOOL ? (left->bool_value ? 1 : 0) : left->int_value;
     long long b = right->kind == TEST_VALUE_BOOL ? (right->bool_value ? 1 : 0) : right->int_value;
     return a == b;
@@ -6353,10 +6373,21 @@ static bool test_eval_expr(const Program *program, TestEnv *env, const Expr *exp
       out->kind = TEST_VALUE_BOOL;
       out->bool_value = expr->bool_value;
       return true;
-    case EXPR_NUMBER:
-      out->kind = TEST_VALUE_INT;
-      out->int_value = strtoll(expr->text ? expr->text : "0", NULL, 0);
+    case EXPR_NUMBER: {
+      const char *text = expr->text ? expr->text : "0";
+      bool is_float = false;
+      for (const char *p = text; *p; p++) {
+        if (*p == '.' || *p == 'e' || *p == 'E') { is_float = true; break; }
+      }
+      if (is_float) {
+        out->kind = TEST_VALUE_FLOAT;
+        out->float_value = strtod(text, NULL);
+      } else {
+        out->kind = TEST_VALUE_INT;
+        out->int_value = strtoll(text, NULL, 0);
+      }
       return true;
+    }
     case EXPR_STRING:
       out->kind = TEST_VALUE_STRING;
       out->string_value = z_strdup(expr->text ? expr->text : "");
@@ -6408,6 +6439,25 @@ static bool test_eval_expr(const Program *program, TestEnv *env, const Expr *exp
       } else if (strcmp(op, "&&") == 0 || strcmp(op, "||") == 0) {
         out->kind = TEST_VALUE_BOOL;
         out->bool_value = strcmp(op, "&&") == 0 ? (test_value_truthy(&left) && test_value_truthy(&right)) : (test_value_truthy(&left) || test_value_truthy(&right));
+      } else if (left.kind == TEST_VALUE_FLOAT || right.kind == TEST_VALUE_FLOAT) {
+        double a = test_value_as_double(&left);
+        double b = test_value_as_double(&right);
+        if (strcmp(op, "+") == 0) { out->kind = TEST_VALUE_FLOAT; out->float_value = a + b; }
+        else if (strcmp(op, "-") == 0) { out->kind = TEST_VALUE_FLOAT; out->float_value = a - b; }
+        else if (strcmp(op, "*") == 0) { out->kind = TEST_VALUE_FLOAT; out->float_value = a * b; }
+        else if (strcmp(op, "/") == 0) { out->kind = TEST_VALUE_FLOAT; out->float_value = b == 0.0 ? 0.0 : a / b; }
+        else if (strcmp(op, "<") == 0 || strcmp(op, "<=") == 0 || strcmp(op, ">") == 0 || strcmp(op, ">=") == 0) {
+          out->kind = TEST_VALUE_BOOL;
+          if (strcmp(op, "<") == 0) out->bool_value = a < b;
+          else if (strcmp(op, "<=") == 0) out->bool_value = a <= b;
+          else if (strcmp(op, ">") == 0) out->bool_value = a > b;
+          else out->bool_value = a >= b;
+        } else {
+          test_fail(failure, expr, "zero test unsupported operator");
+          test_value_free(&left);
+          test_value_free(&right);
+          return false;
+        }
       } else {
         long long a = left.kind == TEST_VALUE_BOOL ? (left.bool_value ? 1 : 0) : left.int_value;
         long long b = right.kind == TEST_VALUE_BOOL ? (right.bool_value ? 1 : 0) : right.int_value;
@@ -6456,6 +6506,24 @@ static bool test_eval_expr(const Program *program, TestEnv *env, const Expr *exp
       if (strcmp(callee_name, "std.mem.eql") == 0 && expr->args.len == 2) {
         out->kind = TEST_VALUE_BOOL;
         out->bool_value = test_value_equals(&args[0], &args[1]);
+      } else if ((strcmp(callee_name, "std.mem.eqlBytes") == 0 || strcmp(callee_name, "std.mem.eql_bytes") == 0) && expr->args.len == 2) {
+        out->kind = TEST_VALUE_BOOL;
+        if (args[0].kind == TEST_VALUE_STRING && args[1].kind == TEST_VALUE_STRING) {
+          out->bool_value = strcmp(args[0].string_value ? args[0].string_value : "",
+                                   args[1].string_value ? args[1].string_value : "") == 0;
+        } else {
+          out->bool_value = test_value_equals(&args[0], &args[1]);
+        }
+      } else if (strcmp(callee_name, "std.mem.len") == 0 && expr->args.len == 1) {
+        out->kind = TEST_VALUE_INT;
+        if (args[0].kind == TEST_VALUE_STRING) {
+          out->int_value = (long long)(args[0].string_value ? strlen(args[0].string_value) : 0);
+        } else {
+          out->int_value = 0;
+        }
+      } else if (strcmp(callee_name, "std.mem.span") == 0 && expr->args.len == 1) {
+        out->kind = TEST_VALUE_STRING;
+        out->string_value = z_strdup(args[0].string_value ? args[0].string_value : "");
       } else {
         const Function *fun = find_program_function(program, callee_name);
         ok = test_eval_function(program, fun, args, expr->args.len, out, failure);
@@ -6561,7 +6629,7 @@ static int run_tests_direct(const Command *command, const SourceInput *input, co
     append_json_string(&buf, input ? input->source_file : "");
     zbuf_append(&buf, ",\n  \"target\": ");
     append_json_string(&buf, target ? target->name : z_host_target());
-    zbuf_append(&buf, ",\n  \"testBackend\": \"direct-frontend\",\n  \"generatedCBytes\": 0,\n  \"cBridgeFallback\": false,\n  \"selectedTests\": ");
+    zbuf_append(&buf, ",\n  \"testBackend\": \"direct-frontend\",\n  \"engine\": \"interpreter\",\n  \"generatedCBytes\": 0,\n  \"cBridgeFallback\": false,\n  \"selectedTests\": ");
     zbuf_appendf(&buf, "%zu", selected);
     zbuf_append(&buf, ",\n  \"discoveredTests\": ");
     zbuf_appendf(&buf, "%zu", discovered);

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -338,6 +338,7 @@ assert.equal(testJson.schemaVersion, 1);
 assert.equal(testJson.ok, true);
 assert.match(testJson.stdout, /1 test\(s\) ok/);
 assert.equal(testJson.testBackend, "direct-frontend");
+assert.equal(testJson.engine, "interpreter");
 assert.equal(testJson.testDiscovery.filter, "addition");
 assert.equal(testJson.fixtures.snapshotKey, "zero-test-direct-frontend-v1");
 assert.equal(testJson.targetFacts.capabilitySupport.status, "supported");


### PR DESCRIPTION
## Summary

The tree-walking `zero test` runner used to bail on any test that touched float division (`1.0 / 60.0`) or the `std.mem.{span, len, eqlBytes}` accessors, leaving the runtime able to *check* and *compile* those expressions but not to *assert* on them. This PR teaches the direct runner to evaluate those forms and records the active engine in `zero test --json` so a later host-compiled engine can flip the field without breaking the schema.

## Source

Addresses B1. Reproduced against `main @ 999a46b`: a test calling `expect(std.mem.len(std.mem.span("abc")) == 3)` fails with `"zero test unknown function: std.mem.len"`, and a test calling `expect(1.0 / 60.0 > 0.016)` silently evaluates to `0 > 0.016` because float literals were truncated to `i64 0`.

## Changes

- `native/zero-c/src/main.c`
  - Add `TEST_VALUE_FLOAT` (with `double float_value`) to the interpreter value, propagated through `test_value_copy`, `test_value_truthy`, and `test_value_equals`.
  - Parse `EXPR_NUMBER` text containing `.`/`e`/`E` as `strtod`; integer literals still parse via `strtoll`.
  - Promote mixed operands through `+ - * / < <= > >=` so float comparisons return the right boolean.
  - Resolve `std.mem.span("...")`, `std.mem.len(span_or_string)`, and `std.mem.eqlBytes(a, b)` directly in the call dispatcher.
  - Emit `"engine": "interpreter"` in the `zero test --json` body next to `testBackend`.
- `conformance/native/pass/test-span-roundtrip.0`, `conformance/native/pass/test-float-div.0`: new fixtures covering the three accessors and float comparison ordering.
- `conformance/run.mjs`: assert the new fixtures pass and that every JSON test body carries `engine === "interpreter"`.
- `scripts/snapshot-command-contracts.mts`: assert `engine` on the canonical `test-blocks.0` JSON body.
- `docs/articles/testing.md`: document the new `engine` field and the recognised stdlib accessors.

## Conformance

- `node conformance/run.mjs` -> `conformance ok`
- `node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/snapshot-command-contracts.mts` -> `command contract snapshots ok`
- `make -C native/zero-c` -> clean build
- `bin/zero fmt --check` clean on both new fixtures

## Proposed CHANGELOG line

- Teach `zero test` to evaluate `f64`/`f32` literals and the `std.mem.{span, len, eqlBytes}` accessors, and expose the active runner as `engine` in `zero test --json`.