### PR TITLE
Extract direct emit patch state

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -607,10 +607,16 @@ assert.equal(compilerMetricsBody.backendFormats.elf.x86ExecutableUsesSharedWrite
 assert.equal(compilerMetricsBody.backendFormats.elf.aarch64ObjectUsesSharedWriter, true);
 assert.equal(compilerMetricsBody.backendFormats.elf.aarch64ExecutableUsesSharedWriter, true);
 assert.deepEqual(compilerMetricsBody.backendFormats.elf.archFilesWithLocalSectionWriters, []);
+assert.equal(compilerMetricsBody.backendFormats.elf.patchStateModule, true);
+assert.equal(compilerMetricsBody.backendFormats.elf.x86UsesPatchStateModule, true);
+assert.deepEqual(compilerMetricsBody.backendFormats.elf.archFilesWithLocalPatchState, []);
 assert.equal(compilerMetricsBody.backendFormats.coff.sharedWriter, true);
 assert.equal(compilerMetricsBody.backendFormats.coff.objectUsesSharedWriter, true);
 assert.equal(compilerMetricsBody.backendFormats.coff.executableUsesSharedWriter, true);
 assert.deepEqual(compilerMetricsBody.backendFormats.coff.archFilesWithLocalContainerWriters, []);
+assert.equal(compilerMetricsBody.backendFormats.coff.patchStateModule, true);
+assert.equal(compilerMetricsBody.backendFormats.coff.x64UsesPatchStateModule, true);
+assert.deepEqual(compilerMetricsBody.backendFormats.coff.archFilesWithLocalPatchState, []);
 assert.equal(compilerMetricsBody.backendFormats.macho.sharedWriter, true);
 assert.equal(compilerMetricsBody.backendFormats.macho.objectUsesSharedWriter, true);
 assert.equal(compilerMetricsBody.backendFormats.macho.executableUsesSharedWriter, true);

--- a/native/zero-c/src/coff_emit_state.c
+++ b/native/zero-c/src/coff_emit_state.c
@@ -1,0 +1,126 @@
+#include "coff_emit_state.h"
+#include "x64_emit.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static const char *const runtime_helper_symbols[COFF_RUNTIME_HELPER_COUNT] = {
+  "zero_world_write",
+};
+
+static bool coff_emit_state_diag(ZDiag *diag, const char *message, int line, int column, const char *actual) {
+  if (diag) {
+    diag->code = 4004;
+    diag->line = line > 0 ? line : 1;
+    diag->column = column > 0 ? column : 1;
+    diag->length = 1;
+    snprintf(diag->message, sizeof(diag->message), "%s", message);
+    snprintf(diag->expected, sizeof(diag->expected), "direct COFF x64 object MVP subset");
+    snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "unsupported feature");
+    snprintf(diag->help, sizeof(diag->help), "reduce the program to primitive direct-backend constructs or choose a supported direct target");
+  }
+  return false;
+}
+
+static bool coff_runtime_helper_valid(CoffRuntimeHelper helper) {
+  return helper >= 0 && helper < COFF_RUNTIME_HELPER_COUNT;
+}
+
+const char *z_coff_runtime_helper_symbol(CoffRuntimeHelper helper) {
+  if (!coff_runtime_helper_valid(helper)) return "";
+  return runtime_helper_symbols[helper];
+}
+
+void z_coff_emit_context_free(CoffEmitContext *ctx) {
+  if (!ctx) return;
+  free(ctx->call_patches);
+  free(ctx->rodata_patches);
+  for (unsigned i = 0; i < COFF_RUNTIME_HELPER_COUNT; i++) {
+    free(ctx->runtime_patches[i].items);
+  }
+}
+
+bool z_coff_record_call_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned callee_index, const IrValue *value, ZDiag *diag) {
+  if (!ctx || callee_index >= ctx->function_count) {
+    return coff_emit_state_diag(diag, "direct COFF call target index is out of range", value ? value->line : 1, value ? value->column : 1, "invalid callee");
+  }
+  if (ctx->call_patch_len == ctx->call_patch_cap) {
+    ctx->call_patch_cap = z_grow_capacity(ctx->call_patch_cap, ctx->call_patch_len + 1, 8);
+    ctx->call_patches = z_checked_reallocarray(ctx->call_patches, ctx->call_patch_cap, sizeof(CoffCallPatch));
+  }
+  ctx->call_patches[ctx->call_patch_len++] = (CoffCallPatch){.patch_offset = patch_offset, .callee_index = callee_index};
+  return true;
+}
+
+bool z_coff_record_rodata_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag) {
+  if (!ctx) return coff_emit_state_diag(diag, "direct COFF readonly data relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  if (ctx->rodata_patch_len == ctx->rodata_patch_cap) {
+    ctx->rodata_patch_cap = z_grow_capacity(ctx->rodata_patch_cap, ctx->rodata_patch_len + 1, 8);
+    ctx->rodata_patches = z_checked_reallocarray(ctx->rodata_patches, ctx->rodata_patch_cap, sizeof(ZCoffImageDataPatch));
+  }
+  ctx->rodata_patches[ctx->rodata_patch_len++] = (ZCoffImageDataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
+  return true;
+}
+
+bool z_coff_record_instr_runtime_patch(CoffEmitContext *ctx, CoffRuntimeHelper helper, size_t patch_offset, const IrInstr *instr, ZDiag *diag) {
+  if (!ctx || !coff_runtime_helper_valid(helper)) {
+    return coff_emit_state_diag(diag, "direct COFF runtime relocation requires an emit context", instr ? instr->line : 1, instr ? instr->column : 1, "missing context");
+  }
+  CoffPatchList *list = &ctx->runtime_patches[helper];
+  if (list->len == list->cap) {
+    list->cap = z_grow_capacity(list->cap, list->len + 1, 4);
+    list->items = z_checked_reallocarray(list->items, list->cap, sizeof(CoffPatch));
+  }
+  list->items[list->len++] = (CoffPatch){.patch_offset = patch_offset};
+  return true;
+}
+
+size_t z_coff_runtime_patch_count(const CoffEmitContext *ctx, CoffRuntimeHelper helper) {
+  if (!ctx || !coff_runtime_helper_valid(helper)) return 0;
+  return ctx->runtime_patches[helper].len;
+}
+
+size_t z_coff_text_relocation_count(const CoffEmitContext *ctx) {
+  if (!ctx) return 0;
+  size_t count = ctx->call_patch_len + ctx->rodata_patch_len;
+  for (unsigned i = 0; i < COFF_RUNTIME_HELPER_COUNT; i++) {
+    count += ctx->runtime_patches[i].len;
+  }
+  return count;
+}
+
+void z_coff_patch_call_patches(ZBuf *text, const CoffEmitContext *ctx) {
+  for (size_t i = 0; ctx && i < ctx->call_patch_len; i++) {
+    const CoffCallPatch *patch = &ctx->call_patches[i];
+    z_x64_patch_rel32(text, patch->patch_offset, ctx->function_offsets[patch->callee_index]);
+  }
+}
+
+void z_coff_patch_runtime_patches(ZBuf *text, const CoffEmitContext *ctx, CoffRuntimeHelper helper, size_t target_offset) {
+  if (!ctx || !coff_runtime_helper_valid(helper)) return;
+  const CoffPatchList *patches = &ctx->runtime_patches[helper];
+  for (size_t i = 0; i < patches->len; i++) {
+    z_x64_patch_rel32(text, patches->items[i].patch_offset, target_offset);
+  }
+}
+
+void z_coff_append_call_relocations(ZBuf *relocs, const CoffEmitContext *ctx, uint32_t function_symbol_base) {
+  for (size_t i = 0; ctx && i < ctx->call_patch_len; i++) {
+    const CoffCallPatch *patch = &ctx->call_patches[i];
+    z_coff_append_reloc_amd64(relocs, (uint32_t)patch->patch_offset, function_symbol_base + patch->callee_index, Z_COFF_RELOC_AMD64_REL32);
+  }
+}
+
+void z_coff_append_rodata_relocations(ZBuf *relocs, const CoffEmitContext *ctx, uint32_t rodata_symbol) {
+  for (size_t i = 0; ctx && i < ctx->rodata_patch_len; i++) {
+    z_coff_append_reloc_amd64(relocs, (uint32_t)ctx->rodata_patches[i].patch_offset, rodata_symbol, Z_COFF_RELOC_AMD64_ADDR64);
+  }
+}
+
+void z_coff_append_runtime_relocations(ZBuf *relocs, const CoffEmitContext *ctx, CoffRuntimeHelper helper, uint32_t runtime_symbol) {
+  if (!ctx || !coff_runtime_helper_valid(helper)) return;
+  const CoffPatchList *patches = &ctx->runtime_patches[helper];
+  for (size_t i = 0; i < patches->len; i++) {
+    z_coff_append_reloc_amd64(relocs, (uint32_t)patches->items[i].patch_offset, runtime_symbol, Z_COFF_RELOC_AMD64_REL32);
+  }
+}

--- a/native/zero-c/src/coff_emit_state.h
+++ b/native/zero-c/src/coff_emit_state.h
@@ -1,0 +1,54 @@
+#ifndef ZERO_C_COFF_EMIT_STATE_H
+#define ZERO_C_COFF_EMIT_STATE_H
+
+#include "zero.h"
+#include "coff_format.h"
+
+typedef enum {
+  COFF_RUNTIME_WORLD_WRITE,
+  COFF_RUNTIME_HELPER_COUNT
+} CoffRuntimeHelper;
+
+typedef struct {
+  size_t patch_offset;
+} CoffPatch;
+
+typedef struct {
+  CoffPatch *items;
+  size_t len;
+  size_t cap;
+} CoffPatchList;
+
+typedef struct {
+  size_t patch_offset;
+  unsigned callee_index;
+} CoffCallPatch;
+
+typedef struct {
+  const IrProgram *program;
+  size_t *function_offsets;
+  size_t function_count;
+  CoffCallPatch *call_patches;
+  size_t call_patch_len;
+  size_t call_patch_cap;
+  ZCoffImageDataPatch *rodata_patches;
+  size_t rodata_patch_len;
+  size_t rodata_patch_cap;
+  CoffPatchList runtime_patches[COFF_RUNTIME_HELPER_COUNT];
+  unsigned rodata_base_offset;
+} CoffEmitContext;
+
+const char *z_coff_runtime_helper_symbol(CoffRuntimeHelper helper);
+void z_coff_emit_context_free(CoffEmitContext *ctx);
+bool z_coff_record_call_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned callee_index, const IrValue *value, ZDiag *diag);
+bool z_coff_record_rodata_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag);
+bool z_coff_record_instr_runtime_patch(CoffEmitContext *ctx, CoffRuntimeHelper helper, size_t patch_offset, const IrInstr *instr, ZDiag *diag);
+size_t z_coff_runtime_patch_count(const CoffEmitContext *ctx, CoffRuntimeHelper helper);
+size_t z_coff_text_relocation_count(const CoffEmitContext *ctx);
+void z_coff_patch_call_patches(ZBuf *text, const CoffEmitContext *ctx);
+void z_coff_patch_runtime_patches(ZBuf *text, const CoffEmitContext *ctx, CoffRuntimeHelper helper, size_t target_offset);
+void z_coff_append_call_relocations(ZBuf *relocs, const CoffEmitContext *ctx, uint32_t function_symbol_base);
+void z_coff_append_rodata_relocations(ZBuf *relocs, const CoffEmitContext *ctx, uint32_t rodata_symbol);
+void z_coff_append_runtime_relocations(ZBuf *relocs, const CoffEmitContext *ctx, CoffRuntimeHelper helper, uint32_t runtime_symbol);
+
+#endif

--- a/native/zero-c/src/elf_emit_state.c
+++ b/native/zero-c/src/elf_emit_state.c
@@ -1,0 +1,133 @@
+#include "elf_emit_state.h"
+#include "elf_format.h"
+#include "x64_emit.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static const char *const runtime_helper_symbols[ELF_RUNTIME_HELPER_COUNT] = {
+  "zero_json_parse_bytes",
+  "zero_http_fetch_result",
+  "zero_http_result_ok",
+  "zero_http_result_status",
+  "zero_http_result_body_len",
+  "zero_http_result_error",
+  "zero_http_response_len",
+  "zero_http_response_headers_len",
+  "zero_http_response_body_offset",
+  "zero_http_header_value",
+  "zero_http_header_found",
+  "zero_http_header_offset",
+  "zero_http_header_len",
+};
+
+static bool elf_emit_state_diag(ZDiag *diag, const char *message, int line, int column, const char *actual) {
+  if (diag) {
+    diag->code = 4004;
+    diag->line = line > 0 ? line : 1;
+    diag->column = column > 0 ? column : 1;
+    diag->length = 1;
+    snprintf(diag->message, sizeof(diag->message), "%s", message);
+    snprintf(diag->expected, sizeof(diag->expected), "direct ELF64 object MVP subset");
+    snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "unsupported construct");
+    snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to exported primitive integer arithmetic functions");
+  }
+  return false;
+}
+
+static bool elf_runtime_helper_valid(ElfRuntimeHelper helper) {
+  return helper >= 0 && helper < ELF_RUNTIME_HELPER_COUNT;
+}
+
+const char *z_elf_runtime_helper_symbol(ElfRuntimeHelper helper) {
+  if (!elf_runtime_helper_valid(helper)) return "";
+  return runtime_helper_symbols[helper];
+}
+
+void z_elf_emit_context_free(ElfEmitContext *ctx) {
+  if (!ctx) return;
+  free(ctx->call_patches);
+  free(ctx->rodata_patches);
+  for (unsigned i = 0; i < ELF_RUNTIME_HELPER_COUNT; i++) {
+    free(ctx->runtime_patches[i].items);
+  }
+}
+
+bool z_elf_record_call_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned callee_index, ZDiag *diag, const IrValue *value) {
+  if (!ctx || callee_index >= ctx->function_count) {
+    return elf_emit_state_diag(diag, "direct ELF64 call target index is out of range", value ? value->line : 1, value ? value->column : 1, "invalid callee");
+  }
+  if (ctx->call_patch_len + 1 > ctx->call_patch_cap) {
+    ctx->call_patch_cap = z_grow_capacity(ctx->call_patch_cap, ctx->call_patch_len + 1, 8);
+    ctx->call_patches = z_checked_reallocarray(ctx->call_patches, ctx->call_patch_cap, sizeof(ElfCallPatch));
+  }
+  ctx->call_patches[ctx->call_patch_len++] = (ElfCallPatch){.patch_offset = patch_offset, .callee_index = callee_index};
+  return true;
+}
+
+bool z_elf_record_rodata_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned data_offset, ZDiag *diag, const IrValue *value) {
+  if (!ctx) return elf_emit_state_diag(diag, "direct ELF64 readonly data patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  if (ctx->rodata_patch_len + 1 > ctx->rodata_patch_cap) {
+    ctx->rodata_patch_cap = z_grow_capacity(ctx->rodata_patch_cap, ctx->rodata_patch_len + 1, 8);
+    ctx->rodata_patches = z_checked_reallocarray(ctx->rodata_patches, ctx->rodata_patch_cap, sizeof(ElfRodataPatch));
+  }
+  ctx->rodata_patches[ctx->rodata_patch_len++] = (ElfRodataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
+  return true;
+}
+
+bool z_elf_record_value_runtime_patch(ElfEmitContext *ctx, ElfRuntimeHelper helper, size_t patch_offset, ZDiag *diag, const IrValue *value) {
+  if (!ctx || !elf_runtime_helper_valid(helper)) {
+    return elf_emit_state_diag(diag, "direct ELF64 runtime patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  }
+  ElfPatchList *list = &ctx->runtime_patches[helper];
+  if (list->len + 1 > list->cap) {
+    list->cap = z_grow_capacity(list->cap, list->len + 1, 4);
+    list->items = z_checked_reallocarray(list->items, list->cap, sizeof(ElfPatch));
+  }
+  list->items[list->len++] = (ElfPatch){.patch_offset = patch_offset};
+  return true;
+}
+
+size_t z_elf_runtime_patch_count(const ElfEmitContext *ctx, ElfRuntimeHelper helper) {
+  if (!ctx || !elf_runtime_helper_valid(helper)) return 0;
+  return ctx->runtime_patches[helper].len;
+}
+
+bool z_elf_has_runtime_patches(const ElfEmitContext *ctx) {
+  if (!ctx) return false;
+  for (unsigned i = 0; i < ELF_RUNTIME_HELPER_COUNT; i++) {
+    if (ctx->runtime_patches[i].len > 0) return true;
+  }
+  return false;
+}
+
+void z_elf_patch_call_patches(ZBuf *code, const ElfEmitContext *ctx) {
+  for (size_t i = 0; ctx && i < ctx->call_patch_len; i++) {
+    const ElfCallPatch *patch = &ctx->call_patches[i];
+    z_x64_patch_rel32(code, patch->patch_offset, ctx->function_offsets[patch->callee_index]);
+  }
+}
+
+void z_elf_patch_rodata_patches(ZBuf *code, const ElfEmitContext *ctx) {
+  for (size_t i = 0; ctx && i < ctx->rodata_patch_len; i++) {
+    const ElfRodataPatch *patch = &ctx->rodata_patches[i];
+    uint64_t addr = ctx->rodata_addr + (patch->data_offset - ctx->rodata_base_offset);
+    for (unsigned b = 0; b < 8; b++) {
+      code->data[patch->patch_offset + b] = (char)((addr >> (8 * b)) & 0xff);
+    }
+  }
+}
+
+void z_elf_append_rodata_relocations(ZBuf *rela_text, const ElfEmitContext *ctx, uint32_t rodata_symbol) {
+  for (size_t i = 0; ctx && i < ctx->rodata_patch_len; i++) {
+    z_elf_append_rela(rela_text, ctx->rodata_patches[i].patch_offset, rodata_symbol, 1, ctx->rodata_patches[i].data_offset - ctx->rodata_base_offset);
+  }
+}
+
+void z_elf_append_runtime_relocations(ZBuf *rela_text, const ElfEmitContext *ctx, ElfRuntimeHelper helper, uint32_t runtime_symbol) {
+  if (!ctx || !elf_runtime_helper_valid(helper)) return;
+  const ElfPatchList *patches = &ctx->runtime_patches[helper];
+  for (size_t i = 0; i < patches->len; i++) {
+    z_elf_append_rela(rela_text, patches->items[i].patch_offset, runtime_symbol, 4, -4);
+  }
+}

--- a/native/zero-c/src/elf_emit_state.h
+++ b/native/zero-c/src/elf_emit_state.h
@@ -1,0 +1,74 @@
+#ifndef ZERO_C_ELF_EMIT_STATE_H
+#define ZERO_C_ELF_EMIT_STATE_H
+
+#include "zero.h"
+
+#include <stdint.h>
+
+typedef enum {
+  ELF_RUNTIME_JSON_PARSE_BYTES,
+  ELF_RUNTIME_HTTP_FETCH,
+  ELF_RUNTIME_HTTP_RESULT_OK,
+  ELF_RUNTIME_HTTP_RESULT_STATUS,
+  ELF_RUNTIME_HTTP_RESULT_BODY_LEN,
+  ELF_RUNTIME_HTTP_RESULT_ERROR,
+  ELF_RUNTIME_HTTP_RESPONSE_LEN,
+  ELF_RUNTIME_HTTP_RESPONSE_HEADERS_LEN,
+  ELF_RUNTIME_HTTP_RESPONSE_BODY_OFFSET,
+  ELF_RUNTIME_HTTP_HEADER_VALUE,
+  ELF_RUNTIME_HTTP_HEADER_FOUND,
+  ELF_RUNTIME_HTTP_HEADER_OFFSET,
+  ELF_RUNTIME_HTTP_HEADER_LEN,
+  ELF_RUNTIME_HELPER_COUNT
+} ElfRuntimeHelper;
+
+typedef struct {
+  size_t patch_offset;
+} ElfPatch;
+
+typedef struct {
+  ElfPatch *items;
+  size_t len;
+  size_t cap;
+} ElfPatchList;
+
+typedef struct {
+  size_t patch_offset;
+  unsigned callee_index;
+} ElfCallPatch;
+
+typedef struct {
+  size_t patch_offset;
+  unsigned data_offset;
+} ElfRodataPatch;
+
+typedef struct {
+  const IrProgram *ir;
+  size_t *function_offsets;
+  size_t function_count;
+  ElfCallPatch *call_patches;
+  size_t call_patch_len;
+  size_t call_patch_cap;
+  ElfRodataPatch *rodata_patches;
+  size_t rodata_patch_len;
+  size_t rodata_patch_cap;
+  ElfPatchList runtime_patches[ELF_RUNTIME_HELPER_COUNT];
+  bool emit_rodata_relocations;
+  bool seed_main_process_args;
+  unsigned rodata_base_offset;
+  uint64_t rodata_addr;
+} ElfEmitContext;
+
+const char *z_elf_runtime_helper_symbol(ElfRuntimeHelper helper);
+void z_elf_emit_context_free(ElfEmitContext *ctx);
+bool z_elf_record_call_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned callee_index, ZDiag *diag, const IrValue *value);
+bool z_elf_record_rodata_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned data_offset, ZDiag *diag, const IrValue *value);
+bool z_elf_record_value_runtime_patch(ElfEmitContext *ctx, ElfRuntimeHelper helper, size_t patch_offset, ZDiag *diag, const IrValue *value);
+size_t z_elf_runtime_patch_count(const ElfEmitContext *ctx, ElfRuntimeHelper helper);
+bool z_elf_has_runtime_patches(const ElfEmitContext *ctx);
+void z_elf_patch_call_patches(ZBuf *code, const ElfEmitContext *ctx);
+void z_elf_patch_rodata_patches(ZBuf *code, const ElfEmitContext *ctx);
+void z_elf_append_rodata_relocations(ZBuf *rela_text, const ElfEmitContext *ctx, uint32_t rodata_symbol);
+void z_elf_append_runtime_relocations(ZBuf *rela_text, const ElfEmitContext *ctx, ElfRuntimeHelper helper, uint32_t runtime_symbol);
+
+#endif

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -1,4 +1,5 @@
 #include "zero.h"
+#include "coff_emit_state.h"
 #include "coff_format.h"
 #include "x64_emit.h"
 
@@ -49,31 +50,6 @@ static bool coff_diag_at(ZDiag *diag, const char *message, int line, int column,
   }
   return false;
 }
-
-typedef struct {
-  size_t patch_offset;
-  unsigned callee_index;
-} CoffCallPatch;
-
-typedef struct {
-  size_t patch_offset;
-} CoffWorldWritePatch;
-
-typedef struct {
-  const IrProgram *program;
-  size_t *function_offsets;
-  size_t function_count;
-  CoffCallPatch *call_patches;
-  size_t call_patch_len;
-  size_t call_patch_cap;
-  ZCoffImageDataPatch *rodata_patches;
-  size_t rodata_patch_len;
-  size_t rodata_patch_cap;
-  CoffWorldWritePatch *world_write_patches;
-  size_t world_write_patch_len;
-  size_t world_write_patch_cap;
-  unsigned rodata_base_offset;
-} CoffEmitContext;
 
 static bool coff_type_is_scalar32(IrTypeKind type) {
   return type == IR_TYPE_BOOL || type == IR_TYPE_U8 || type == IR_TYPE_U16 || type == IR_TYPE_I32 || type == IR_TYPE_U32 || type == IR_TYPE_USIZE;
@@ -162,38 +138,6 @@ static unsigned coff_setcc_opcode(IrCompareOp op) {
   return 0x94;
 }
 
-static bool coff_record_call_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned callee_index, const IrValue *value, ZDiag *diag) {
-  if (!ctx || callee_index >= ctx->function_count) {
-    return coff_diag_at(diag, "direct COFF call target index is out of range", value ? value->line : 1, value ? value->column : 1, "invalid callee");
-  }
-  if (ctx->call_patch_len == ctx->call_patch_cap) {
-    ctx->call_patch_cap = z_grow_capacity(ctx->call_patch_cap, ctx->call_patch_len + 1, 8);
-    ctx->call_patches = z_checked_reallocarray(ctx->call_patches, ctx->call_patch_cap, sizeof(CoffCallPatch));
-  }
-  ctx->call_patches[ctx->call_patch_len++] = (CoffCallPatch){.patch_offset = patch_offset, .callee_index = callee_index};
-  return true;
-}
-
-static bool coff_record_rodata_patch(CoffEmitContext *ctx, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag) {
-  if (!ctx) return coff_diag_at(diag, "direct COFF readonly data relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  if (ctx->rodata_patch_len == ctx->rodata_patch_cap) {
-    ctx->rodata_patch_cap = z_grow_capacity(ctx->rodata_patch_cap, ctx->rodata_patch_len + 1, 8);
-    ctx->rodata_patches = z_checked_reallocarray(ctx->rodata_patches, ctx->rodata_patch_cap, sizeof(ZCoffImageDataPatch));
-  }
-  ctx->rodata_patches[ctx->rodata_patch_len++] = (ZCoffImageDataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
-  return true;
-}
-
-static bool coff_record_world_write_patch(CoffEmitContext *ctx, size_t patch_offset, const IrInstr *instr, ZDiag *diag) {
-  if (!ctx) return coff_diag_at(diag, "direct COFF World write relocation requires an emit context", instr ? instr->line : 1, instr ? instr->column : 1, "missing context");
-  if (ctx->world_write_patch_len == ctx->world_write_patch_cap) {
-    ctx->world_write_patch_cap = z_grow_capacity(ctx->world_write_patch_cap, ctx->world_write_patch_len + 1, 4);
-    ctx->world_write_patches = z_checked_reallocarray(ctx->world_write_patches, ctx->world_write_patch_cap, sizeof(CoffWorldWritePatch));
-  }
-  ctx->world_write_patches[ctx->world_write_patch_len++] = (CoffWorldWritePatch){.patch_offset = patch_offset};
-  return true;
-}
-
 static bool coff_const_u32_value(const IrValue *value, unsigned *out) {
   if (!value || value->kind != IR_VALUE_INT || value->int_value > UINT32_MAX) return false;
   if (out) *out = (unsigned)value->int_value;
@@ -254,7 +198,7 @@ static bool coff_emit_rodata_ptr_rax(ZBuf *text, unsigned data_offset, CoffEmitC
   size_t patch = text->len;
   uint64_t addend = data_offset - (ctx ? ctx->rodata_base_offset : 0);
   for (unsigned i = 0; i < 8; i++) append_u8(text, (unsigned)((addend >> (i * 8)) & 0xffu));
-  return coff_record_rodata_patch(ctx, patch, data_offset, value, diag);
+  return z_coff_record_rodata_patch(ctx, patch, data_offset, value, diag);
 }
 
 static bool coff_emit_byte_view_ptr(ZBuf *text, const IrFunction *fun, const IrValue *view, CoffEmitContext *ctx, ZDiag *diag);
@@ -385,7 +329,7 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       size_t patch = text->len;
       append_u32le(text, 0);
       z_x64_emit_add_rsp(text, 32);
-      return coff_record_call_patch(ctx, patch, value->callee_index, value, diag);
+      return z_coff_record_call_patch(ctx, patch, value->callee_index, value, diag);
     }
     case IR_VALUE_VEC_LEN:
     case IR_VALUE_VEC_CAPACITY:
@@ -537,7 +481,7 @@ static bool coff_emit_world_write(ZBuf *text, const IrFunction *fun, const IrIns
   append_u8(text, 0x0f);
   append_u8(text, 0x0b); // ud2 on runtime write failure
   z_x64_patch_rel32(text, ok_patch, text->len);
-  return coff_record_world_write_patch(ctx, patch, instr, diag);
+  return z_coff_record_instr_runtime_patch(ctx, COFF_RUNTIME_WORLD_WRITE, patch, instr, diag);
 }
 
 static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, CoffEmitContext *ctx, ZDiag *diag) {
@@ -815,9 +759,7 @@ bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *
     while (text.len % 16 != 0) append_u8(&text, 0x90);
     offsets[i] = text.len;
     if (!coff_emit_function_text(&text, &program->functions[i], &ctx, diag)) {
-      free(ctx.world_write_patches);
-      free(ctx.rodata_patches);
-      free(ctx.call_patches);
+      z_coff_emit_context_free(&ctx);
       free(offsets);
       zbuf_free(&relocs);
       zbuf_free(&rodata);
@@ -827,32 +769,22 @@ bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *
   }
 
   unsigned section_symbol_count = has_rodata ? 2u : 1u;
-  size_t symbol_len = program->function_len + (ctx.world_write_patch_len > 0 ? 1u : 0u);
+  bool has_world_write = z_coff_runtime_patch_count(&ctx, COFF_RUNTIME_WORLD_WRITE) > 0;
+  size_t symbol_len = program->function_len + (has_world_write ? 1u : 0u);
   ZCoffSymbol *symbols = z_checked_calloc(symbol_len, sizeof(ZCoffSymbol));
   if (!symbols) {
-    free(ctx.world_write_patches);
-    free(ctx.rodata_patches);
-    free(ctx.call_patches);
+    z_coff_emit_context_free(&ctx);
     free(offsets);
     zbuf_free(&relocs);
     zbuf_free(&rodata);
     zbuf_free(&text);
     return coff_diag(diag, "out of memory while emitting COFF object");
   }
-  for (size_t i = 0; i < ctx.call_patch_len; i++) {
-    const CoffCallPatch *patch = &ctx.call_patches[i];
-    z_x64_patch_rel32(&text, patch->patch_offset, offsets[patch->callee_index]);
-    z_coff_append_reloc_amd64(&relocs, (uint32_t)patch->patch_offset, section_symbol_count + patch->callee_index, Z_COFF_RELOC_AMD64_REL32);
-  }
-  for (size_t i = 0; i < ctx.rodata_patch_len; i++) {
-    const ZCoffImageDataPatch *patch = &ctx.rodata_patches[i];
-    z_coff_append_reloc_amd64(&relocs, (uint32_t)patch->patch_offset, 1u, Z_COFF_RELOC_AMD64_ADDR64);
-  }
+  z_coff_patch_call_patches(&text, &ctx);
+  z_coff_append_call_relocations(&relocs, &ctx, section_symbol_count);
+  z_coff_append_rodata_relocations(&relocs, &ctx, 1u);
   uint32_t world_write_symbol_index = section_symbol_count + (uint32_t)program->function_len;
-  for (size_t i = 0; i < ctx.world_write_patch_len; i++) {
-    const CoffWorldWritePatch *patch = &ctx.world_write_patches[i];
-    z_coff_append_reloc_amd64(&relocs, (uint32_t)patch->patch_offset, world_write_symbol_index, Z_COFF_RELOC_AMD64_REL32);
-  }
+  z_coff_append_runtime_relocations(&relocs, &ctx, COFF_RUNTIME_WORLD_WRITE, world_write_symbol_index);
 
   for (size_t i = 0; i < program->function_len; i++) {
     symbols[i] = (ZCoffSymbol){
@@ -863,9 +795,9 @@ bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *
       .storage_class = program->functions[i].is_exported ? Z_COFF_SYMBOL_EXTERNAL : Z_COFF_SYMBOL_STATIC
     };
   }
-  if (ctx.world_write_patch_len > 0) {
+  if (has_world_write) {
     symbols[program->function_len] = (ZCoffSymbol){
-      .name = "zero_world_write",
+      .name = z_coff_runtime_helper_symbol(COFF_RUNTIME_WORLD_WRITE),
       .section_number = 0,
       .type = 0x20,
       .storage_class = Z_COFF_SYMBOL_EXTERNAL
@@ -876,15 +808,13 @@ bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *
     .text = &text,
     .rodata = has_rodata ? &rodata : NULL,
     .text_relocs = &relocs,
-    .text_reloc_count = (uint16_t)(ctx.call_patch_len + ctx.rodata_patch_len + ctx.world_write_patch_len),
+    .text_reloc_count = (uint16_t)z_coff_text_relocation_count(&ctx),
     .symbols = symbols,
     .symbol_len = symbol_len
   };
   z_coff_write_object(out, &image);
 
-  free(ctx.world_write_patches);
-  free(ctx.rodata_patches);
-  free(ctx.call_patches);
+  z_coff_emit_context_free(&ctx);
   free(offsets);
   free(symbols);
   zbuf_free(&relocs);
@@ -1047,9 +977,7 @@ bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *dia
     while (text.len % 16 != 0) append_u8(&text, 0x90);
     offsets[i] = text.len;
     if (!coff_emit_function_text(&text, &program->functions[i], &ctx, diag)) {
-      free(ctx.world_write_patches);
-      free(ctx.rodata_patches);
-      free(ctx.call_patches);
+      z_coff_emit_context_free(&ctx);
       free(offsets);
       zbuf_free(&rdata);
       zbuf_free(&text);
@@ -1057,19 +985,14 @@ bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *dia
     }
   }
   size_t world_write_offset = 0;
-  if (ctx.world_write_patch_len > 0) {
+  if (z_coff_runtime_patch_count(&ctx, COFF_RUNTIME_WORLD_WRITE) > 0) {
     while (text.len % 16 != 0) append_u8(&text, 0x90);
     world_write_offset = coff_emit_exe_world_write(&text, import_patches, &import_patch_len);
   }
 
   z_x64_patch_rel32(&text, start_main_patch, offsets[main_index]);
-  for (size_t i = 0; i < ctx.call_patch_len; i++) {
-    const CoffCallPatch *patch = &ctx.call_patches[i];
-    z_x64_patch_rel32(&text, patch->patch_offset, offsets[patch->callee_index]);
-  }
-  for (size_t i = 0; i < ctx.world_write_patch_len; i++) {
-    z_x64_patch_rel32(&text, ctx.world_write_patches[i].patch_offset, world_write_offset);
-  }
+  z_coff_patch_call_patches(&text, &ctx);
+  z_coff_patch_runtime_patches(&text, &ctx, COFF_RUNTIME_WORLD_WRITE, world_write_offset);
 
   ZCoffExecutableImage image = {
     .machine = Z_COFF_MACHINE_AMD64,
@@ -1086,9 +1009,7 @@ bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *dia
   };
   z_coff_write_pe64_executable(out, &image);
 
-  free(ctx.world_write_patches);
-  free(ctx.rodata_patches);
-  free(ctx.call_patches);
+  z_coff_emit_context_free(&ctx);
   free(offsets);
   zbuf_free(&rdata);
   zbuf_free(&text);

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -1,4 +1,5 @@
 #include "zero.h"
+#include "elf_emit_state.h"
 #include "elf_format.h"
 #include "x64_emit.h"
 
@@ -181,96 +182,25 @@ static unsigned elf_setcc_opcode(IrCompareOp op, bool uns) {
   return 0x94;
 }
 
-typedef struct {
-  size_t patch_offset;
-  unsigned callee_index;
-} ElfCallPatch;
-
-typedef struct {
-  size_t patch_offset;
-  unsigned data_offset;
-} ElfRodataPatch;
-
-typedef struct {
-  size_t patch_offset;
-} ElfRuntimePatch;
-
-typedef struct {
-  const IrProgram *ir;
-  size_t *function_offsets;
-  size_t function_count;
-  ElfCallPatch *call_patches;
-  size_t call_patch_len;
-  size_t call_patch_cap;
-  ElfRodataPatch *rodata_patches;
-  size_t rodata_patch_len;
-  size_t rodata_patch_cap;
-  ElfRuntimePatch *runtime_json_parse_bytes_patches;
-  size_t runtime_json_parse_bytes_patch_len;
-  size_t runtime_json_parse_bytes_patch_cap;
-  ElfRuntimePatch *runtime_http_fetch_patches;
-  size_t runtime_http_fetch_patch_len;
-  size_t runtime_http_fetch_patch_cap;
-  ElfRuntimePatch *runtime_http_result_ok_patches;
-  size_t runtime_http_result_ok_patch_len;
-  size_t runtime_http_result_ok_patch_cap;
-  ElfRuntimePatch *runtime_http_result_status_patches;
-  size_t runtime_http_result_status_patch_len;
-  size_t runtime_http_result_status_patch_cap;
-  ElfRuntimePatch *runtime_http_result_body_len_patches;
-  size_t runtime_http_result_body_len_patch_len;
-  size_t runtime_http_result_body_len_patch_cap;
-  ElfRuntimePatch *runtime_http_result_error_patches;
-  size_t runtime_http_result_error_patch_len;
-  size_t runtime_http_result_error_patch_cap;
-  ElfRuntimePatch *runtime_http_response_len_patches;
-  size_t runtime_http_response_len_patch_len;
-  size_t runtime_http_response_len_patch_cap;
-  ElfRuntimePatch *runtime_http_response_headers_len_patches;
-  size_t runtime_http_response_headers_len_patch_len;
-  size_t runtime_http_response_headers_len_patch_cap;
-  ElfRuntimePatch *runtime_http_response_body_offset_patches;
-  size_t runtime_http_response_body_offset_patch_len;
-  size_t runtime_http_response_body_offset_patch_cap;
-  ElfRuntimePatch *runtime_http_header_value_patches;
-  size_t runtime_http_header_value_patch_len;
-  size_t runtime_http_header_value_patch_cap;
-  ElfRuntimePatch *runtime_http_header_found_patches;
-  size_t runtime_http_header_found_patch_len;
-  size_t runtime_http_header_found_patch_cap;
-  ElfRuntimePatch *runtime_http_header_offset_patches;
-  size_t runtime_http_header_offset_patch_len;
-  size_t runtime_http_header_offset_patch_cap;
-  ElfRuntimePatch *runtime_http_header_len_patches;
-  size_t runtime_http_header_len_patch_len;
-  size_t runtime_http_header_len_patch_cap;
-  bool emit_rodata_relocations;
-  bool seed_main_process_args;
-  unsigned rodata_base_offset;
-  uint64_t rodata_addr;
-} ElfEmitContext;
+static ElfRuntimeHelper elf_runtime_helper_for_value(IrValueKind kind) {
+  switch (kind) {
+    case IR_VALUE_HTTP_RESULT_OK: return ELF_RUNTIME_HTTP_RESULT_OK;
+    case IR_VALUE_HTTP_RESULT_STATUS: return ELF_RUNTIME_HTTP_RESULT_STATUS;
+    case IR_VALUE_HTTP_RESULT_BODY_LEN: return ELF_RUNTIME_HTTP_RESULT_BODY_LEN;
+    case IR_VALUE_HTTP_RESULT_ERROR: return ELF_RUNTIME_HTTP_RESULT_ERROR;
+    case IR_VALUE_HTTP_RESPONSE_LEN: return ELF_RUNTIME_HTTP_RESPONSE_LEN;
+    case IR_VALUE_HTTP_RESPONSE_HEADERS_LEN: return ELF_RUNTIME_HTTP_RESPONSE_HEADERS_LEN;
+    case IR_VALUE_HTTP_RESPONSE_BODY_OFFSET: return ELF_RUNTIME_HTTP_RESPONSE_BODY_OFFSET;
+    case IR_VALUE_HTTP_HEADER_VALUE: return ELF_RUNTIME_HTTP_HEADER_VALUE;
+    case IR_VALUE_HTTP_HEADER_FOUND: return ELF_RUNTIME_HTTP_HEADER_FOUND;
+    case IR_VALUE_HTTP_HEADER_OFFSET: return ELF_RUNTIME_HTTP_HEADER_OFFSET;
+    case IR_VALUE_HTTP_HEADER_LEN: return ELF_RUNTIME_HTTP_HEADER_LEN;
+    default: return ELF_RUNTIME_HELPER_COUNT;
+  }
+}
 
 static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *value, ElfEmitContext *ctx, ZDiag *diag);
 static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fun, const IrInstr *instr, ElfEmitContext *ctx, ZDiag *diag);
-
-static void elf_emit_context_free(ElfEmitContext *ctx) {
-  if (!ctx) return;
-  free(ctx->call_patches);
-  free(ctx->rodata_patches);
-  free(ctx->runtime_json_parse_bytes_patches);
-  free(ctx->runtime_http_fetch_patches);
-  free(ctx->runtime_http_result_ok_patches);
-  free(ctx->runtime_http_result_status_patches);
-  free(ctx->runtime_http_result_body_len_patches);
-  free(ctx->runtime_http_result_error_patches);
-  free(ctx->runtime_http_response_len_patches);
-  free(ctx->runtime_http_response_headers_len_patches);
-  free(ctx->runtime_http_response_body_offset_patches);
-  free(ctx->runtime_http_header_value_patches);
-  free(ctx->runtime_http_header_found_patches);
-  free(ctx->runtime_http_header_offset_patches);
-  free(ctx->runtime_http_header_len_patches);
-}
 
 static bool elf_function_propagates_to_process_exit(const IrFunction *fun) {
   return fun && (fun->raises ||
@@ -278,121 +208,6 @@ static bool elf_function_propagates_to_process_exit(const IrFunction *fun) {
                   fun->name && strcmp(fun->name, "main") == 0 &&
                   fun->return_type == IR_TYPE_I32 &&
                   fun->value_return_type == IR_TYPE_VOID));
-}
-
-static bool elf_record_call_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned callee_index, ZDiag *diag, const IrValue *value) {
-  if (!ctx || callee_index >= ctx->function_count) {
-    return elf_diag(diag, "direct ELF64 call target index is out of range", value ? value->line : 1, value ? value->column : 1, "invalid callee");
-  }
-  if (ctx->call_patch_len + 1 > ctx->call_patch_cap) {
-    ctx->call_patch_cap = z_grow_capacity(ctx->call_patch_cap, ctx->call_patch_len + 1, 8);
-    ctx->call_patches = z_checked_reallocarray(ctx->call_patches, ctx->call_patch_cap, sizeof(ElfCallPatch));
-  }
-  ctx->call_patches[ctx->call_patch_len++] = (ElfCallPatch){.patch_offset = patch_offset, .callee_index = callee_index};
-  return true;
-}
-
-static bool elf_record_rodata_patch(ElfEmitContext *ctx, size_t patch_offset, unsigned data_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 readonly data patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  if (ctx->rodata_patch_len + 1 > ctx->rodata_patch_cap) {
-    ctx->rodata_patch_cap = z_grow_capacity(ctx->rodata_patch_cap, ctx->rodata_patch_len + 1, 8);
-    ctx->rodata_patches = z_checked_reallocarray(ctx->rodata_patches, ctx->rodata_patch_cap, sizeof(ElfRodataPatch));
-  }
-  ctx->rodata_patches[ctx->rodata_patch_len++] = (ElfRodataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
-  return true;
-}
-
-static bool elf_record_runtime_patch(ElfRuntimePatch **items, size_t *len, size_t *cap, size_t patch_offset, ZDiag *diag, const IrValue *value, const char *name) {
-  (void)name;
-  if (!items || !len || !cap) return elf_diag(diag, "direct ELF64 runtime patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  if (*len + 1 > *cap) {
-    *cap = z_grow_capacity(*cap, *len + 1, 4);
-    *items = z_checked_reallocarray(*items, *cap, sizeof(ElfRuntimePatch));
-  }
-  (*items)[(*len)++] = (ElfRuntimePatch){.patch_offset = patch_offset};
-  return true;
-}
-
-static bool elf_record_runtime_json_parse_bytes_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 JSON runtime relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_json_parse_bytes_patches, &ctx->runtime_json_parse_bytes_patch_len, &ctx->runtime_json_parse_bytes_patch_cap, patch_offset, diag, value, "zero_json_parse_bytes");
-}
-
-static bool elf_record_runtime_http_fetch_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP runtime relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_fetch_patches, &ctx->runtime_http_fetch_patch_len, &ctx->runtime_http_fetch_patch_cap, patch_offset, diag, value, "zero_http_fetch_result");
-}
-
-static bool elf_record_runtime_http_result_ok_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP result relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_result_ok_patches, &ctx->runtime_http_result_ok_patch_len, &ctx->runtime_http_result_ok_patch_cap, patch_offset, diag, value, "zero_http_result_ok");
-}
-
-static bool elf_record_runtime_http_result_status_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP result relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_result_status_patches, &ctx->runtime_http_result_status_patch_len, &ctx->runtime_http_result_status_patch_cap, patch_offset, diag, value, "zero_http_result_status");
-}
-
-static bool elf_record_runtime_http_result_body_len_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP result relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_result_body_len_patches, &ctx->runtime_http_result_body_len_patch_len, &ctx->runtime_http_result_body_len_patch_cap, patch_offset, diag, value, "zero_http_result_body_len");
-}
-
-static bool elf_record_runtime_http_result_error_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP result relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_result_error_patches, &ctx->runtime_http_result_error_patch_len, &ctx->runtime_http_result_error_patch_cap, patch_offset, diag, value, "zero_http_result_error");
-}
-
-static bool elf_record_runtime_http_response_len_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP response relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_response_len_patches, &ctx->runtime_http_response_len_patch_len, &ctx->runtime_http_response_len_patch_cap, patch_offset, diag, value, "zero_http_response_len");
-}
-
-static bool elf_record_runtime_http_response_headers_len_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP response relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_response_headers_len_patches, &ctx->runtime_http_response_headers_len_patch_len, &ctx->runtime_http_response_headers_len_patch_cap, patch_offset, diag, value, "zero_http_response_headers_len");
-}
-
-static bool elf_record_runtime_http_response_body_offset_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP response relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_response_body_offset_patches, &ctx->runtime_http_response_body_offset_patch_len, &ctx->runtime_http_response_body_offset_patch_cap, patch_offset, diag, value, "zero_http_response_body_offset");
-}
-
-static bool elf_record_runtime_http_header_value_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP header relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_header_value_patches, &ctx->runtime_http_header_value_patch_len, &ctx->runtime_http_header_value_patch_cap, patch_offset, diag, value, "zero_http_header_value");
-}
-
-static bool elf_record_runtime_http_header_found_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP header relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_header_found_patches, &ctx->runtime_http_header_found_patch_len, &ctx->runtime_http_header_found_patch_cap, patch_offset, diag, value, "zero_http_header_found");
-}
-
-static bool elf_record_runtime_http_header_offset_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP header relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_header_offset_patches, &ctx->runtime_http_header_offset_patch_len, &ctx->runtime_http_header_offset_patch_cap, patch_offset, diag, value, "zero_http_header_offset");
-}
-
-static bool elf_record_runtime_http_header_len_patch(ElfEmitContext *ctx, size_t patch_offset, ZDiag *diag, const IrValue *value) {
-  if (!ctx) return elf_diag(diag, "direct ELF64 HTTP header relocation requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
-  return elf_record_runtime_patch(&ctx->runtime_http_header_len_patches, &ctx->runtime_http_header_len_patch_len, &ctx->runtime_http_header_len_patch_cap, patch_offset, diag, value, "zero_http_header_len");
-}
-
-static void elf_patch_call_patches(ZBuf *code, const ElfEmitContext *ctx) {
-  for (size_t i = 0; i < ctx->call_patch_len; i++) {
-    const ElfCallPatch *patch = &ctx->call_patches[i];
-    z_x64_patch_rel32(code, patch->patch_offset, ctx->function_offsets[patch->callee_index]);
-  }
-}
-
-static void elf_patch_rodata_patches(ZBuf *code, const ElfEmitContext *ctx) {
-  for (size_t i = 0; ctx && i < ctx->rodata_patch_len; i++) {
-    const ElfRodataPatch *patch = &ctx->rodata_patches[i];
-    uint64_t addr = ctx->rodata_addr + (patch->data_offset - ctx->rodata_base_offset);
-    for (unsigned b = 0; b < 8; b++) {
-      code->data[patch->patch_offset + b] = (char)((addr >> (8 * b)) & 0xff);
-    }
-  }
 }
 
 static bool elf_function_seeds_process_args(const IrFunction *fun, const ElfEmitContext *ctx) {
@@ -619,7 +434,7 @@ static bool elf_emit_rodata_ptr_rax(ZBuf *code, unsigned data_offset, ElfEmitCon
   size_t imm_offset = code->len;
   unsigned compact_offset = ctx ? data_offset - ctx->rodata_base_offset : data_offset;
   elf_append_u64(code, ctx && ctx->emit_rodata_relocations ? 0 : (ctx ? ctx->rodata_addr : 0) + compact_offset);
-  return elf_record_rodata_patch(ctx, imm_offset, data_offset, diag, value);
+  return z_elf_record_rodata_patch(ctx, imm_offset, data_offset, diag, value);
 }
 
 static void elf_emit_store_local_slot_rax(ZBuf *code, const IrLocal *local, unsigned slot_offset) {
@@ -653,7 +468,7 @@ static bool elf_emit_json_parse_bytes_call(ZBuf *code, const IrFunction *fun, co
   z_x64_emit_pop_reg64(code, 6);
   z_x64_emit_pop_reg64(code, 7);
   size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-  return elf_record_runtime_json_parse_bytes_patch(ctx, patch, diag, value);
+  return z_elf_record_value_runtime_patch(ctx, ELF_RUNTIME_JSON_PARSE_BYTES, patch, diag, value);
 }
 
 static bool elf_emit_byte_view_len(ZBuf *code, const IrFunction *fun, const IrValue *view, ElfEmitContext *ctx, ZDiag *diag) {
@@ -879,7 +694,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
         z_x64_emit_pop_reg64(code, param_regs[i - 1]);
       }
       size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-      return elf_record_call_patch(ctx, patch, value->callee_index, diag, value);
+      return z_elf_record_call_patch(ctx, patch, value->callee_index, diag, value);
     }
     case IR_VALUE_JSON_PARSE_BYTES:
       return elf_emit_json_parse_bytes_call(code, fun, value, ctx, diag);
@@ -925,7 +740,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       z_x64_emit_pop_reg64(code, 6);
       z_x64_emit_pop_reg64(code, 7);
       size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-      return elf_record_runtime_http_fetch_patch(ctx, patch, diag, value);
+      return z_elf_record_value_runtime_patch(ctx, ELF_RUNTIME_HTTP_FETCH, patch, diag, value);
     }
     case IR_VALUE_HTTP_RESULT_OK:
     case IR_VALUE_HTTP_RESULT_STATUS:
@@ -938,13 +753,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       elf_emit_push_rax(code);
       z_x64_emit_pop_reg64(code, 7);
       size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-      if (value->kind == IR_VALUE_HTTP_RESULT_OK) return elf_record_runtime_http_result_ok_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_RESULT_STATUS) return elf_record_runtime_http_result_status_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_RESULT_BODY_LEN) return elf_record_runtime_http_result_body_len_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_RESULT_ERROR) return elf_record_runtime_http_result_error_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_HEADER_FOUND) return elf_record_runtime_http_header_found_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_HEADER_OFFSET) return elf_record_runtime_http_header_offset_patch(ctx, patch, diag, value);
-      return elf_record_runtime_http_header_len_patch(ctx, patch, diag, value);
+      return z_elf_record_value_runtime_patch(ctx, elf_runtime_helper_for_value(value->kind), patch, diag, value);
     }
     case IR_VALUE_HTTP_RESPONSE_LEN:
     case IR_VALUE_HTTP_RESPONSE_HEADERS_LEN:
@@ -956,9 +765,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       z_x64_emit_pop_reg64(code, 6);
       z_x64_emit_pop_reg64(code, 7);
       size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-      if (value->kind == IR_VALUE_HTTP_RESPONSE_LEN) return elf_record_runtime_http_response_len_patch(ctx, patch, diag, value);
-      if (value->kind == IR_VALUE_HTTP_RESPONSE_HEADERS_LEN) return elf_record_runtime_http_response_headers_len_patch(ctx, patch, diag, value);
-      return elf_record_runtime_http_response_body_offset_patch(ctx, patch, diag, value);
+      return z_elf_record_value_runtime_patch(ctx, elf_runtime_helper_for_value(value->kind), patch, diag, value);
     }
     case IR_VALUE_HTTP_HEADER_VALUE: {
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
@@ -974,7 +781,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       z_x64_emit_pop_reg64(code, 6);
       z_x64_emit_pop_reg64(code, 7);
       size_t patch = z_x64_emit_jmp32_placeholder(code, 0xe8);
-      return elf_record_runtime_http_header_value_patch(ctx, patch, diag, value);
+      return z_elf_record_value_runtime_patch(ctx, ELF_RUNTIME_HTTP_HEADER_VALUE, patch, diag, value);
     }
     case IR_VALUE_ARGS_LEN:
       if (ctx && ctx->seed_main_process_args) {
@@ -2602,7 +2409,7 @@ bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
       free(function_offsets);
       free(function_sizes);
       free(symbol_names);
-      elf_emit_context_free(&ctx);
+      z_elf_emit_context_free(&ctx);
       zbuf_free(&text);
       zbuf_free(&rodata);
       zbuf_free(&rela_text);
@@ -2615,210 +2422,33 @@ bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
     zbuf_append(&strtab, ir->functions[i].name);
     elf_append_u8(&strtab, 0);
   }
-  const bool has_runtime_json_parse_bytes = ctx.runtime_json_parse_bytes_patch_len > 0;
-  const bool has_runtime_http_fetch = ctx.runtime_http_fetch_patch_len > 0;
-  const bool has_runtime_http_result_ok = ctx.runtime_http_result_ok_patch_len > 0;
-  const bool has_runtime_http_result_status = ctx.runtime_http_result_status_patch_len > 0;
-  const bool has_runtime_http_result_body_len = ctx.runtime_http_result_body_len_patch_len > 0;
-  const bool has_runtime_http_result_error = ctx.runtime_http_result_error_patch_len > 0;
-  const bool has_runtime_http_response_len = ctx.runtime_http_response_len_patch_len > 0;
-  const bool has_runtime_http_response_headers_len = ctx.runtime_http_response_headers_len_patch_len > 0;
-  const bool has_runtime_http_response_body_offset = ctx.runtime_http_response_body_offset_patch_len > 0;
-  const bool has_runtime_http_header_value = ctx.runtime_http_header_value_patch_len > 0;
-  const bool has_runtime_http_header_found = ctx.runtime_http_header_found_patch_len > 0;
-  const bool has_runtime_http_header_offset = ctx.runtime_http_header_offset_patch_len > 0;
-  const bool has_runtime_http_header_len = ctx.runtime_http_header_len_patch_len > 0;
-  uint32_t runtime_json_parse_bytes_name = 0;
-  uint32_t runtime_http_fetch_name = 0;
-  uint32_t runtime_http_result_ok_name = 0;
-  uint32_t runtime_http_result_status_name = 0;
-  uint32_t runtime_http_result_body_len_name = 0;
-  uint32_t runtime_http_result_error_name = 0;
-  uint32_t runtime_http_response_len_name = 0;
-  uint32_t runtime_http_response_headers_len_name = 0;
-  uint32_t runtime_http_response_body_offset_name = 0;
-  uint32_t runtime_http_header_value_name = 0;
-  uint32_t runtime_http_header_found_name = 0;
-  uint32_t runtime_http_header_offset_name = 0;
-  uint32_t runtime_http_header_len_name = 0;
-  if (has_runtime_json_parse_bytes) {
-    runtime_json_parse_bytes_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_json_parse_bytes");
+  uint32_t runtime_names[ELF_RUNTIME_HELPER_COUNT] = {0};
+  for (unsigned helper = 0; helper < ELF_RUNTIME_HELPER_COUNT; helper++) {
+    ElfRuntimeHelper runtime_helper = (ElfRuntimeHelper)helper;
+    if (z_elf_runtime_patch_count(&ctx, runtime_helper) == 0) continue;
+    runtime_names[helper] = (uint32_t)strtab.len;
+    zbuf_append(&strtab, z_elf_runtime_helper_symbol(runtime_helper));
     elf_append_u8(&strtab, 0);
   }
-  if (has_runtime_http_fetch) {
-    runtime_http_fetch_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_fetch_result");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_result_ok) {
-    runtime_http_result_ok_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_result_ok");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_result_status) {
-    runtime_http_result_status_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_result_status");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_result_body_len) {
-    runtime_http_result_body_len_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_result_body_len");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_result_error) {
-    runtime_http_result_error_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_result_error");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_response_len) {
-    runtime_http_response_len_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_response_len");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_response_headers_len) {
-    runtime_http_response_headers_len_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_response_headers_len");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_response_body_offset) {
-    runtime_http_response_body_offset_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_response_body_offset");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_header_value) {
-    runtime_http_header_value_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_header_value");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_header_found) {
-    runtime_http_header_found_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_header_found");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_header_offset) {
-    runtime_http_header_offset_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_header_offset");
-    elf_append_u8(&strtab, 0);
-  }
-  if (has_runtime_http_header_len) {
-    runtime_http_header_len_name = (uint32_t)strtab.len;
-    zbuf_append(&strtab, "zero_http_header_len");
-    elf_append_u8(&strtab, 0);
-  }
-  elf_patch_call_patches(&text, &ctx);
-  for (size_t i = 0; i < ctx.rodata_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.rodata_patches[i].patch_offset, 1, 1, ctx.rodata_patches[i].data_offset - ctx.rodata_base_offset);
-  }
+  z_elf_patch_call_patches(&text, &ctx);
+  z_elf_append_rodata_relocations(&rela_text, &ctx, 1);
   const uint32_t function_symbol_base = has_rodata ? 2u : 1u;
   uint32_t next_runtime_symbol = function_symbol_base + (uint32_t)ir->function_len;
-  uint32_t runtime_json_parse_bytes_symbol = 0;
-  uint32_t runtime_http_fetch_symbol = 0;
-  uint32_t runtime_http_result_ok_symbol = 0;
-  uint32_t runtime_http_result_status_symbol = 0;
-  uint32_t runtime_http_result_body_len_symbol = 0;
-  uint32_t runtime_http_result_error_symbol = 0;
-  uint32_t runtime_http_response_len_symbol = 0;
-  uint32_t runtime_http_response_headers_len_symbol = 0;
-  uint32_t runtime_http_response_body_offset_symbol = 0;
-  uint32_t runtime_http_header_value_symbol = 0;
-  uint32_t runtime_http_header_found_symbol = 0;
-  uint32_t runtime_http_header_offset_symbol = 0;
-  uint32_t runtime_http_header_len_symbol = 0;
-  if (has_runtime_json_parse_bytes) runtime_json_parse_bytes_symbol = next_runtime_symbol++;
-  if (has_runtime_http_fetch) runtime_http_fetch_symbol = next_runtime_symbol++;
-  if (has_runtime_http_result_ok) runtime_http_result_ok_symbol = next_runtime_symbol++;
-  if (has_runtime_http_result_status) runtime_http_result_status_symbol = next_runtime_symbol++;
-  if (has_runtime_http_result_body_len) runtime_http_result_body_len_symbol = next_runtime_symbol++;
-  if (has_runtime_http_result_error) runtime_http_result_error_symbol = next_runtime_symbol++;
-  if (has_runtime_http_response_len) runtime_http_response_len_symbol = next_runtime_symbol++;
-  if (has_runtime_http_response_headers_len) runtime_http_response_headers_len_symbol = next_runtime_symbol++;
-  if (has_runtime_http_response_body_offset) runtime_http_response_body_offset_symbol = next_runtime_symbol++;
-  if (has_runtime_http_header_value) runtime_http_header_value_symbol = next_runtime_symbol++;
-  if (has_runtime_http_header_found) runtime_http_header_found_symbol = next_runtime_symbol++;
-  if (has_runtime_http_header_offset) runtime_http_header_offset_symbol = next_runtime_symbol++;
-  if (has_runtime_http_header_len) runtime_http_header_len_symbol = next_runtime_symbol++;
-  for (size_t i = 0; i < ctx.runtime_json_parse_bytes_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_json_parse_bytes_patches[i].patch_offset, runtime_json_parse_bytes_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_fetch_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_fetch_patches[i].patch_offset, runtime_http_fetch_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_result_ok_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_result_ok_patches[i].patch_offset, runtime_http_result_ok_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_result_status_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_result_status_patches[i].patch_offset, runtime_http_result_status_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_result_body_len_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_result_body_len_patches[i].patch_offset, runtime_http_result_body_len_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_result_error_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_result_error_patches[i].patch_offset, runtime_http_result_error_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_response_len_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_response_len_patches[i].patch_offset, runtime_http_response_len_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_response_headers_len_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_response_headers_len_patches[i].patch_offset, runtime_http_response_headers_len_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_response_body_offset_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_response_body_offset_patches[i].patch_offset, runtime_http_response_body_offset_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_header_value_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_header_value_patches[i].patch_offset, runtime_http_header_value_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_header_found_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_header_found_patches[i].patch_offset, runtime_http_header_found_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_header_offset_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_header_offset_patches[i].patch_offset, runtime_http_header_offset_symbol, 4, -4);
-  }
-  for (size_t i = 0; i < ctx.runtime_http_header_len_patch_len; i++) {
-    z_elf_append_rela(&rela_text, ctx.runtime_http_header_len_patches[i].patch_offset, runtime_http_header_len_symbol, 4, -4);
+  uint32_t runtime_symbols[ELF_RUNTIME_HELPER_COUNT] = {0};
+  for (unsigned helper = 0; helper < ELF_RUNTIME_HELPER_COUNT; helper++) {
+    ElfRuntimeHelper runtime_helper = (ElfRuntimeHelper)helper;
+    if (z_elf_runtime_patch_count(&ctx, runtime_helper) == 0) continue;
+    runtime_symbols[helper] = next_runtime_symbol++;
+    z_elf_append_runtime_relocations(&rela_text, &ctx, runtime_helper, runtime_symbols[helper]);
   }
 
   for (size_t i = 0; i < ir->function_len; i++) {
     z_elf_append_symbol(&symtab, symbol_names[i], ir->functions[i].is_exported ? 0x12 : 0x02, 1, function_offsets[i], function_sizes[i]);
   }
-  if (has_runtime_json_parse_bytes) {
-    z_elf_append_symbol(&symtab, runtime_json_parse_bytes_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_fetch) {
-    z_elf_append_symbol(&symtab, runtime_http_fetch_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_result_ok) {
-    z_elf_append_symbol(&symtab, runtime_http_result_ok_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_result_status) {
-    z_elf_append_symbol(&symtab, runtime_http_result_status_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_result_body_len) {
-    z_elf_append_symbol(&symtab, runtime_http_result_body_len_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_result_error) {
-    z_elf_append_symbol(&symtab, runtime_http_result_error_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_response_len) {
-    z_elf_append_symbol(&symtab, runtime_http_response_len_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_response_headers_len) {
-    z_elf_append_symbol(&symtab, runtime_http_response_headers_len_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_response_body_offset) {
-    z_elf_append_symbol(&symtab, runtime_http_response_body_offset_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_header_value) {
-    z_elf_append_symbol(&symtab, runtime_http_header_value_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_header_found) {
-    z_elf_append_symbol(&symtab, runtime_http_header_found_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_header_offset) {
-    z_elf_append_symbol(&symtab, runtime_http_header_offset_name, 0x12, 0, 0, 0);
-  }
-  if (has_runtime_http_header_len) {
-    z_elf_append_symbol(&symtab, runtime_http_header_len_name, 0x12, 0, 0, 0);
+  for (unsigned helper = 0; helper < ELF_RUNTIME_HELPER_COUNT; helper++) {
+    ElfRuntimeHelper runtime_helper = (ElfRuntimeHelper)helper;
+    if (z_elf_runtime_patch_count(&ctx, runtime_helper) == 0) continue;
+    z_elf_append_symbol(&symtab, runtime_names[helper], 0x12, 0, 0, 0);
   }
   ZElfObjectImage image = {
     .machine = Z_ELF_MACHINE_X86_64,
@@ -2836,7 +2466,7 @@ bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
   free(function_offsets);
   free(function_sizes);
   free(symbol_names);
-  elf_emit_context_free(&ctx);
+  z_elf_emit_context_free(&ctx);
   zbuf_free(&text);
   zbuf_free(&rodata);
   zbuf_free(&rela_text);
@@ -2948,37 +2578,25 @@ bool z_emit_elf64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
     function_offsets[i] = text.len;
     if (!elf_emit_function_text(&text, &ir->functions[i], &ctx, diag)) {
       free(function_offsets);
-      elf_emit_context_free(&ctx);
+      z_elf_emit_context_free(&ctx);
       zbuf_free(&text);
       zbuf_free(&rodata);
       return false;
     }
   }
-  if (ctx.runtime_json_parse_bytes_patch_len > 0 ||
-      ctx.runtime_http_fetch_patch_len > 0 ||
-      ctx.runtime_http_result_ok_patch_len > 0 ||
-      ctx.runtime_http_result_status_patch_len > 0 ||
-      ctx.runtime_http_result_body_len_patch_len > 0 ||
-      ctx.runtime_http_result_error_patch_len > 0 ||
-      ctx.runtime_http_response_len_patch_len > 0 ||
-      ctx.runtime_http_response_headers_len_patch_len > 0 ||
-      ctx.runtime_http_response_body_offset_patch_len > 0 ||
-      ctx.runtime_http_header_value_patch_len > 0 ||
-      ctx.runtime_http_header_found_patch_len > 0 ||
-      ctx.runtime_http_header_offset_patch_len > 0 ||
-      ctx.runtime_http_header_len_patch_len > 0) {
+  if (z_elf_has_runtime_patches(&ctx)) {
     free(function_offsets);
-    elf_emit_context_free(&ctx);
+    z_elf_emit_context_free(&ctx);
     zbuf_free(&text);
     zbuf_free(&rodata);
     return elf_diag(diag, "direct ELF64 executable runtime helpers require object emission and an explicit runtime link step", 1, 1, "use --emit obj and link zero_runtime.c");
   }
   z_x64_patch_rel32(&text, start_call_patch, function_offsets[main_index]);
-  elf_patch_call_patches(&text, &ctx);
+  z_elf_patch_call_patches(&text, &ctx);
 
   size_t rodata_offset = has_rodata ? z_elf_align(text_offset + text.len, 8) : 0;
   ctx.rodata_addr = has_rodata ? base_addr + rodata_offset : 0;
-  elf_patch_rodata_patches(&text, &ctx);
+  z_elf_patch_rodata_patches(&text, &ctx);
   ZElfExecutableImage image = {
     .machine = Z_ELF_MACHINE_X86_64,
     .base_addr = base_addr,
@@ -2991,7 +2609,7 @@ bool z_emit_elf64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
   };
   z_elf_write_executable64(out, &image);
   free(function_offsets);
-  elf_emit_context_free(&ctx);
+  z_elf_emit_context_free(&ctx);
   zbuf_free(&text);
   zbuf_free(&rodata);
   return true;

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -26,8 +26,12 @@ const fileBudgets = {
   "native/zero-c/src/call_resolve.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_format.c": { maxLines: 370, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_format.h": { maxLines: 100, maxStrcmpCalls: 0 },
+  "native/zero-c/src/coff_emit_state.c": { maxLines: 150, maxStrcmpCalls: 0 },
+  "native/zero-c/src/coff_emit_state.h": { maxLines: 70, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.c": { maxLines: 220, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.h": { maxLines: 60, maxStrcmpCalls: 0 },
+  "native/zero-c/src/elf_emit_state.c": { maxLines: 160, maxStrcmpCalls: 0 },
+  "native/zero-c/src/elf_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.c": { maxLines: 470, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/aarch64_emit.c": { maxLines: 320, maxStrcmpCalls: 0 },
@@ -35,9 +39,9 @@ const fileBudgets = {
   "native/zero-c/src/emit_macho64.c": { maxLines: 1400, maxStrcmpCalls: 2 },
   "native/zero-c/src/macho_emit_state.c": { maxLines: 210, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
-  "native/zero-c/src/emit_elf64.c": { maxLines: 3000, maxStrcmpCalls: 3 },
+  "native/zero-c/src/emit_elf64.c": { maxLines: 2700, maxStrcmpCalls: 3 },
   "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 205, maxStrcmpCalls: 1 },
-  "native/zero-c/src/emit_coff.c": { maxLines: 1150, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff.c": { maxLines: 1050, maxStrcmpCalls: 1 },
   "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 32 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1300, maxStrcmpCalls: 0 },
   "native/zero-c/src/mir_verify.h": { maxLines: 50, maxStrcmpCalls: 0 },
@@ -57,23 +61,21 @@ const fileBudgets = {
 const knownLargeFunctionLimits = new Map([
   ["native/zero-c/src/ir.c|static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunction *fun, const Expr *expr, IrValue **out) {", 1484],
   ["native/zero-c/src/checker.c|static bool check_expr_expected(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope, ZDiag *diag, const char *expected) {", 1170],
-  ["native/zero-c/src/emit_elf64.c|static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *value, ElfEmitContext *ctx, ZDiag *diag) {", 1085],
+  ["native/zero-c/src/emit_elf64.c|static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *value, ElfEmitContext *ctx, ZDiag *diag) {", 1077],
   ["native/zero-c/src/main.c|int main(int argc, char **argv) {", 924],
   ["native/zero-c/src/emit_macho64.c|bool z_emit_macho64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {", 157],
-  ["native/zero-c/src/emit_elf64.c|bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {", 302],
+  ["native/zero-c/src/emit_elf64.c|bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {", 125],
   ["native/zero-c/src/main.c|static void append_graph_json(ZBuf *buf, const SourceInput *input, const Program *program, const ZTargetInfo *target) {", 374],
   ["native/zero-c/src/emit_elf64.c|static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, ElfEmitContext *ctx, ZDiag *diag) {", 300],
   ["native/zero-c/src/emit_macho64.c|static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {", 275],
   ["native/zero-c/src/checker.c|static bool check_stmt(CheckContext *ctx, const Program *program, const Function *fun, const Stmt *stmt, Scope *scope, ZDiag *diag, int loop_depth) {", 259],
   ["native/zero-c/src/checker.c|bool z_check_program(const Program *program, ZDiag *diag) {", 213],
-  ["native/zero-c/src/emit_coff.c|bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {", 213],
   ["native/zero-c/src/checker.c|static const char *expr_type(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope) {", 205],
   ["native/zero-c/src/emit_macho64.c|static bool macho_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, bool restore_process_args, MachOEmitContext *ctx, ZDiag *diag) {", 193],
   ["native/zero-c/src/checker.c|static bool collect_return_value_provenance_from_stmt_vec(CheckContext *ctx, const Program *program, const Function *fun, const StmtVec *body, Scope *scope, GenericBinding *bindings, size_t binding_len, ValueProvenance *out, bool *may_return, bool *complete) {", 192],
   ["native/zero-c/src/emit_coff.c|static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {", 191],
   ["native/zero-c/src/row_syntax.c|ZRowTokenVec z_row_tokenize(const char *source, ZDiag *diag) {", 177],
   ["native/zero-c/src/ir.c|static bool ir_lower_stmt_to_vec(const Program *program, IrProgram *ir, IrFunction *mir_fun, const Stmt *stmt, IrInstr **out_items, size_t *out_len, size_t *out_cap, bool *saw_return) {", 172],
-  ["native/zero-c/src/emit_coff.c|bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {", 171],
   ["native/zero-c/src/emit_coff.c|static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, CoffEmitContext *ctx, ZDiag *diag) {", 165],
   ["native/zero-c/src/checker.c|static bool expr_reference_provenance(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope, ValueProvenance *origins) {", 152],
   ["native/zero-c/src/main.c|static int run_tests_direct(const Command *command, const SourceInput *input, const Program *program, const ZTargetInfo *target) {", 151],
@@ -603,6 +605,19 @@ function budgetViolations(files, allLargeFunctions, stdlib, backendFormats) {
       paths: backendFormats.elf.archFilesWithLocalSectionWriters,
     });
   }
+  if (!backendFormats.elf.patchStateModule ||
+      !backendFormats.elf.x86UsesPatchStateModule) {
+    violations.push({
+      kind: "elf-patch-state-split",
+      elf: backendFormats.elf,
+    });
+  }
+  if (backendFormats.elf.archFilesWithLocalPatchState.length > 0) {
+    violations.push({
+      kind: "elf-patch-state-in-architecture-file",
+      paths: backendFormats.elf.archFilesWithLocalPatchState,
+    });
+  }
   if (!backendFormats.coff.sharedWriter ||
       !backendFormats.coff.objectUsesSharedWriter ||
       !backendFormats.coff.executableUsesSharedWriter) {
@@ -615,6 +630,19 @@ function budgetViolations(files, allLargeFunctions, stdlib, backendFormats) {
     violations.push({
       kind: "coff-container-writer-in-architecture-file",
       paths: backendFormats.coff.archFilesWithLocalContainerWriters,
+    });
+  }
+  if (!backendFormats.coff.patchStateModule ||
+      !backendFormats.coff.x64UsesPatchStateModule) {
+    violations.push({
+      kind: "coff-patch-state-split",
+      coff: backendFormats.coff,
+    });
+  }
+  if (backendFormats.coff.archFilesWithLocalPatchState.length > 0) {
+    violations.push({
+      kind: "coff-patch-state-in-architecture-file",
+      paths: backendFormats.coff.archFilesWithLocalPatchState,
     });
   }
   if (!backendFormats.macho.sharedWriter ||
@@ -750,7 +778,9 @@ const stdlib = {
   },
 };
 const elfFormatSource = texts.get("native/zero-c/src/elf_format.c") ?? "";
+const elfEmitStateSource = cCodeText(texts.get("native/zero-c/src/elf_emit_state.c") ?? "");
 const coffFormatSource = texts.get("native/zero-c/src/coff_format.c") ?? "";
+const coffEmitStateSource = cCodeText(texts.get("native/zero-c/src/coff_emit_state.c") ?? "");
 const machoFormatSource = texts.get("native/zero-c/src/macho_format.c") ?? "";
 const machoEmitStateSource = cCodeText(texts.get("native/zero-c/src/macho_emit_state.c") ?? "");
 const aarch64EmitSource = texts.get("native/zero-c/src/aarch64_emit.c") ?? "";
@@ -772,6 +802,17 @@ const backendFormats = {
     ]
       .filter(([, text]) => /\bappend_section_header\s*\(/.test(text))
       .map(([path]) => path),
+    patchStateModule: /\bz_elf_record_value_runtime_patch\s*\(/.test(elfEmitStateSource) &&
+      /\bz_elf_append_runtime_relocations\s*\(/.test(elfEmitStateSource) &&
+      /\bz_elf_patch_rodata_patches\s*\(/.test(elfEmitStateSource),
+    x86UsesPatchStateModule: /\bz_elf_record_value_runtime_patch\s*\(/.test(elfX64Source) &&
+      /\bz_elf_append_runtime_relocations\s*\(/.test(elfX64Source) &&
+      /\bz_elf_has_runtime_patches\s*\(/.test(elfX64Source),
+    archFilesWithLocalPatchState: [
+      ["native/zero-c/src/emit_elf64.c", elfX64Source],
+    ]
+      .filter(([, text]) => /\bElfRuntimePatch\b|(?:\.|->)runtime_[A-Za-z0-9_]+_patch_len\b|(?:\.|->)runtime_[A-Za-z0-9_]+_patches\b|\bstatic\s+bool\s+elf_record_(?:call_patch|rodata_patch|runtime_)\b|\bstatic\s+void\s+elf_patch_(?:call_patches|rodata_patches)\b/.test(text))
+      .map(([path]) => path),
   },
   coff: {
     sharedWriter: /\bz_coff_write_object\s*\(/.test(coffFormatSource) && /\bz_coff_write_pe64_executable\s*\(/.test(coffFormatSource),
@@ -781,6 +822,17 @@ const backendFormats = {
       ["native/zero-c/src/emit_coff.c", coffX64Source],
     ]
       .filter(([, text]) => /\bappend_coff_name\s*\(|\bcoff_append_import_table\s*\(|\bPE32\+|\bIMAGE_FILE_MACHINE_AMD64/.test(text))
+      .map(([path]) => path),
+    patchStateModule: /\bz_coff_record_instr_runtime_patch\s*\(/.test(coffEmitStateSource) &&
+      /\bz_coff_append_runtime_relocations\s*\(/.test(coffEmitStateSource) &&
+      /\bz_coff_patch_runtime_patches\s*\(/.test(coffEmitStateSource),
+    x64UsesPatchStateModule: /\bz_coff_record_instr_runtime_patch\s*\(/.test(coffX64Source) &&
+      /\bz_coff_append_runtime_relocations\s*\(/.test(coffX64Source) &&
+      /\bz_coff_patch_runtime_patches\s*\(/.test(coffX64Source),
+    archFilesWithLocalPatchState: [
+      ["native/zero-c/src/emit_coff.c", coffX64Source],
+    ]
+      .filter(([, text]) => /\bCoff(?:CallPatch|WorldWritePatch)\b|(?:\.|->)world_write_patch_len\b|(?:\.|->)world_write_patches\b|\bstatic\s+bool\s+coff_record_(?:call_patch|rodata_patch|world_write_patch)\b/.test(text))
       .map(([path]) => path),
   },
   macho: {


### PR DESCRIPTION
- Move ELF and COFF patch tracking into dedicated emit-state modules
- Route runtime and data relocations through shared backend helpers
- Add metrics checks for direct backend patch-state boundaries