### PR TITLE
Add unary negation, logical/bitwise not, and bitwise/shift operators

### DIFF
--- a/conformance/native/fail/shift-overflow.0
+++ b/conformance/native/fail/shift-overflow.0
@@ -1,0 +1,7 @@
+pub fun main(world: World) -> Void raises {
+    let x: i32 = 1
+    let y: i32 = x << 32
+    if y == 0 {
+        check world.out.write("never\n")
+    }
+}

--- a/conformance/native/pass/ops-bitwise.0
+++ b/conformance/native/pass/ops-bitwise.0
@@ -1,0 +1,29 @@
+pub fun main(world: World) -> Void raises {
+    let a: i32 = 0x0F & 0xF0
+    let b: i32 = 0x0F | 0xF0
+    let c: i32 = 0x0F ^ 0xFF
+    let d: i32 = 1 << 4
+    let e: i32 = 0x80 >> 3
+    let f: i32 = ~0
+    let g: i32 = 1 | 2 & 4
+    let h: i32 = (1 | 2) & 3
+    let i: i32 = 1 << 2 | 1
+    let j: i32 = 1 + 2 << 1
+    // UTF-8 encode the codepoint formed from a UTF-16 surrogate pair.
+    // High 0xD83D + Low 0xDE00 -> U+1F600 (grinning face).
+    let highSurrogate: u32 = 0xD83D_u32
+    let lowSurrogate: u32 = 0xDE00_u32
+    let codepoint: u32 = ((highSurrogate - 0xD800_u32) << 10_u32) + (lowSurrogate - 0xDC00_u32) + 0x10000_u32
+    let byte0: u32 = 0xF0_u32 | (codepoint >> 18_u32)
+    let byte1: u32 = 0x80_u32 | ((codepoint >> 12_u32) & 0x3F_u32)
+    let byte2: u32 = 0x80_u32 | ((codepoint >> 6_u32) & 0x3F_u32)
+    let byte3: u32 = 0x80_u32 | (codepoint & 0x3F_u32)
+    let okBitwise: Bool = a == 0 && b == 0xFF && c == 0xF0 && d == 16 && e == 0x10 && f == -1
+    let okPrecedence: Bool = g == 1 && h == 3 && i == 5 && j == 6
+    let okUtf8: Bool = codepoint == 0x1F600_u32 && byte0 == 0xF0_u32 && byte1 == 0x9F_u32 && byte2 == 0x98_u32 && byte3 == 0x80_u32
+    if okBitwise && okPrecedence && okUtf8 {
+        check world.out.write("bitwise ok\n")
+    } else {
+        check world.out.write("bitwise fail\n")
+    }
+}

--- a/conformance/native/pass/ops-not.0
+++ b/conformance/native/pass/ops-not.0
@@ -1,0 +1,13 @@
+pub fun main(world: World) -> Void raises {
+    let p: Bool = true
+    let q: Bool = !p
+    let r: Bool = !!p
+    let s: Bool = !(1 == 2)
+    let t: Bool = !true || !false
+    let u: Bool = !(true && false)
+    if !q && r && s && t && u {
+        check world.out.write("not ok\n")
+    } else {
+        check world.out.write("not fail\n")
+    }
+}

--- a/conformance/native/pass/ops-unary-neg.0
+++ b/conformance/native/pass/ops-unary-neg.0
@@ -1,0 +1,14 @@
+pub fun main(world: World) -> Void raises {
+    let a: i32 = -1
+    let b: i32 = 5
+    let c: i32 = -b
+    let d: i32 = -(2 + 3)
+    let e: i64 = -1000000000
+    let f: i32 = - -7
+    let g: i32 = 10 + -3
+    if a == -1 && c == -5 && d == -5 && e < 0 && f == 7 && g == 7 {
+        check world.out.write("unary neg ok\n")
+    } else {
+        check world.out.write("unary neg fail\n")
+    }
+}

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -312,6 +312,9 @@ for (const fixture of [
   "conformance/native/pass/array-repeat-literal.0",
   "conformance/native/pass/array-repeat-record-field.0",
   "conformance/native/pass/integer-widths.0",
+  "conformance/native/pass/ops-unary-neg.0",
+  "conformance/native/pass/ops-not.0",
+  "conformance/native/pass/ops-bitwise.0",
   "conformance/native/pass/std-codec-widths.0",
   "conformance/native/pass/std-crypto-hmac32.0",
   "conformance/native/pass/parse-integers.0",
@@ -2593,6 +2596,9 @@ for (const runtimeFixture of [
   ["conformance/native/pass/std-fs-bytes.0", "std-fs-bytes", { stdout: "fs bytes ok\n", stderr: "fs bytes err ok\n" }],
   ["conformance/native/pass/std-fs-resource.0", "std-fs-resource", { stdout: "fs resource ok\n", file: { name: "std-fs-resource.txt", text: "zero file\n" } }],
   ["conformance/native/pass/integer-widths.0", "integer-widths", { stdout: "integer widths ok\n" }],
+  ["conformance/native/pass/ops-unary-neg.0", "ops-unary-neg", { stdout: "unary neg ok\n" }],
+  ["conformance/native/pass/ops-not.0", "ops-not", { stdout: "not ok\n" }],
+  ["conformance/native/pass/ops-bitwise.0", "ops-bitwise", { stdout: "bitwise ok\n" }],
   ["conformance/native/pass/std-codec-widths.0", "std-codec-widths", { stdout: "codec widths ok\n" }],
   ["conformance/native/pass/std-crypto-hmac32.0", "std-crypto-hmac32", { stdout: "crypto hmac32 ok\n" }],
   ["conformance/native/pass/parse-integers.0", "parse-integers", { stdout: "parse integers ok\n" }],
@@ -2842,6 +2848,10 @@ assert.match(badChoicePayload.stderr, /VAR004/);
 const allocatorInvalid = await execFileAsync(zero, ["check", "conformance/native/fail/allocator-invalid.0"]).catch((error) => error);
 assert.notEqual(allocatorInvalid.code, 0);
 assert.match(allocatorInvalid.stderr, /STD003/);
+
+const shiftOverflow = await execFileAsync(zero, ["check", "conformance/native/fail/shift-overflow.0"]).catch((error) => error);
+assert.notEqual(shiftOverflow.code, 0);
+assert.match(shiftOverflow.stderr, /TYP002/);
 
 const allocatorImmutableFixedBuf = await execFileAsync(zero, ["check", "conformance/native/fail/allocator-immutable-fixedbuf.0"]).catch((error) => error);
 assert.notEqual(allocatorImmutableFixedBuf.code, 0);

--- a/docs/articles/language-reference.md
+++ b/docs/articles/language-reference.md
@@ -414,6 +414,33 @@ The native compiler does not yet support:
 - assignment through calls or temporaries
 - profile-specific bounds-check elision
 
+## Operators
+
+Zero parses prefix and binary operators with the following precedence (lowest
+to highest, all binary operators are left-associative):
+
+| Tier | Operators | Notes |
+| --- | --- | --- |
+| 1 | `\|\|` | logical or, short-circuits, `Bool` operands |
+| 2 | `&&` | logical and, short-circuits, `Bool` operands |
+| 3 | `==` `!=` `<` `<=` `>` `>=` | equality and ordered comparison |
+| 4 | `\|` | bitwise or |
+| 5 | `^` | bitwise xor |
+| 6 | `&` | bitwise and (binary `&`; unary `&` is the borrow operator) |
+| 7 | `<<` `>>` | shift; `>>` is logical for unsigned types and arithmetic for signed |
+| 8 | `+` `-` `+%` `+|` | additive (wrapping and saturating include their modifier) |
+| 9 | `*` `/` `%` | multiplicative |
+| unary | `-` `!` `~` | numeric negation, logical not, bitwise not |
+
+Bitwise `&`, `|`, `^`, and the shifts `<<`, `>>` require integer operands of
+matching width and signedness. Shift amounts must be unsigned integers and
+strictly smaller than the left operand's bit width; larger constants are
+rejected at check time as `TYP002`. Unary `-` requires a signed integer or
+float; unary `~` requires an integer; unary `!` requires a `Bool`.
+
+Two adjacent `>` tokens with no whitespace between them are parsed as `>>`,
+so `Foo<Bar<T>>` still closes cleanly when no shift is intended.
+
 ## Control Flow
 
 Use `if` / `else` for branches:

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -137,6 +137,7 @@ typedef enum {
   EXPR_SLICE,
   EXPR_CALL,
   EXPR_BINARY,
+  EXPR_UNARY,
   EXPR_CAST,
   EXPR_BORROW,
   EXPR_CHECK,
@@ -452,6 +453,7 @@ typedef enum {
   IR_VALUE_BOOL,
   IR_VALUE_LOCAL,
   IR_VALUE_BINARY,
+  IR_VALUE_UNARY,
   IR_VALUE_COMPARE,
   IR_VALUE_CALL,
   IR_VALUE_INDEX_LOAD,
@@ -529,8 +531,19 @@ typedef enum {
   IR_BIN_DIV,
   IR_BIN_MOD,
   IR_BIN_AND,
-  IR_BIN_OR
+  IR_BIN_OR,
+  IR_BIN_BITAND,
+  IR_BIN_BITOR,
+  IR_BIN_BITXOR,
+  IR_BIN_SHL,
+  IR_BIN_SHR
 } IrBinaryOp;
+
+typedef enum {
+  IR_UNARY_NEG,
+  IR_UNARY_NOT,
+  IR_UNARY_BITNOT
+} IrUnaryOp;
 
 typedef enum {
   IR_CMP_EQ,
@@ -557,6 +570,7 @@ struct IrValue {
   IrTypeKind element_type;
   unsigned error_code;
   IrBinaryOp binary_op;
+  IrUnaryOp unary_op;
   IrCompareOp compare_op;
   IrValue **args;
   size_t arg_len;

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -3874,12 +3874,43 @@ static bool eval_meta_value_uncached(CheckContext *ctx, const Program *program, 
       } else if (strcmp(expr->text, "%") == 0) {
         if (right.number == 0) return false;
         *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number % right.number};
+      } else if (strcmp(expr->text, "&") == 0) *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number & right.number};
+      else if (strcmp(expr->text, "|") == 0) *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number | right.number};
+      else if (strcmp(expr->text, "^") == 0) *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number ^ right.number};
+      else if (strcmp(expr->text, "<<") == 0) {
+        if (right.number >= 64) return false;
+        *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number << right.number};
+      } else if (strcmp(expr->text, ">>") == 0) {
+        if (right.number >= 64) return false;
+        *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = left.number >> right.number};
       } else if (strcmp(expr->text, "<") == 0) *out = (MetaValue){.kind = META_VALUE_BOOL, .boolean = left.number < right.number};
       else if (strcmp(expr->text, "<=") == 0) *out = (MetaValue){.kind = META_VALUE_BOOL, .boolean = left.number <= right.number};
       else if (strcmp(expr->text, ">") == 0) *out = (MetaValue){.kind = META_VALUE_BOOL, .boolean = left.number > right.number};
       else if (strcmp(expr->text, ">=") == 0) *out = (MetaValue){.kind = META_VALUE_BOOL, .boolean = left.number >= right.number};
       else return false;
       return true;
+    }
+    case EXPR_UNARY: {
+      MetaValue operand = {0};
+      if (!eval_meta_value(ctx, program, expr->left, &operand, depth + 1, steps)) return false;
+      if (!expr->text) return false;
+      if (strcmp(expr->text, "!") == 0) {
+        if (operand.kind != META_VALUE_BOOL) return false;
+        *out = (MetaValue){.kind = META_VALUE_BOOL, .boolean = !operand.boolean};
+        return true;
+      }
+      if (strcmp(expr->text, "~") == 0) {
+        if (operand.kind != META_VALUE_NUMBER) return false;
+        *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = ~operand.number};
+        return true;
+      }
+      if (strcmp(expr->text, "-") == 0) {
+        if (operand.kind != META_VALUE_NUMBER) return false;
+        if (operand.number != 0) return false;
+        *out = (MetaValue){.kind = META_VALUE_NUMBER, .number = 0};
+        return true;
+      }
+      return false;
     }
     default:
       return false;
@@ -5283,7 +5314,10 @@ static const char *expr_type(CheckContext *ctx, const Program *program, const Ex
       if (strcmp(expr->text, "==") == 0 || strcmp(expr->text, "!=") == 0 || strcmp(expr->text, "<") == 0 ||
           strcmp(expr->text, "<=") == 0 || strcmp(expr->text, ">") == 0 || strcmp(expr->text, ">=") == 0 ||
           strcmp(expr->text, "&&") == 0 || strcmp(expr->text, "||") == 0) return "Bool";
-      return "i32";
+      return expr->left ? expr_type(ctx, program, expr->left, scope) : "i32";
+    case EXPR_UNARY:
+      if (expr->text && strcmp(expr->text, "!") == 0) return "Bool";
+      return expr->left ? expr_type(ctx, program, expr->left, scope) : "i32";
     case EXPR_MEMBER:
       if (expr->left) {
         if (expr->left->kind == EXPR_IDENT && find_enum(program, expr->left->text)) return expr->left->text;
@@ -6721,6 +6755,8 @@ static bool check_expr_expected(CheckContext *ctx, const Program *program, const
       bool comparison = strcmp(expr->text, "==") == 0 || strcmp(expr->text, "!=") == 0 || strcmp(expr->text, "<") == 0 ||
         strcmp(expr->text, "<=") == 0 || strcmp(expr->text, ">") == 0 || strcmp(expr->text, ">=") == 0;
       bool logical = strcmp(expr->text, "&&") == 0 || strcmp(expr->text, "||") == 0;
+      bool bitwise = strcmp(expr->text, "&") == 0 || strcmp(expr->text, "|") == 0 || strcmp(expr->text, "^") == 0;
+      bool shift = strcmp(expr->text, "<<") == 0 || strcmp(expr->text, ">>") == 0;
       if (!check_expr_expected(ctx, program, expr->left, scope, diag, expected && (is_int_type(expected) || is_float_type(expected)) ? expected : NULL)) return false;
       const char *left_type = expr_type(ctx, program, expr->left, scope);
       if (logical) {
@@ -6764,6 +6800,42 @@ static bool check_expr_expected(CheckContext *ctx, const Program *program, const
         set_expr_resolved_type(expr, "Bool");
         return true;
       }
+      if (bitwise) {
+        if (!is_int_type(left_type) || !is_int_type(right_type)) {
+          return set_diag_detail(diag, 3006, "bitwise operators require integer operands", expr->line, expr->column, "matching integer operands", is_float_type(left_type) || is_float_type(right_type) ? "float operand" : "non-integer operand", "use integers with the same width and signedness for &, |, and ^");
+        }
+        if (strcmp(left_type, right_type) != 0) {
+          return set_diag_detail(diag, 3006, "bitwise operands must have the same integer type", expr->line, expr->column, left_type, right_type, "match the operand types before applying &, |, or ^");
+        }
+        set_expr_resolved_type(expr, left_type);
+        return true;
+      }
+      if (shift) {
+        if (!is_int_type(left_type)) {
+          return set_diag_detail(diag, 3006, "shift operators require an integer left operand", expr->line, expr->column, "integer left operand", left_type, "shift an integer value");
+        }
+        if (!is_int_type(right_type)) {
+          return set_diag_detail(diag, 3006, "shift amount must be an unsigned integer", expr->line, expr->column, "usize or unsigned integer shift amount", right_type, "use an unsigned integer such as usize or u32 for the shift amount");
+        }
+        if (expr->right && expr->right->kind == EXPR_NUMBER) {
+          ParsedIntegerLiteral parsed = {0};
+          if (parse_integer_literal(expr->right->text, &parsed)) {
+            unsigned long long width = 0;
+            if (strcmp(left_type, "i8") == 0 || strcmp(left_type, "u8") == 0) width = 8;
+            else if (strcmp(left_type, "i16") == 0 || strcmp(left_type, "u16") == 0) width = 16;
+            else if (strcmp(left_type, "i32") == 0 || strcmp(left_type, "u32") == 0) width = 32;
+            else if (strcmp(left_type, "i64") == 0 || strcmp(left_type, "u64") == 0) width = 64;
+            else if (strcmp(left_type, "usize") == 0 || strcmp(left_type, "isize") == 0) width = 64;
+            if (width > 0 && parsed.value >= width) {
+              char message[160];
+              snprintf(message, sizeof(message), "shift amount must be smaller than %llu", width);
+              return set_diag_detail(diag, 3006, "shift amount exceeds operand bit width", expr->right->line, expr->right->column, message, expr->right->text, "use a shift amount strictly smaller than the operand's bit width");
+            }
+          }
+        }
+        set_expr_resolved_type(expr, left_type);
+        return true;
+      }
       if (!((is_int_type(left_type) && is_int_type(right_type)) || (is_float_type(left_type) && is_float_type(right_type)))) {
         return set_diag_detail(diag, 3006, "arithmetic operators require matching numeric operands", expr->line, expr->column, "matching integer or float operands", is_char_type(left_type) || is_char_type(right_type) ? "char operand" : "mixed or non-numeric operand", "keep integers, floats, and chars separate");
       }
@@ -6772,6 +6844,41 @@ static bool check_expr_expected(CheckContext *ctx, const Program *program, const
       }
       set_expr_resolved_type(expr, left_type);
       return true;
+    }
+    case EXPR_UNARY: {
+      if (!expr->text || !expr->left) return set_diag_detail(diag, 100, "malformed unary expression", expr->line, expr->column, "unary operator", "missing operator or operand", "use -x, !x, or ~x with a valid operand");
+      const char *op = expr->text;
+      if (strcmp(op, "!") == 0) {
+        if (!check_expr_expected(ctx, program, expr->left, scope, diag, "Bool")) return false;
+        const char *operand_type = expr_type(ctx, program, expr->left, scope);
+        if (!is_bool_type(operand_type)) {
+          return set_diag_detail(diag, 3006, "logical not requires a Bool operand", expr->line, expr->column, "Bool", operand_type, "apply ! to a Bool value");
+        }
+        set_expr_resolved_type(expr, "Bool");
+        return true;
+      }
+      if (strcmp(op, "-") == 0) {
+        if (!check_expr_expected(ctx, program, expr->left, scope, diag, expected && (is_int_type(expected) || is_float_type(expected)) ? expected : NULL)) return false;
+        const char *operand_type = expr_type(ctx, program, expr->left, scope);
+        if (!is_int_type(operand_type) && !is_float_type(operand_type)) {
+          return set_diag_detail(diag, 3006, "unary negation requires a numeric operand", expr->line, expr->column, "integer or float operand", operand_type, "negate an integer or float value");
+        }
+        if (is_int_type(operand_type) && operand_type[0] == 'u') {
+          return set_diag_detail(diag, 3006, "unary negation requires a signed numeric operand", expr->line, expr->column, "signed integer or float operand", operand_type, "cast to a signed integer type or use a signed literal");
+        }
+        set_expr_resolved_type(expr, operand_type);
+        return true;
+      }
+      if (strcmp(op, "~") == 0) {
+        if (!check_expr_expected(ctx, program, expr->left, scope, diag, expected && is_int_type(expected) ? expected : NULL)) return false;
+        const char *operand_type = expr_type(ctx, program, expr->left, scope);
+        if (!is_int_type(operand_type)) {
+          return set_diag_detail(diag, 3006, "bitwise not requires an integer operand", expr->line, expr->column, "integer operand", operand_type, "apply ~ to an integer value");
+        }
+        set_expr_resolved_type(expr, operand_type);
+        return true;
+      }
+      return set_diag_detail(diag, 100, "unsupported unary operator", expr->line, expr->column, "- ! ~", op, "use one of the supported unary operators");
     }
     case EXPR_SHAPE_LITERAL: {
       const Shape *shape = find_shape(program, expr->text);

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -479,7 +479,9 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       coff_emit_load_local_eax(text, fun, value->local_index);
       return true;
     case IR_VALUE_BINARY:
-      if (value->binary_op != IR_BIN_ADD && value->binary_op != IR_BIN_SUB && value->binary_op != IR_BIN_MUL) return coff_diag_at(diag, "direct COFF binary operator is unsupported", value->line, value->column, "unsupported operator");
+      if (value->binary_op != IR_BIN_ADD && value->binary_op != IR_BIN_SUB && value->binary_op != IR_BIN_MUL &&
+          value->binary_op != IR_BIN_BITAND && value->binary_op != IR_BIN_BITOR && value->binary_op != IR_BIN_BITXOR &&
+          value->binary_op != IR_BIN_SHL && value->binary_op != IR_BIN_SHR) return coff_diag_at(diag, "direct COFF binary operator is unsupported", value->line, value->column, "unsupported operator");
       if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
       append_u8(text, 0x50);
       if (!coff_emit_value(text, fun, value->right, ctx, diag)) return false;
@@ -490,11 +492,53 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
         append_u8(text, 0x0f);
         append_u8(text, 0xaf);
         append_u8(text, 0xc1);
+      } else if (value->binary_op == IR_BIN_BITAND) {
+        append_u8(text, 0x21);
+        append_u8(text, 0xc8);
+      } else if (value->binary_op == IR_BIN_BITOR) {
+        append_u8(text, 0x09);
+        append_u8(text, 0xc8);
+      } else if (value->binary_op == IR_BIN_BITXOR) {
+        append_u8(text, 0x31);
+        append_u8(text, 0xc8);
+      } else if (value->binary_op == IR_BIN_SHL) {
+        append_u8(text, 0xd3);
+        append_u8(text, 0xe0);
+      } else if (value->binary_op == IR_BIN_SHR) {
+        bool sign = !(value->type == IR_TYPE_U8 || value->type == IR_TYPE_U16 || value->type == IR_TYPE_U32 || value->type == IR_TYPE_U64 || value->type == IR_TYPE_USIZE);
+        append_u8(text, 0xd3);
+        append_u8(text, sign ? 0xf8 : 0xe8);
       } else {
         append_u8(text, value->binary_op == IR_BIN_ADD ? 0x01 : 0x29);
         append_u8(text, 0xc8);
       }
       return true;
+    case IR_VALUE_UNARY: {
+      if (!value->left) return coff_diag_at(diag, "direct COFF unary requires an operand", value->line, value->column, "missing operand");
+      if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
+      if (value->unary_op == IR_UNARY_NEG) {
+        append_u8(text, 0xf7);
+        append_u8(text, 0xd8);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_BITNOT) {
+        append_u8(text, 0xf7);
+        append_u8(text, 0xd0);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_NOT) {
+        append_u8(text, 0x85);
+        append_u8(text, 0xc0);
+        append_u8(text, 0x0f);
+        append_u8(text, 0x94);
+        append_u8(text, 0xc0);
+        append_u8(text, 0x0f);
+        append_u8(text, 0xb6);
+        append_u8(text, 0xc0);
+        return true;
+      }
+      return coff_diag_at(diag, "direct COFF unary operator is unsupported", value->line, value->column, "unsupported unary operator");
+    }
     case IR_VALUE_COMPARE:
       if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF comparison requires two operands", value->line, value->column, "invalid comparison");
       if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -851,6 +851,35 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
         if (wide) elf_append_u8(code, 0x48);
         elf_append_u8(code, value->binary_op == IR_BIN_AND ? 0x21 : 0x09);
         elf_append_u8(code, 0xc8);
+      } else if (value->binary_op == IR_BIN_BITAND) {
+        if (wide) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0x21);
+        elf_append_u8(code, 0xc8);
+      } else if (value->binary_op == IR_BIN_BITOR) {
+        if (wide) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0x09);
+        elf_append_u8(code, 0xc8);
+      } else if (value->binary_op == IR_BIN_BITXOR) {
+        if (wide) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0x31);
+        elf_append_u8(code, 0xc8);
+      } else if (value->binary_op == IR_BIN_SHL) {
+        // shl r/m, cl
+        if (wide) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0xd3);
+        elf_append_u8(code, 0xe0);
+      } else if (value->binary_op == IR_BIN_SHR) {
+        if (elf_type_is_unsigned(value->type)) {
+          // shr r/m, cl
+          if (wide) elf_append_u8(code, 0x48);
+          elf_append_u8(code, 0xd3);
+          elf_append_u8(code, 0xe8);
+        } else {
+          // sar r/m, cl
+          if (wide) elf_append_u8(code, 0x48);
+          elf_append_u8(code, 0xd3);
+          elf_append_u8(code, 0xf8);
+        }
       } else if (value->binary_op == IR_BIN_DIV) {
         if (elf_type_is_unsigned(value->type)) {
           if (wide) elf_append_u8(code, 0x48);
@@ -896,6 +925,38 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
         return elf_diag(diag, "direct ELF64 binary operator is unsupported", value->line, value->column, "unsupported operator");
       }
       return true;
+    }
+    case IR_VALUE_UNARY: {
+      if (!value->left) return elf_diag(diag, "direct ELF64 unary requires an operand", value->line, value->column, "missing operand");
+      if (!elf_emit_value(code, fun, value->left, ctx, diag)) return false;
+      bool wide_u = elf_type_is_i64(value->type);
+      if (value->unary_op == IR_UNARY_NEG) {
+        // neg r/m
+        if (wide_u) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0xf7);
+        elf_append_u8(code, 0xd8);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_BITNOT) {
+        // not r/m
+        if (wide_u) elf_append_u8(code, 0x48);
+        elf_append_u8(code, 0xf7);
+        elf_append_u8(code, 0xd0);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_NOT) {
+        // test eax, eax ; sete al ; movzx eax, al
+        elf_append_u8(code, 0x85);
+        elf_append_u8(code, 0xc0);
+        elf_append_u8(code, 0x0f);
+        elf_append_u8(code, 0x94);
+        elf_append_u8(code, 0xc0);
+        elf_append_u8(code, 0x0f);
+        elf_append_u8(code, 0xb6);
+        elf_append_u8(code, 0xc0);
+        return true;
+      }
+      return elf_diag(diag, "direct ELF64 unary operator is unsupported", value->line, value->column, "unsupported unary operator");
     }
     case IR_VALUE_COMPARE: {
       if (!value->left || !value->right || !elf_type_is_supported_scalar(value->left->type) || value->left->type != value->right->type) {

--- a/native/zero-c/src/emit_elf_aarch64.c
+++ b/native/zero-c/src/emit_elf_aarch64.c
@@ -57,10 +57,41 @@ static bool a64_diag(ZDiag *diag, const char *message, int line, int column, con
   return false;
 }
 
+static bool a64_value_contains_new_opcode(const IrValue *value) {
+  if (!value) return false;
+  if (value->kind == IR_VALUE_UNARY) return true;
+  if (value->kind == IR_VALUE_BINARY) {
+    if (value->binary_op == IR_BIN_BITAND || value->binary_op == IR_BIN_BITOR ||
+        value->binary_op == IR_BIN_BITXOR || value->binary_op == IR_BIN_SHL ||
+        value->binary_op == IR_BIN_SHR) return true;
+  }
+  if (a64_value_contains_new_opcode(value->left)) return true;
+  if (a64_value_contains_new_opcode(value->right)) return true;
+  if (a64_value_contains_new_opcode(value->index)) return true;
+  for (size_t i = 0; i < value->arg_len; i++) {
+    if (a64_value_contains_new_opcode(value->args[i])) return true;
+  }
+  return false;
+}
+
+static bool a64_instr_contains_new_opcode(const IrInstr *instrs, size_t len) {
+  for (size_t i = 0; i < len; i++) {
+    const IrInstr *instr = &instrs[i];
+    if (a64_value_contains_new_opcode(instr->value)) return true;
+    if (a64_value_contains_new_opcode(instr->index)) return true;
+    if (a64_instr_contains_new_opcode(instr->then_instrs, instr->then_len)) return true;
+    if (a64_instr_contains_new_opcode(instr->else_instrs, instr->else_len)) return true;
+  }
+  return false;
+}
+
 static bool a64_return_literal(const IrFunction *fun, uint32_t *out, ZDiag *diag) {
   if (!fun) return a64_diag(diag, "direct AArch64 ELF object backend requires a function", 1, 1, "missing function");
   if (fun->return_type != IR_TYPE_VOID && fun->return_type != IR_TYPE_U8 && fun->return_type != IR_TYPE_I32 && fun->return_type != IR_TYPE_U32 && fun->return_type != IR_TYPE_USIZE) {
     return a64_diag(diag, "direct AArch64 ELF object backend currently supports primitive 32-bit-or-smaller integer returns", fun->line, fun->column, fun->name);
+  }
+  if (a64_instr_contains_new_opcode(fun->instrs, fun->instr_len)) {
+    return a64_diag(diag, "direct AArch64 ELF object backend does not yet lower unary or bitwise/shift operators", fun->line, fun->column, fun->name);
   }
   *out = 0;
   for (size_t i = 0; i < fun->instr_len; i++) {

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -545,7 +545,42 @@ static void macho_emit_binary_reg(ZBuf *text, IrBinaryOp op, unsigned dst, unsig
     append_u32le(text, sf | 0x4b000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
   } else if (op == IR_BIN_MUL) {
     append_u32le(text, sf | 0x1b000000u | ((rhs & 31u) << 16) | (31u << 10) | ((lhs & 31u) << 5) | (dst & 31u));
+  } else if (op == IR_BIN_BITAND) {
+    append_u32le(text, sf | 0x0a000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+  } else if (op == IR_BIN_BITOR) {
+    append_u32le(text, sf | 0x2a000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+  } else if (op == IR_BIN_BITXOR) {
+    append_u32le(text, sf | 0x4a000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
   }
+}
+
+static void macho_emit_shift_reg(ZBuf *text, IrBinaryOp op, IrTypeKind type, unsigned dst, unsigned lhs, unsigned rhs, bool wide) {
+  uint32_t sf = wide ? 0x80000000u : 0;
+  if (op == IR_BIN_SHL) {
+    // LSLV: sf 0 0 1101 0110 Rm 0010 00 Rn Rd
+    append_u32le(text, sf | 0x1ac02000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+  } else {
+    bool is_unsigned = (type == IR_TYPE_U8 || type == IR_TYPE_U16 || type == IR_TYPE_U32 || type == IR_TYPE_U64 || type == IR_TYPE_USIZE);
+    if (is_unsigned) {
+      // LSRV
+      append_u32le(text, sf | 0x1ac02400u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+    } else {
+      // ASRV
+      append_u32le(text, sf | 0x1ac02800u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+    }
+  }
+}
+
+static void macho_emit_neg_reg(ZBuf *text, unsigned dst, unsigned src, bool wide) {
+  uint32_t sf = wide ? 0x80000000u : 0;
+  // SUB Rd, XZR(31), Rm
+  append_u32le(text, sf | 0x4b000000u | ((src & 31u) << 16) | (31u << 5) | (dst & 31u));
+}
+
+static void macho_emit_mvn_reg(ZBuf *text, unsigned dst, unsigned src, bool wide) {
+  uint32_t sf = wide ? 0x80000000u : 0;
+  // ORN Rd, XZR, Rm => MVN
+  append_u32le(text, sf | 0x2a2003e0u | ((src & 31u) << 16) | (dst & 31u));
 }
 
 static void macho_emit_div_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs, bool is_unsigned, bool wide) {
@@ -1107,7 +1142,9 @@ static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const 
         return true;
       }
       if (value->binary_op != IR_BIN_ADD && value->binary_op != IR_BIN_SUB && value->binary_op != IR_BIN_MUL &&
-          value->binary_op != IR_BIN_DIV && value->binary_op != IR_BIN_MOD) return macho_diag_at(diag, "direct AArch64 Mach-O binary operator is unsupported", value->line, value->column, "unsupported operator");
+          value->binary_op != IR_BIN_DIV && value->binary_op != IR_BIN_MOD &&
+          value->binary_op != IR_BIN_BITAND && value->binary_op != IR_BIN_BITOR && value->binary_op != IR_BIN_BITXOR &&
+          value->binary_op != IR_BIN_SHL && value->binary_op != IR_BIN_SHR) return macho_diag_at(diag, "direct AArch64 Mach-O binary operator is unsupported", value->line, value->column, "unsupported operator");
       if (!macho_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
       if (!macho_emit_store_scratch(text, 8, value->left ? value->left->type : IR_TYPE_I32, scratch_slot, value->left, diag)) return false;
       if (!macho_emit_value_to_reg_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
@@ -1118,10 +1155,36 @@ static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const 
       } else if (value->binary_op == IR_BIN_MOD) {
         macho_emit_div_reg(text, 10, 8, 9, macho_type_is_unsigned(value->type), wide);
         macho_emit_msub_reg(text, reg, 10, 9, 8, wide);
+      } else if (value->binary_op == IR_BIN_SHL || value->binary_op == IR_BIN_SHR) {
+        macho_emit_shift_reg(text, value->binary_op, value->type, reg, 8, 9, wide);
       } else {
         macho_emit_binary_reg(text, value->binary_op, reg, 8, 9, wide);
       }
       return true;
+    case IR_VALUE_UNARY: {
+      if (!value->left) return macho_diag_at(diag, "direct AArch64 Mach-O unary requires an operand", value->line, value->column, "missing operand");
+      if (!macho_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+      bool wide_u = macho_type_is_scalar64(value->type);
+      if (value->unary_op == IR_UNARY_NEG) {
+        macho_emit_neg_reg(text, reg, 8, wide_u);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_BITNOT) {
+        macho_emit_mvn_reg(text, reg, 8, wide_u);
+        return true;
+      }
+      if (value->unary_op == IR_UNARY_NOT) {
+        // Bool not: result = (operand == 0) ? 1 : 0 via CBZ-based skip.
+        size_t zero_branch = macho_emit_cbz_w_placeholder(text, 8);
+        macho_emit_movz_w(text, reg, 0);
+        size_t end_patch = macho_emit_b_placeholder(text);
+        macho_patch_cond19(text, zero_branch, text->len);
+        macho_emit_movz_w(text, reg, 1);
+        macho_patch_branch26(text, end_patch, text->len);
+        return true;
+      }
+      return macho_diag_at(diag, "direct AArch64 Mach-O unary operator is unsupported", value->line, value->column, "unsupported unary operator");
+    }
     case IR_VALUE_COMPARE: {
       if (!value->left || !value->right) {
         return macho_diag_at(diag, "direct AArch64 Mach-O comparison requires two operands", value->line, value->column, "invalid comparison");

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -1074,6 +1074,20 @@ static bool ir_binary_op(const char *text, IrBinaryOp *out) {
   else if (strcmp(text, "%") == 0) *out = IR_BIN_MOD;
   else if (strcmp(text, "&&") == 0) *out = IR_BIN_AND;
   else if (strcmp(text, "||") == 0) *out = IR_BIN_OR;
+  else if (strcmp(text, "&") == 0) *out = IR_BIN_BITAND;
+  else if (strcmp(text, "|") == 0) *out = IR_BIN_BITOR;
+  else if (strcmp(text, "^") == 0) *out = IR_BIN_BITXOR;
+  else if (strcmp(text, "<<") == 0) *out = IR_BIN_SHL;
+  else if (strcmp(text, ">>") == 0) *out = IR_BIN_SHR;
+  else return false;
+  return true;
+}
+
+static bool ir_unary_op(const char *text, IrUnaryOp *out) {
+  if (!text) return false;
+  if (strcmp(text, "-") == 0) *out = IR_UNARY_NEG;
+  else if (strcmp(text, "!") == 0) *out = IR_UNARY_NOT;
+  else if (strcmp(text, "~") == 0) *out = IR_UNARY_BITNOT;
   else return false;
   return true;
 }
@@ -2602,10 +2616,35 @@ static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunctio
         ir_free_value(right);
         return false;
       }
+      if ((op == IR_BIN_SHL || op == IR_BIN_SHR) && right && left && right->type != left->type && right->kind == IR_VALUE_INT) {
+        right->type = left->type;
+      }
       IrValue *value = ir_new_value(ir, IR_VALUE_BINARY, type, expr->line, expr->column);
       value->binary_op = op;
       value->left = left;
       value->right = right;
+      *out = value;
+      return true;
+    }
+    case EXPR_UNARY: {
+      IrUnaryOp uop = IR_UNARY_NEG;
+      if (!ir_unary_op(expr->text, &uop)) {
+        ir_mark_unsupported(ir, "direct backend unary operator is unsupported", expr->line, expr->column, expr->text ? expr->text : "?");
+        return false;
+      }
+      IrTypeKind type = ir_type_kind(expr->resolved_type);
+      if (!(type == IR_TYPE_BOOL || ir_type_is_value(type))) {
+        ir_mark_unsupported(ir, "direct backend unary expression type is unsupported", expr->line, expr->column, expr->resolved_type);
+        return false;
+      }
+      IrValue *operand = NULL;
+      if (!ir_lower_expr(program, ir, fun, expr->left, &operand)) {
+        ir_free_value(operand);
+        return false;
+      }
+      IrValue *value = ir_new_value(ir, IR_VALUE_UNARY, type, expr->line, expr->column);
+      value->unary_op = uop;
+      value->left = operand;
       *out = value;
       return true;
     }

--- a/native/zero-c/src/lexer.c
+++ b/native/zero-c/src/lexer.c
@@ -31,7 +31,7 @@ static bool is_keyword(const char *text) {
 }
 
 static bool two_char_symbol(const char *source, size_t offset) {
-  const char *symbols[] = {"->", "=>", "..", "==", "!=", "<=", ">=", "&&", "||", "+%", "+|", NULL};
+  const char *symbols[] = {"->", "=>", "..", "==", "!=", "<=", ">=", "&&", "||", "+%", "+|", "<<", ">>", NULL};
   for (int i = 0; symbols[i]; i++) {
     if (source[offset] == symbols[i][0] && source[offset + 1] == symbols[i][1]) return true;
   }
@@ -204,7 +204,7 @@ TokenVec z_tokenize(const char *source, ZDiag *diag) {
       continue;
     }
 
-    if (strchr("(){}[],.;:<>=+-*/%!&", ch)) {
+    if (strchr("(){}[],.;:<>=+-*/%!&|^~", ch)) {
       push_token(&tokens, make_token(TOK_SYMBOL, z_strndup(source + offset, 1), start_line, start_column, start, 1));
       offset++;
       column++;

--- a/native/zero-c/src/lexer.c
+++ b/native/zero-c/src/lexer.c
@@ -31,7 +31,10 @@ static bool is_keyword(const char *text) {
 }
 
 static bool two_char_symbol(const char *source, size_t offset) {
-  const char *symbols[] = {"->", "=>", "..", "==", "!=", "<=", ">=", "&&", "||", "+%", "+|", "<<", ">>", NULL};
+  // `>>` is intentionally NOT lexed here: it would conflict with closing
+  // nested generic type arguments like `Foo<Bar<T>>`. The parser recognises
+  // two adjacent `>` tokens as the right-shift operator instead.
+  const char *symbols[] = {"->", "=>", "..", "==", "!=", "<=", ">=", "&&", "||", "+%", "+|", "<<", NULL};
   for (int i = 0; symbols[i]; i++) {
     if (source[offset] == symbols[i][0] && source[offset + 1] == symbols[i][1]) return true;
   }

--- a/native/zero-c/src/mir_verify.c
+++ b/native/zero-c/src/mir_verify.c
@@ -664,12 +664,49 @@ static bool mir_verify_binary_value_contract(IrProgram *ir, const IrValue *value
   if (!mir_verify_direct_primitive_value(ir, value, "MIR verifier found binary result type mismatch", "binary result")) return false;
   if ((value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB ||
        value->binary_op == IR_BIN_MUL || value->binary_op == IR_BIN_DIV ||
-       value->binary_op == IR_BIN_MOD) &&
+       value->binary_op == IR_BIN_MOD ||
+       value->binary_op == IR_BIN_BITAND || value->binary_op == IR_BIN_BITOR ||
+       value->binary_op == IR_BIN_BITXOR ||
+       value->binary_op == IR_BIN_SHL || value->binary_op == IR_BIN_SHR) &&
       value->type == IR_TYPE_BOOL) {
     mir_verify_mark_unsupported(ir, "MIR verifier found invalid boolean arithmetic", value->line, value->column, "arithmetic result is Bool");
     return false;
   }
+  if (value->binary_op == IR_BIN_SHL || value->binary_op == IR_BIN_SHR) {
+    if (!value->left || !value->right || !mir_type_is_integer_value(value->left->type) || !mir_type_is_integer_value(value->right->type)) {
+      mir_verify_mark_unsupported(ir, "MIR verifier found shift operand type mismatch", value->line, value->column, "shift operands must be integers");
+      return false;
+    }
+    if (value->type != value->left->type) {
+      mir_verify_mark_unsupported(ir, "MIR verifier found shift result type mismatch", value->line, value->column, "shift result must match left operand type");
+      return false;
+    }
+    return true;
+  }
   return mir_verify_same_type_operands(ir, value, "MIR verifier found binary operand type mismatch", "binary");
+}
+
+static bool mir_verify_unary_value_contract(IrProgram *ir, const IrValue *value) {
+  if (!value || !value->left) {
+    mir_verify_mark_unsupported(ir, "MIR verifier found unary missing operand", value ? value->line : 0, value ? value->column : 0, "unary operand missing");
+    return false;
+  }
+  if (value->unary_op == IR_UNARY_NOT) {
+    if (value->type != IR_TYPE_BOOL || value->left->type != IR_TYPE_BOOL) {
+      mir_verify_mark_unsupported(ir, "MIR verifier found unary not operand type mismatch", value->line, value->column, "logical not requires Bool");
+      return false;
+    }
+    return true;
+  }
+  if (!mir_type_is_integer_value(value->left->type)) {
+    mir_verify_mark_unsupported(ir, "MIR verifier found unary operand non-integer", value->line, value->column, "unary operand must be integer");
+    return false;
+  }
+  if (value->type != value->left->type) {
+    mir_verify_mark_unsupported(ir, "MIR verifier found unary result type mismatch", value->line, value->column, "unary result must match operand type");
+    return false;
+  }
+  return true;
 }
 
 static bool mir_verify_compare_value_contract(IrProgram *ir, const IrValue *value) {
@@ -860,6 +897,8 @@ static bool mir_verify_direct_value_kind_contract(IrProgram *ir, const IrFunctio
     }
     case IR_VALUE_BINARY:
       return mir_verify_binary_value_contract(ir, value);
+    case IR_VALUE_UNARY:
+      return mir_verify_unary_value_contract(ir, value);
     case IR_VALUE_COMPARE:
       return mir_verify_compare_value_contract(ir, value);
     case IR_VALUE_CALL:

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -339,8 +339,12 @@ static int precedence(const char *op) {
   if (strcmp(op, "&&") == 0) return 2;
   if (strcmp(op, "==") == 0 || strcmp(op, "!=") == 0 || strcmp(op, "<") == 0 ||
       strcmp(op, "<=") == 0 || strcmp(op, ">") == 0 || strcmp(op, ">=") == 0) return 3;
-  if (strcmp(op, "+") == 0 || strcmp(op, "-") == 0 || strcmp(op, "+%") == 0 || strcmp(op, "+|") == 0) return 4;
-  if (strcmp(op, "*") == 0 || strcmp(op, "/") == 0 || strcmp(op, "%") == 0) return 5;
+  if (strcmp(op, "|") == 0) return 4;
+  if (strcmp(op, "^") == 0) return 5;
+  if (strcmp(op, "&") == 0) return 6;
+  if (strcmp(op, "<<") == 0 || strcmp(op, ">>") == 0) return 7;
+  if (strcmp(op, "+") == 0 || strcmp(op, "-") == 0 || strcmp(op, "+%") == 0 || strcmp(op, "+|") == 0) return 8;
+  if (strcmp(op, "*") == 0 || strcmp(op, "/") == 0 || strcmp(op, "%") == 0) return 9;
   return -1;
 }
 
@@ -514,6 +518,13 @@ static Expr *parse_unary(Parser *parser) {
     bool mutable_borrow = match(parser, "mut");
     Expr *expr = new_expr(EXPR_BORROW, borrow_token);
     expr->mutable_borrow = mutable_borrow;
+    expr->left = parse_unary(parser);
+    return expr;
+  }
+  if (match(parser, "!") || match(parser, "~") || match(parser, "-")) {
+    Token *op_token = previous(parser);
+    Expr *expr = new_expr(EXPR_UNARY, op_token);
+    expr->text = z_strdup(op_token->text);
     expr->left = parse_unary(parser);
     return expr;
   }

--- a/native/zero-c/src/parser.c
+++ b/native/zero-c/src/parser.c
@@ -121,6 +121,7 @@ static bool match_kind(Parser *parser, TokenKind kind) {
   return true;
 }
 
+
 static bool fail(Parser *parser, const char *message) {
   parser->diag->code = 100;
   parser->diag->line = current(parser)->line;
@@ -531,19 +532,33 @@ static Expr *parse_unary(Parser *parser) {
   return parse_postfix(parser);
 }
 
+// Recognise an adjacent `>` `>` token pair as the `>>` shift operator. The
+// lexer keeps these as two single tokens so generic-argument terminators like
+// `Foo<Bar<T>>` continue to work; only here in expression position do we
+// fold them into a shift token.
+static bool current_is_right_shift(Parser *parser) {
+  Token *tok = current(parser);
+  if (!tok || !tok->text || strcmp(tok->text, ">") != 0) return false;
+  if (parser->index + 1 >= parser->tokens->len) return false;
+  Token *next = &parser->tokens->items[parser->index + 1];
+  return next->text && strcmp(next->text, ">") == 0 && tok->offset + tok->length == next->offset;
+}
+
 static Expr *parse_binary(Parser *parser, int min_precedence) {
   Expr *left = parse_unary(parser);
   if (!left) return NULL;
   while (true) {
-    int prec = precedence(current(parser)->text);
+    bool right_shift = current_is_right_shift(parser);
+    int prec = right_shift ? 7 : precedence(current(parser)->text);
     if (prec < min_precedence) return left;
     Token *op = current(parser);
     parser->index++;
+    if (right_shift) parser->index++;
     Expr *right = parse_binary(parser, prec + 1);
     Expr *binary = new_expr(EXPR_BINARY, op);
     binary->left = left;
     binary->right = right;
-    binary->text = z_strdup(op->text);
+    binary->text = z_strdup(right_shift ? ">>" : op->text);
     left = binary;
   }
 }


### PR DESCRIPTION
## Summary

Adds parsing, type-checking, IR lowering, and emitter coverage for the unary
operators `-`, `!`, `~` and the binary operators `|`, `^`, `<<`, `>>` (plus
binary `&` precedence). Previously these all failed at parse time with
`PAR100`.

## Source

Addresses B4 + P1-6. Reproduced against main @ 999a46b.

Before this change every form below failed at `PAR100`:

- `-1`, `-x`, `-1.0`
- `!p`
- `x | y`, `x ^ y`, `~x`
- `x << 1`, `x >> 1`

Multiplicative `*`, `/`, `%` already worked, and binary `&`, `&&`, `||` already
parsed via existing precedence, so no arithmetic work was needed there.

## Changes

- **Lexer**: emit `|`, `^`, `~`, `<<` as new tokens. `>>` is intentionally
  kept as two `>` tokens so generic terminators like `Foo<Bar<T>>` still
  close; the expression parser folds two adjacent (no-whitespace) `>` into
  a `>>` shift operator.
- **Parser**: new `EXPR_UNARY` node for prefix `-`, `!`, `~`. Binary
  precedence (high to low): unary > `* / %` > `+ - +% +|` > `<< >>` > `&` >
  `^` > `|` > cmp > `&&` > `||`.
- **Checker**: bitwise operators are integer-only with matching types;
  shifts require an integer left operand and an unsigned shift amount;
  constant shift amounts at or beyond the operand bit width are rejected
  as `TYP002`. Unary `-` rejects unsigned types; `!` requires `Bool`; `~`
  requires an integer. The meta evaluator constant-folds all of the new
  operators.
- **IR**: extends `IrBinaryOp` with `BITAND/BITOR/BITXOR/SHL/SHR` and adds
  `IR_VALUE_UNARY` with `NEG/NOT/BITNOT`. Right-shift selects logical (LSR)
  for unsigned and arithmetic (ASR/SAR) for signed operands. MIR verifier
  enforces operand and result types for the new opcodes.
- **Emitters**:
  - `emit_macho64.c` (AArch64 Mach-O): real lowering using AND/ORR/EOR,
    LSLV/LSRV/ASRV, NEG (SUB with XZR), MVN, and a CBZ-based bool not.
  - `emit_elf64.c` (x86_64 ELF) and `emit_coff.c` (x86_64 COFF): real
    lowering using `AND/OR/XOR (21/09/31 c8)`, `SHL/SHR/SAR via cl
    (D3 E0/E8/F8)`, `NEG/NOT (F7 D8/D0)`, and test+sete+movzx for bool
    not.
  - `emit_elf_aarch64.c` (AArch64 ELF, MVP literal-return backend):
    rather than silently dropping new opcodes, walks the IR for each
    function and reports an explicit `CGEN004` if any new opcode appears.

## Conformance

Adds three passing fixtures and one failing fixture, wired into
`conformance/run.mjs`:

- `conformance/native/pass/ops-unary-neg.0` – unary negation across types,
  including nested negation and `-(a + b)`.
- `conformance/native/pass/ops-not.0` – `!`, `!!`, and `!(...)` over `Bool`
  expressions including short-circuit interactions.
- `conformance/native/pass/ops-bitwise.0` – `&`, `|`, `^`, `<<`, `>>`, `~`,
  precedence checks, and a UTF-16 surrogate-pair (`0xD83D` / `0xDE00`)
  decoded to its codepoint `U+1F600` and re-encoded to the UTF-8 bytes
  `F0 9F 98 80` using only the new shift/mask operators.
- `conformance/native/fail/shift-overflow.0` – `1 << 32` against an `i32`
  is rejected at check time with `TYP002`.

Local gates pass on darwin-arm64:

- `ZERO_NATIVE_TEST_ALLOW_LOCAL=1 node conformance/run.mjs` → `conformance ok`
- `node --experimental-strip-types scripts/snapshot-command-contracts.mts` →
  `command contract snapshots ok`

The `linux-musl-x64` cross step in `native:test:local` continues to fail on
this host because no cross compiler / zig is installed; this is
environmental and not a regression introduced here.

## Proposed CHANGELOG line

- Compiler: parse and lower unary `-`, `!`, `~` and binary `|`, `^`, `<<`,
  `>>` for integer expressions; bitwise/shift operands are integer-only,
  shifts validate the shift amount against the operand bit width, and
  `>>` selects logical or arithmetic shift based on signedness.