### PR TITLE
Add Maybe.some / Maybe.none constructors with T->Maybe<T> coercion

### DIFF
--- a/conformance/native/fail/maybe-bare-without-context.0
+++ b/conformance/native/fail/maybe-bare-without-context.0
@@ -1,0 +1,4 @@
+pub fun main(world: World) -> Void raises {
+    let value = Maybe.none
+    check world.out.write("bare maybe none\n")
+}

--- a/conformance/native/pass/maybe-coerce-return.0
+++ b/conformance/native/pass/maybe-coerce-return.0
@@ -1,0 +1,14 @@
+fun produce(flag: Bool) -> Maybe<u8> {
+    if flag {
+        return 42_u8
+    }
+    return null
+}
+
+pub fun main(world: World) -> Void raises {
+    let present = produce(true)
+    let absent = produce(false)
+    if present.has && absent.has == false {
+        check world.out.write("maybe coerce return ok\n")
+    }
+}

--- a/conformance/native/pass/maybe-some.0
+++ b/conformance/native/pass/maybe-some.0
@@ -1,0 +1,7 @@
+pub fun main(world: World) -> Void raises {
+    let present: Maybe<u8> = Maybe.some(42_u8)
+    let absent: Maybe<u8> = Maybe.none
+    if present.has && absent.has == false {
+        check world.out.write("maybe some ok\n")
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -287,6 +287,8 @@ for (const fixture of [
   "conformance/native/pass/choice-match-payload-return-origin.0",
   "conformance/native/pass/match-choice-fallback.0",
   "conformance/native/pass/null-maybe.0",
+  "conformance/native/pass/maybe-some.0",
+  "conformance/native/pass/maybe-coerce-return.0",
   "conformance/native/pass/meta-typed-target-type.0",
   "conformance/native/pass/std-args.0",
   "conformance/native/pass/std-env.0",
@@ -2361,6 +2363,12 @@ const uncheckedFallibleBody = JSON.parse(uncheckedFallibleJson.stdout);
 assert.equal(uncheckedFallibleBody.diagnostics[0].code, "ERR003");
 assert.equal(uncheckedFallibleBody.diagnostics[0].fixSafety, "api-changing");
 
+const maybeBareWithoutContextJson = await execFileAsync(zero, ["check", "--json", "conformance/native/fail/maybe-bare-without-context.0"]).catch((error) => error);
+assert.notEqual(maybeBareWithoutContextJson.code, 0);
+const maybeBareWithoutContextBody = JSON.parse(maybeBareWithoutContextJson.stdout);
+assert.equal(maybeBareWithoutContextBody.diagnostics[0].code, "TYP011");
+assert.match(maybeBareWithoutContextBody.diagnostics[0].message, /Maybe\.none requires an explicit Maybe<T> context/);
+
 const errorSetMismatchJson = await execFileAsync(zero, ["check", "--json", "conformance/native/fail/error-set-mismatch.0"]).catch((error) => error);
 assert.notEqual(errorSetMismatchJson.code, 0);
 const errorSetMismatchBody = JSON.parse(errorSetMismatchJson.stdout);
@@ -2587,6 +2595,8 @@ for (const runtimeFixture of [
   ["conformance/native/pass/match-fallback.0", "match-fallback", { stdout: "match fallback ok\n" }],
   ["conformance/native/pass/match-choice-fallback.0", "match-choice-fallback", { stdout: "choice fallback ok\n" }],
   ["conformance/native/pass/null-maybe.0", "null-maybe", { stdout: /null maybe ok/ }],
+  ["conformance/native/pass/maybe-some.0", "maybe-some", { stdout: /maybe some ok/ }],
+  ["conformance/native/pass/maybe-coerce-return.0", "maybe-coerce-return", { stdout: /maybe coerce return ok/ }],
   ["conformance/native/pass/std-args.0", "std-args", { stdout: "alpha\n", args: ["alpha", "beta"] }],
   ["conformance/native/pass/std-env.0", "std-env", { stdout: "env ok\n", env: { ZERO_CONFORMANCE_ENV: "agent-env" } }],
   ["conformance/native/pass/std-fs.0", "std-fs", { stdout: "fs ok\n", file: { name: "std-fs-write.txt", text: "zero write\n" } }],

--- a/docs/articles/diagnostics.md
+++ b/docs/articles/diagnostics.md
@@ -123,7 +123,7 @@ The native compiler keeps stable codes for implemented control-flow and type rul
 - `OWN001`: owned value use after move, or generic containers that would own unconstrained generic payloads
 - `TYP010`: conditions must be `Bool`
 - `TYP002`: type mismatch in assignments, literals, returns, or shape defaults
-- `TYP011`: `null` requires a `Maybe<T>` context
+- `TYP011`: `null` or `Maybe.none` requires a `Maybe<T>` context
 - `TYP012`: `break` requires an enclosing loop
 - `TYP013`: `continue` requires an enclosing loop
 - `TYP014`: range loop bounds must be integer-compatible

--- a/docs/articles/language-reference.md
+++ b/docs/articles/language-reference.md
@@ -336,8 +336,13 @@ or from `u8`, and it is not accepted in integer arithmetic.
 `f16`, Unicode scalar literals, and char arrays are not part of the current
 public surface. `Void` is used when a function returns no useful value.
 
-Optional values use `Maybe<T>`. Use `null` only where the expected type is a
-`Maybe<T>`; untyped `null` is rejected.
+Optional values use `Maybe<T>`. Construct a present value with
+`Maybe.some(value)` and an absent value with `Maybe.none` (equivalent to
+`null` in a `Maybe<T>` context). A plain `T` value coerces to
+`Maybe.some(value)` in a position that expects `Maybe<T>` (return,
+let-with-annotation, or argument). Untyped `null` and bare `Maybe.none`
+without an explicit `Maybe<T>` context are rejected. Test presence with
+`.has` and read the payload with `.value` after proving `.has`.
 
 Memory-oriented APIs use types such as `Span<T>`, `MutSpan<T>`, `ref<T>`,
 `mutref<T>`, and `Alloc`. The hosted file slice also exposes `Fs`, `File`, and

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -1469,6 +1469,20 @@ static bool type_has_generic_arg(const char *type, const char *name, const char 
   return *inner_len > 0;
 }
 
+static bool is_maybe_none_expr(const Expr *expr) {
+  return expr && expr->kind == EXPR_MEMBER && expr->left && expr->left->kind == EXPR_IDENT &&
+    expr->left->text && strcmp(expr->left->text, "Maybe") == 0 &&
+    expr->text && strcmp(expr->text, "none") == 0;
+}
+
+static bool is_maybe_some_call(const Expr *expr) {
+  if (!expr || expr->kind != EXPR_CALL || !expr->left || expr->left->kind != EXPR_MEMBER) return false;
+  const Expr *callee = expr->left;
+  return callee->left && callee->left->kind == EXPR_IDENT &&
+    callee->left->text && strcmp(callee->left->text, "Maybe") == 0 &&
+    callee->text && strcmp(callee->text, "some") == 0;
+}
+
 static bool split_generic_args(const char *inner, size_t inner_len, char ***out_items, size_t *out_len) {
   char **items = NULL;
   size_t len = 0;
@@ -5123,6 +5137,17 @@ static const char *expr_type(CheckContext *ctx, const Program *program, const Ex
   if (!expr) return "Void";
   const char *resolved_type = expr_resolved_type_for_current_context(ctx, expr);
   if (resolved_type) return resolved_type;
+  if (is_maybe_none_expr(expr)) return expr->resolved_type ? expr->resolved_type : "Unknown";
+  if (is_maybe_some_call(expr)) {
+    if (expr->resolved_type) return expr->resolved_type;
+    if (expr->args.len == 1) {
+      const char *inner_type = expr_type(ctx, program, expr->args.items[0], scope);
+      static char some_type[192];
+      snprintf(some_type, sizeof(some_type), "Maybe<%s>", inner_type ? inner_type : "Unknown");
+      return some_type;
+    }
+    return "Unknown";
+  }
   switch (expr->kind) {
     case EXPR_STRING: return "String";
     case EXPR_CHAR: return "char";
@@ -5819,16 +5844,69 @@ static bool check_stdlib_table_arg_range_expected(CheckContext *ctx, const Progr
 static bool check_expr_expected(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope, ZDiag *diag, const char *expected) {
   diag = check_context_diag(ctx, diag);
   if (!expr) return true;
-  if (expr->kind == EXPR_NUMBER) {
-    if (is_float_literal_text(expr->text)) return validate_float_literal_for_type(expr, expected, diag);
-    return validate_integer_literal_for_type(expr, expected, diag);
-  }
   if (expr->kind == EXPR_NULL) {
     if (expected && type_is_named_generic(expected, "Maybe")) {
       set_expr_resolved_type(expr, expected);
       return true;
     }
     return set_diag_detail(diag, 3017, "null requires an explicit Maybe<T> context", expr->line, expr->column, "Maybe<T>", expected ? expected : "untyped null", "add a Maybe<T> annotation or use a non-null value");
+  }
+  if (is_maybe_none_expr(expr)) {
+    if (expected && type_is_named_generic(expected, "Maybe")) {
+      set_expr_resolved_type(expr, expected);
+      return true;
+    }
+    return set_diag_detail(diag, 3017, "Maybe.none requires an explicit Maybe<T> context", expr->line, expr->column, "Maybe<T>", expected ? expected : "untyped Maybe.none", "annotate the destination type or use Maybe.some(value) at a typed position");
+  }
+  if (is_maybe_some_call(expr)) {
+    if (expr->args.len != 1) {
+      return set_diag_detail(diag, 3004, "Maybe.some expects one argument", expr->line, expr->column, "Maybe.some(value)", "wrong argument count", "pass exactly one value to Maybe.some");
+    }
+    const char *inner_expected = NULL;
+    char inner_buf[160];
+    if (expected && type_is_named_generic(expected, "Maybe")) {
+      const char *inner = NULL;
+      size_t inner_len = 0;
+      if (type_has_generic_arg(expected, "Maybe", &inner, &inner_len) && inner_len < sizeof(inner_buf)) {
+        snprintf(inner_buf, sizeof(inner_buf), "%.*s", (int)inner_len, inner);
+        inner_expected = inner_buf;
+      }
+    }
+    if (!check_expr_expected(ctx, program, expr->args.items[0], scope, diag, inner_expected)) return false;
+    const char *actual_inner = expr_type(ctx, program, expr->args.items[0], scope);
+    if (inner_expected && actual_inner && !types_compatible_in_scope(program, scope, inner_expected, actual_inner)) {
+      return set_diag_detail(diag, 3005, "Maybe.some payload type does not match expected Maybe<T>", expr->args.items[0]->line, expr->args.items[0]->column, inner_expected, actual_inner, "pass a value matching the expected Maybe element type");
+    }
+    char resolved[192];
+    snprintf(resolved, sizeof(resolved), "Maybe<%s>", inner_expected ? inner_expected : (actual_inner ? actual_inner : "Unknown"));
+    set_expr_resolved_type(expr, resolved);
+    return true;
+  }
+  if (expected && type_is_named_generic(expected, "Maybe")) {
+    const char *inner = NULL;
+    size_t inner_len = 0;
+    if (type_has_generic_arg(expected, "Maybe", &inner, &inner_len)) {
+      char inner_buf[160];
+      if (inner_len < sizeof(inner_buf)) {
+        snprintf(inner_buf, sizeof(inner_buf), "%.*s", (int)inner_len, inner);
+        const char *predicted = expr_type(ctx, program, expr, scope);
+        if (predicted && !type_is_named_generic(predicted, "Maybe") && strcmp(predicted, "Unknown") != 0 &&
+            types_compatible_in_scope(program, scope, inner_buf, predicted)) {
+          if (!check_expr_expected(ctx, program, expr, scope, diag, inner_buf)) return false;
+          set_expr_resolved_type(expr, expected);
+          return true;
+        }
+        if (expr->kind == EXPR_NUMBER) {
+          if (!check_expr_expected(ctx, program, expr, scope, diag, inner_buf)) return false;
+          set_expr_resolved_type(expr, expected);
+          return true;
+        }
+      }
+    }
+  }
+  if (expr->kind == EXPR_NUMBER) {
+    if (is_float_literal_text(expr->text)) return validate_float_literal_for_type(expr, expected, diag);
+    return validate_integer_literal_for_type(expr, expected, diag);
   }
   switch (expr->kind) {
     case EXPR_IDENT:

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -1169,6 +1169,20 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
     }
     case EXPR_NUMBER: {
       IrTypeKind type = ir_type_kind(expr->resolved_type);
+      if (type == IR_TYPE_MAYBE_SCALAR) {
+        IrTypeKind element = ir_maybe_scalar_element_type(expr->resolved_type);
+        if (element == IR_TYPE_UNSUPPORTED) {
+          ir_mark_unsupported(ir, "direct backend Maybe element type is unsupported", expr->line, expr->column, expr->resolved_type ? expr->resolved_type : "unknown Maybe type");
+          return false;
+        }
+        unsigned long long parsed = 0;
+        if (!ir_parse_integer_literal(expr->text, &parsed)) {
+          ir_mark_unsupported(ir, "direct backend integer literal is malformed", expr->line, expr->column, expr->text);
+          return false;
+        }
+        *out = ir_new_maybe_scalar_literal(ir, true, element, parsed, expr->line, expr->column);
+        return true;
+      }
       if (!ir_type_is_value(type)) {
         ir_mark_unsupported(ir, "direct backend numeric expression type is unsupported", expr->line, expr->column, expr->resolved_type);
         return false;
@@ -1206,6 +1220,14 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
       return true;
     }
     case EXPR_MEMBER: {
+      if (expr->left && expr->left->kind == EXPR_IDENT &&
+          expr->left->text && strcmp(expr->left->text, "Maybe") == 0 &&
+          expr->text && strcmp(expr->text, "none") == 0) {
+        IrTypeKind element = ir_maybe_scalar_element_type(expr->resolved_type);
+        if (element == IR_TYPE_UNSUPPORTED) element = IR_TYPE_I32;
+        *out = ir_new_maybe_scalar_literal(ir, false, element, 0, expr->line, expr->column);
+        return true;
+      }
       if (expr->left && expr->left->kind == EXPR_IDENT) {
         const EnumDecl *item_enum = ir_find_enum(program, expr->left->text);
         unsigned long long case_value = 0;
@@ -1333,6 +1355,24 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
     }
     case EXPR_CALL: {
       char *callee_name = ir_expr_callee_name(expr->left);
+      if (strcmp(callee_name, "Maybe.some") == 0 && expr->args.len == 1) {
+        IrTypeKind element = ir_maybe_scalar_element_type(expr->resolved_type);
+        if (element == IR_TYPE_UNSUPPORTED) {
+          free(callee_name);
+          ir_mark_unsupported(ir, "direct backend Maybe.some currently supports primitive scalar element types", expr->line, expr->column, expr->resolved_type ? expr->resolved_type : "unknown Maybe type");
+          return false;
+        }
+        const Expr *arg = expr->args.items[0];
+        unsigned long long number = 0;
+        if (!arg || arg->kind != EXPR_NUMBER || !ir_parse_integer_literal(arg->text, &number)) {
+          free(callee_name);
+          ir_mark_unsupported(ir, "direct backend Maybe.some currently requires an integer literal payload", expr->line, expr->column, "non-literal Maybe.some payload");
+          return false;
+        }
+        free(callee_name);
+        *out = ir_new_maybe_scalar_literal(ir, true, element, number, expr->line, expr->column);
+        return true;
+      }
       if ((strcmp(callee_name, "std.codec.readU8") == 0 ||
            strcmp(callee_name, "std.codec.readU16") == 0 ||
            strcmp(callee_name, "std.codec.readU32") == 0) &&

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2770,6 +2770,16 @@ static const ExplainInfo explain_infos[] = {
     "let mut bytes: [4]u8 = [0, 0, 0, 0]\nstd.mem.fill(bytes, 0_u8)",
   },
   {
+    "TYP011",
+    "type",
+    "Maybe<T> context required",
+    "`null` or `Maybe.none` was used outside an explicit `Maybe<T>` context.",
+    "Zero keeps optional flow visible: untyped `null` and bare `Maybe.none` need a destination type so the compiler can pick the element type, while `Maybe.some(value)` works anywhere a present optional is acceptable.",
+    "Annotate the destination (return type, let binding, or argument) as `Maybe<T>`, or replace bare `Maybe.none` with `Maybe.some(value)` when the absence is unintended.",
+    "let value = Maybe.none",
+    "let value: Maybe<u8> = Maybe.none",
+  },
+  {
     "TYP023",
     "type",
     "Generic type argument mismatch",


### PR DESCRIPTION
## Summary

Adds explicit `Maybe.some(value)` and `Maybe.none` constructors, mirroring
the choice-style pattern, and lets a plain `T` value coerce to
`Maybe.some(value)` in any position that already expects `Maybe<T>`
(return, let-with-annotation, or argument). The existing `.has`/`.value`
member access and `check maybe` semantics are unchanged.

## Source

Addresses B3. Reproduced against main @ 999a46b:

- `fun a(x:u64)->Maybe<u64>{return x}` failed with `TYP003`.
- `return Maybe.some(x)` failed with `NAM003` because `Maybe` was not a
  visible symbol.

## Changes

- `native/zero-c/src/checker.c`: recognize `Maybe.some(value)` and
  `Maybe.none`, type them as `Maybe<T>`, and add a `T -> Maybe<T>`
  coercion in `check_expr_expected` (covers `EXPR_NUMBER` and any other
  expression whose actual type is compatible with `T`). A new `TYP011`
  message variant fires when `Maybe.none` lacks an explicit
  `Maybe<T>` context.
- `native/zero-c/src/ir.c`: lower `Maybe.some(literal)`, `Maybe.none`,
  and the `T -> Maybe<T>` integer literal coercion to the existing
  `IR_VALUE_MAYBE_SCALAR_LITERAL`. No new IR opcodes were added, so
  every backend (ELF64, Mach-O, COFF, AArch64 MVP) continues to work
  without changes. Non-literal `Maybe.some` payloads and non-scalar
  element types fall back to `CGEN004` like other MVP gaps.
- `native/zero-c/src/main.c`: register a `zero explain TYP011` entry
  covering the expanded message.
- `docs/articles/language-reference.md`,
  `docs/articles/diagnostics.md`: document the new constructors and the
  refreshed TYP011 scope.

## Conformance

- `conformance/native/pass/maybe-some.0`: build present and absent
  Maybe<u8> via the new constructors and check `.has`.
- `conformance/native/pass/maybe-coerce-return.0`: function returning
  `Maybe<u8>` via plain `T` and `null` coercion.
- `conformance/native/fail/maybe-bare-without-context.0`: bare
  `Maybe.none` is rejected with `TYP011`.
- `node conformance/run.mjs` and
  `node --experimental-strip-types scripts/snapshot-command-contracts.mts`
  both pass locally.

## Proposed CHANGELOG line

- Add `Maybe.some(value)` and `Maybe.none` constructors and accept plain `T` in `Maybe<T>` positions.