### PR TITLE
Parser ergonomics: else-if chains, trailing commas, no bare shape literals in conditions

### DIFF
--- a/conformance/native/fail/cond-bare-struct-literal.0
+++ b/conformance/native/fail/cond-bare-struct-literal.0
@@ -1,0 +1,9 @@
+shape Box {
+    n: i32,
+}
+
+fun main(world: World) -> Void {
+    while Box { n: 1 } == Box { n: 2 } {
+        return
+    }
+}

--- a/conformance/native/pass/cond-ident-before-block.0
+++ b/conformance/native/pass/cond-ident-before-block.0
@@ -1,0 +1,20 @@
+fun search(buf: [8]i32, n: i32) -> i32 {
+    let R: i32 = 7
+    let mut j: i32 = 0
+    while j < n {
+        if buf[j] == R {
+            return j
+        }
+        j = j + 1
+    }
+    return 99
+}
+
+pub fun main(world: World) -> Void raises {
+    let nums: [8]i32 = [1, 2, 3, 4, 5, 6, 7, 8]
+    if search(nums, 8) == 6 {
+        check world.out.write("cond ident ok\n")
+    } else {
+        check world.out.write("cond ident failed\n")
+    }
+}

--- a/conformance/native/pass/cond-paren-struct-literal.0
+++ b/conformance/native/pass/cond-paren-struct-literal.0
@@ -1,0 +1,15 @@
+shape Box {
+    n: i32,
+}
+
+fun unbox(b: Box) -> i32 {
+    return b.n
+}
+
+pub fun main(world: World) -> Void raises {
+    if unbox((Box { n: 7 })) == 7 {
+        check world.out.write("cond paren ok\n")
+    } else {
+        check world.out.write("cond paren failed\n")
+    }
+}

--- a/conformance/native/pass/else-if-chain.0
+++ b/conformance/native/pass/else-if-chain.0
@@ -1,0 +1,19 @@
+fun classify(value: i32) -> i32 {
+    if value == 1 {
+        return 10
+    } else if value == 2 {
+        return 20
+    } else if value == 3 {
+        return 30
+    } else {
+        return 0
+    }
+}
+
+pub fun main(world: World) -> Void raises {
+    if classify(2) == 20 && classify(3) == 30 && classify(9) == 0 {
+        check world.out.write("else-if chain ok\n")
+    } else {
+        check world.out.write("else-if chain failed\n")
+    }
+}

--- a/conformance/native/pass/trailing-comma-array.0
+++ b/conformance/native/pass/trailing-comma-array.0
@@ -1,0 +1,8 @@
+pub fun main(world: World) -> Void raises {
+    let nums: [4]i32 = [10, 20, 30, 40,]
+    if nums[0] + nums[3] == 50 {
+        check world.out.write("trailing-comma array ok\n")
+    } else {
+        check world.out.write("trailing-comma array failed\n")
+    }
+}

--- a/conformance/native/pass/trailing-comma-params.0
+++ b/conformance/native/pass/trailing-comma-params.0
@@ -1,0 +1,16 @@
+fun add(left: i32, right: i32,) -> i32 {
+    return left + right
+}
+
+fun classify<T,>(value: T,) -> T {
+    return value
+}
+
+pub fun main(world: World) -> Void raises {
+    let total: i32 = add(40, 2,)
+    if total == 42 && classify<i32,>(7,) == 7 {
+        check world.out.write("trailing-comma params ok\n")
+    } else {
+        check world.out.write("trailing-comma params failed\n")
+    }
+}

--- a/conformance/native/pass/trailing-comma-struct.0
+++ b/conformance/native/pass/trailing-comma-struct.0
@@ -1,0 +1,13 @@
+shape Point {
+    x: i32,
+    y: i32,
+}
+
+pub fun main(world: World) -> Void raises {
+    let p = Point { x: 1, y: 2, }
+    if p.x + p.y == 3 {
+        check world.out.write("trailing-comma struct ok\n")
+    } else {
+        check world.out.write("trailing-comma struct failed\n")
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -469,6 +469,8 @@ for (const fixture of [
   "conformance/native/pass/trailing-comma-params.0",
   "conformance/native/pass/trailing-comma-array.0",
   "conformance/native/pass/trailing-comma-struct.0",
+  "conformance/native/pass/cond-ident-before-block.0",
+  "conformance/native/pass/cond-paren-struct-literal.0",
 ]) {
   await execFileAsync(zero, ["check", fixture]);
 }
@@ -979,6 +981,7 @@ for (const [fixture, message] of [
   ["conformance/check/fail/parse-missing-brace.0", /expected '\}'/],
   ["conformance/check/fail/parse-missing-comma.0", /expected '\{'/],
   ["conformance/check/fail/parse-bad-type-args.0", /expected '\}'/],
+  ["conformance/native/fail/cond-bare-struct-literal.0", /shape literal not allowed here/],
 ]) {
   const parseFailure = await execFileAsync(zero, ["check", "--json", fixture]).catch((error) => error);
   assert.notEqual(parseFailure.code, 0);

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -465,6 +465,7 @@ for (const fixture of [
   "examples/static-method.0",
   "examples/static-interface.0",
   "examples/ownership-cleanup.0",
+  "conformance/native/pass/else-if-chain.0",
 ]) {
   await execFileAsync(zero, ["check", fixture]);
 }

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -466,6 +466,9 @@ for (const fixture of [
   "examples/static-interface.0",
   "examples/ownership-cleanup.0",
   "conformance/native/pass/else-if-chain.0",
+  "conformance/native/pass/trailing-comma-params.0",
+  "conformance/native/pass/trailing-comma-array.0",
+  "conformance/native/pass/trailing-comma-struct.0",
 ]) {
   await execFileAsync(zero, ["check", fixture]);
 }

--- a/docs/articles/language-reference.md
+++ b/docs/articles/language-reference.md
@@ -428,6 +428,18 @@ if value == 42 {
 
 Conditions must be `Bool`; integers and pointers do not coerce to truthy or falsey values.
 
+Chain branches with `else if`:
+
+```zero
+if value == 1 {
+    check world.out.write("one\n")
+} else if value == 2 {
+    check world.out.write("two\n")
+} else {
+    check world.out.write("other\n")
+}
+```
+
 Use `while` for loops:
 
 ```zero
@@ -450,6 +462,31 @@ for index in 0..4 {
 Use `break` to exit the nearest loop and `continue` to skip to the next iteration.
 
 Use `return` to exit a function with a value.
+
+Inside `if`, `while`, `for`, and `match` headers the `{` that follows the
+condition opens the body block, so a bare shape literal there would be
+ambiguous. Wrap the shape literal in parentheses when you need it in a
+condition:
+
+```zero
+if compare((Point { x: 1, y: 2 }), origin) {
+    check world.out.write("at origin\n")
+}
+```
+
+Comma-separated lists — function parameters and arguments, generic
+parameters and type arguments, array literals, shape-literal field
+inits, and `raises { ... }` error sets — accept a single optional
+trailing comma:
+
+```zero
+fun add(left: i32, right: i32,) -> i32 {
+    return left + right
+}
+
+let nums: [4]i32 = [10, 20, 30, 40,]
+let point = Point { x: 1, y: 2, }
+```
 
 ## Effects And Errors
 

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -2979,6 +2979,16 @@ static const ExplainInfo explain_infos[] = {
     "zero build --emit obj --target linux-arm64 examples/direct-call-add.0",
     "zero build --emit obj --target linux-x64 examples/direct-call-add.0",
   },
+  {
+    "PAR100",
+    "parser",
+    "Parser rejected the source",
+    "The parser could not produce an AST. The diagnostic message names the construct that did not match the grammar.",
+    "Zero keeps the surface syntax small and explicit; ambiguous or malformed input is reported eagerly instead of being heuristically repaired.",
+    "Adjust the source so it matches the language reference. For shape literals in `if`/`while`/`for`/`match` headers, wrap the literal in parentheses so the `{` that follows opens the body block.",
+    "while Box { n: 1 } == Box { n: 2 } {\n    return\n}",
+    "while (Box { n: 1 }) == (Box { n: 2 }) {\n    return\n}",
+  },
   {NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL},
 };
 

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -622,7 +622,14 @@ static Stmt *parse_statement(Parser *parser) {
     Stmt *stmt = new_stmt(STMT_IF, start);
     stmt->expr = parse_expr(parser);
     stmt->then_body = parse_block(parser);
-    if (match(parser, "else")) stmt->else_body = parse_block(parser);
+    if (match(parser, "else")) {
+      if (check(parser, "if")) {
+        Stmt *nested = parse_statement(parser);
+        if (nested) push_stmt(&stmt->else_body, nested);
+      } else {
+        stmt->else_body = parse_block(parser);
+      }
+    }
     return stmt;
   }
   if (match(parser, "while")) {

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -211,6 +211,7 @@ static ParamVec parse_params(Parser *parser) {
   if (!expect(parser, "(", "expected '(' before parameters")) return params;
   if (match(parser, ")")) return params;
   do {
+    if (check(parser, ")")) break;
     bool is_static = match(parser, "static");
     Token *name = expect_ident(parser, "expected parameter name");
     if (!name) return params;
@@ -233,6 +234,7 @@ static ParamVec parse_type_params(Parser *parser) {
   if (!match(parser, "<")) return params;
   if (match(parser, ">")) return params;
   do {
+    if (check(parser, ">")) break;
     bool is_static = match(parser, "static");
     Token *name = expect_ident(parser, "expected generic parameter name");
     if (!name) return params;
@@ -303,6 +305,7 @@ static TypeArgVec parse_type_args(Parser *parser) {
   if (!expect(parser, "<", "expected '<' before type arguments")) return args;
   if (match(parser, ">")) return args;
   do {
+    if (check(parser, ">")) break;
     Token *start = current(parser);
     TypeArg arg = {
       .type = parse_generic_arg_text(parser),
@@ -320,6 +323,7 @@ static ParamVec parse_error_set(Parser *parser) {
   if (!expect(parser, "{", "expected '{' before error set")) return errors;
   if (match(parser, "}")) return errors;
   do {
+    if (check(parser, "}")) break;
     Token *name = expect_ident(parser, "expected error name");
     if (!name) return errors;
     Param error = {
@@ -361,6 +365,7 @@ static Expr *parse_primary(Parser *parser) {
       expr->text = z_strdup(token->text);
       if (!match(parser, "}")) {
         do {
+          if (check(parser, "}")) break;
           Token *field_name = expect_ident(parser, "expected shape literal field name");
           if (!field_name) return expr;
           expect(parser, ":", "expected ':' after shape literal field name");
@@ -420,6 +425,7 @@ static Expr *parse_primary(Parser *parser) {
         if (count) push_expr(&expr->args, count);
       } else {
         while (match(parser, ",")) {
+          if (check(parser, "]")) break;
           Expr *item = parse_expr(parser);
           if (item) push_expr(&expr->args, item);
         }
@@ -484,6 +490,7 @@ static Expr *parse_postfix(Parser *parser) {
       call->left = expr;
       if (!match(parser, ")")) {
         do {
+          if (check(parser, ")")) break;
           Expr *arg = parse_expr(parser);
           if (arg) push_expr(&call->args, arg);
         } while (match(parser, ","));

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -8,6 +8,15 @@ typedef struct {
   TokenVec *tokens;
   size_t index;
   ZDiag *diag;
+  /* When true, parsers must reject a top-level shape literal because the
+     surrounding context expects a block-introducing '{' (if/while/for/match
+     conditions). Parenthesized sub-expressions reset this flag so users can
+     opt in with explicit parens. */
+  bool no_struct_literal;
+  /* When true, subsequent calls to fail()/fail_at() become no-ops so a
+     precise upstream diagnostic is preserved instead of being overwritten by
+     a cascade of follow-on parser errors. */
+  bool diag_sticky;
 } Parser;
 
 static void *parser_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
@@ -122,6 +131,7 @@ static bool match_kind(Parser *parser, TokenKind kind) {
 }
 
 static bool fail(Parser *parser, const char *message) {
+  if (parser->diag_sticky) return false;
   parser->diag->code = 100;
   parser->diag->line = current(parser)->line;
   parser->diag->column = current(parser)->column;
@@ -130,6 +140,7 @@ static bool fail(Parser *parser, const char *message) {
 }
 
 static bool fail_at(Parser *parser, Token *token, const char *message) {
+  if (parser->diag_sticky) return false;
   parser->diag->code = 100;
   parser->diag->line = token ? token->line : current(parser)->line;
   parser->diag->column = token ? token->column : current(parser)->column;
@@ -159,6 +170,7 @@ static Token *expect_ident(Parser *parser, const char *message) {
 }
 
 static Expr *parse_expr(Parser *parser);
+static Expr *parse_cond_expr(Parser *parser);
 static StmtVec parse_block(Parser *parser);
 static void free_expr(Expr *expr);
 
@@ -359,7 +371,49 @@ static Expr *new_expr(ExprKind kind, Token *token) {
 static Expr *parse_primary(Parser *parser) {
   Token *token = current(parser);
   if (match_kind(parser, TOK_IDENT)) {
-    if (token->text[0] >= 'A' && token->text[0] <= 'Z' && check(parser, "{")) {
+    if (parser->no_struct_literal && token->text[0] >= 'A' && token->text[0] <= 'Z' && check(parser, "{")) {
+      /* Detect an unambiguous shape-literal attempt in a control-flow
+         condition (identifier followed by '{' then 'name:'). Emit a
+         dedicated diagnostic suggesting parentheses; otherwise treat the
+         identifier as a plain reference so the '{' opens the block. */
+      size_t lookahead = parser->index;
+      if (lookahead + 1 < parser->tokens->len &&
+          parser->tokens->items[lookahead].text[0] == '{' &&
+          parser->tokens->items[lookahead + 1].kind == TOK_IDENT &&
+          lookahead + 2 < parser->tokens->len &&
+          strcmp(parser->tokens->items[lookahead + 2].text, ":") == 0) {
+        /* Skip over the shape literal body so the surrounding block-opener
+           '{' is recognised cleanly. We swallow tokens until the matching
+           '}' is consumed. */
+        parser->index++; /* consume opening '{' */
+        int depth = 1;
+        while (current(parser)->kind != TOK_EOF && depth > 0) {
+          if (check(parser, "{")) {
+            depth++;
+            parser->index++;
+          } else if (check(parser, "}")) {
+            depth--;
+            parser->index++;
+          } else {
+            parser->index++;
+          }
+        }
+        /* Report after the skip so this diagnostic is the final one. */
+        parser->diag->code = 100;
+        parser->diag->line = token->line;
+        parser->diag->column = token->column;
+        snprintf(parser->diag->message, sizeof(parser->diag->message),
+                 "shape literal not allowed here; wrap it in parentheses");
+        snprintf(parser->diag->help, sizeof(parser->diag->help),
+                 "control-flow conditions reserve '{' for the block body; write '(%s { ... })' to use a shape literal",
+                 token->text);
+        parser->diag_sticky = true;
+        Expr *expr = new_expr(EXPR_IDENT, token);
+        expr->text = z_strdup(token->text);
+        return expr;
+      }
+    }
+    if (!parser->no_struct_literal && token->text[0] >= 'A' && token->text[0] <= 'Z' && check(parser, "{")) {
       parser->index++;
       Expr *expr = new_expr(EXPR_SHAPE_LITERAL, token);
       expr->text = z_strdup(token->text);
@@ -410,11 +464,16 @@ static Expr *parse_primary(Parser *parser) {
     return new_expr(EXPR_NULL, previous(parser));
   }
   if (match(parser, "(")) {
+    bool saved = parser->no_struct_literal;
+    parser->no_struct_literal = false;
     Expr *expr = parse_expr(parser);
     expect(parser, ")", "expected ')' after expression");
+    parser->no_struct_literal = saved;
     return expr;
   }
   if (match(parser, "[")) {
+    bool saved = parser->no_struct_literal;
+    parser->no_struct_literal = false;
     Expr *expr = new_expr(EXPR_ARRAY_LITERAL, token);
     if (!match(parser, "]")) {
       Expr *first = parse_expr(parser);
@@ -432,6 +491,7 @@ static Expr *parse_primary(Parser *parser) {
       }
       expect(parser, "]", "expected ']' after array literal");
     }
+    parser->no_struct_literal = saved;
     return expr;
   }
   fail(parser, "expected expression");
@@ -457,6 +517,8 @@ static Expr *parse_postfix(Parser *parser) {
     }
     if (match(parser, "[")) {
       Token *index_token = previous(parser);
+      bool saved = parser->no_struct_literal;
+      parser->no_struct_literal = false;
       if (match(parser, "..")) {
         Expr *slice = new_expr(EXPR_SLICE, index_token);
         slice->left = expr;
@@ -465,6 +527,7 @@ static Expr *parse_postfix(Parser *parser) {
         push_expr(&slice->args, end);
         expect(parser, "]", "expected ']' after slice expression");
         expr = slice;
+        parser->no_struct_literal = saved;
         continue;
       }
       Expr *start = parse_expr(parser);
@@ -476,6 +539,7 @@ static Expr *parse_postfix(Parser *parser) {
         push_expr(&slice->args, end);
         expect(parser, "]", "expected ']' after slice expression");
         expr = slice;
+        parser->no_struct_literal = saved;
         continue;
       }
       Expr *index = new_expr(EXPR_INDEX, index_token);
@@ -483,11 +547,14 @@ static Expr *parse_postfix(Parser *parser) {
       index->right = start;
       expect(parser, "]", "expected ']' after index expression");
       expr = index;
+      parser->no_struct_literal = saved;
       continue;
     }
     if (match(parser, "(")) {
       Expr *call = new_expr(EXPR_CALL, expr ? &parser->tokens->items[parser->index - 1] : current(parser));
       call->left = expr;
+      bool saved = parser->no_struct_literal;
+      parser->no_struct_literal = false;
       if (!match(parser, ")")) {
         do {
           if (check(parser, ")")) break;
@@ -497,6 +564,7 @@ static Expr *parse_postfix(Parser *parser) {
         expect(parser, ")", "expected ')' after arguments");
       }
       expr = call;
+      parser->no_struct_literal = saved;
       continue;
     }
     return expr;
@@ -542,6 +610,19 @@ static Expr *parse_binary(Parser *parser, int min_precedence) {
     binary->text = z_strdup(op->text);
     left = binary;
   }
+}
+
+/* parse_cond_expr is used for the head expression in control-flow forms
+   (if/while/for/match) where '{' is reserved for the body block. A bare
+   shape literal `Foo { ... }` would otherwise consume the body opener and
+   yield a confusing diagnostic; this entry point flips a parser flag so
+   the primary parser can detect that case and surface a precise error. */
+static Expr *parse_cond_expr(Parser *parser) {
+  bool saved = parser->no_struct_literal;
+  parser->no_struct_literal = true;
+  Expr *expr = parse_expr(parser);
+  parser->no_struct_literal = saved;
+  return expr;
 }
 
 static Expr *parse_expr(Parser *parser) {
@@ -627,7 +708,7 @@ static Stmt *parse_statement(Parser *parser) {
   }
   if (match(parser, "if")) {
     Stmt *stmt = new_stmt(STMT_IF, start);
-    stmt->expr = parse_expr(parser);
+    stmt->expr = parse_cond_expr(parser);
     stmt->then_body = parse_block(parser);
     if (match(parser, "else")) {
       if (check(parser, "if")) {
@@ -641,7 +722,7 @@ static Stmt *parse_statement(Parser *parser) {
   }
   if (match(parser, "while")) {
     Stmt *stmt = new_stmt(STMT_WHILE, start);
-    stmt->expr = parse_expr(parser);
+    stmt->expr = parse_cond_expr(parser);
     stmt->then_body = parse_block(parser);
     return stmt;
   }
@@ -651,9 +732,9 @@ static Stmt *parse_statement(Parser *parser) {
     if (!name) return stmt;
     stmt->name = z_strdup(name->text);
     expect(parser, "in", "expected 'in' after loop binding");
-    stmt->expr = parse_expr(parser);
+    stmt->expr = parse_cond_expr(parser);
     expect(parser, "..", "expected '..' in range loop");
-    stmt->range_end = parse_expr(parser);
+    stmt->range_end = parse_cond_expr(parser);
     stmt->then_body = parse_block(parser);
     return stmt;
   }
@@ -665,7 +746,7 @@ static Stmt *parse_statement(Parser *parser) {
   }
   if (match(parser, "match")) {
     Stmt *stmt = new_stmt(STMT_MATCH, start);
-    stmt->expr = parse_expr(parser);
+    stmt->expr = parse_cond_expr(parser);
     expect(parser, "{", "expected '{' before match arms");
     while (!check(parser, "}") && current(parser)->kind != TOK_EOF && parser->diag->code == 0) {
       match(parser, ".");
@@ -994,7 +1075,7 @@ static UseImport parse_use_import(Parser *parser) {
 }
 
 Program z_parse(TokenVec *tokens, ZDiag *diag) {
-  Parser parser = {tokens, 0, diag};
+  Parser parser = {tokens, 0, diag, false, false};
   Program program = {0};
   while (current(&parser)->kind != TOK_EOF && diag->code == 0) {
     if (check(&parser, "use")) {


### PR DESCRIPTION
## Summary

Three small, isolated parser changes that close long-standing ergonomic gaps:

- `if x == 1 { ... } else if x == 3 { ... } else { ... }` now parses (P2-9).
- Comma-separated lists accept a single optional trailing comma (B7a) — function parameters and arguments, generic parameters and type arguments, `raises { ... }` error sets, array literals, and shape-literal field inits.
- Control-flow heads (`if` / `while` / `for` / `match`) no longer misparse a bare identifier-before-`{` as a shape literal (B6). When the user genuinely tries `while Foo { x: 1 } { ... }`, a precise PAR100 diagnostic suggests wrapping the literal in parentheses.

Pure parser change. No codegen, checker, or runtime touched.

## Source

Addresses B6 + B7a + P2-9. Reproduced against `main @ 999a46b` before each fix.

## Changes

- `native/zero-c/src/parser.c`
  - `else if` is delegated to `parse_statement`, with the nested branch stored as the sole entry in `else_body` so downstream passes see the existing shape.
  - `do { ... } while (match(","))` loops gain a `check(close) break` so a single trailing comma is silently accepted.
  - New `parse_cond_expr` flips a `no_struct_literal` parser flag for the condition position in `if` / `while` / `for` / `match`; `(...)` and `[...]` sub-expressions reset the flag, and an unambiguous shape-literal attempt emits a sticky PAR100 diagnostic suggesting parens.
- `native/zero-c/src/main.c`: `zero explain PAR100` now returns a real entry covering the new shape-literal-in-condition guidance.
- `docs/articles/language-reference.md`: short notes on else-if chains, the parens rule for shape literals in conditions, and trailing commas.

## Conformance

Appended to the `for (const fixture of [...])` block in `conformance/run.mjs` and the PAR100 fail table:

- pass: `conformance/native/pass/else-if-chain.0`
- pass: `conformance/native/pass/trailing-comma-params.0`
- pass: `conformance/native/pass/trailing-comma-array.0`
- pass: `conformance/native/pass/trailing-comma-struct.0`
- pass: `conformance/native/pass/cond-ident-before-block.0` (B6 repro, now green)
- pass: `conformance/native/pass/cond-paren-struct-literal.0`
- fail: `conformance/native/fail/cond-bare-struct-literal.0` (asserts the new diagnostic)

Gates: `conformance:local` and `command-contracts:local` both pass locally.

## Proposed CHANGELOG line

- Parser: accept `else if` chains, allow one optional trailing comma in every delimited list, and reject bare shape literals in `if`/`while`/`for`/`match` heads with a parens-suggestion diagnostic (PAR100).

🤖 Generated with [Claude Code](https://claude.com/claude-code)