### PR TITLE
Share x64 value helpers

### DIFF
--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -263,36 +263,26 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
     case IR_VALUE_BINARY:
       if (value->binary_op != IR_BIN_ADD && value->binary_op != IR_BIN_SUB && value->binary_op != IR_BIN_MUL) return coff_diag_at(diag, "direct COFF binary operator is unsupported", value->line, value->column, "unsupported operator");
       if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_value(text, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x89);
-      z_x64_append_u8(text, 0xc1);
-      z_x64_append_u8(text, 0x58);
-      if (value->binary_op == IR_BIN_MUL) {
-        z_x64_append_u8(text, 0x0f);
-        z_x64_append_u8(text, 0xaf);
-        z_x64_append_u8(text, 0xc1);
+      z_x64_emit_mov_rcx_from_rax(text, false);
+      z_x64_emit_pop_rax(text);
+      if (value->binary_op == IR_BIN_ADD) {
+        z_x64_emit_add_rax_rcx(text, false);
+      } else if (value->binary_op == IR_BIN_SUB) {
+        z_x64_emit_sub_rax_rcx(text, false);
       } else {
-        z_x64_append_u8(text, value->binary_op == IR_BIN_ADD ? 0x01 : 0x29);
-        z_x64_append_u8(text, 0xc8);
+        z_x64_emit_imul_rax_rcx(text, false);
       }
       return true;
     case IR_VALUE_COMPARE:
       if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF comparison requires two operands", value->line, value->column, "invalid comparison");
       if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_value(text, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x89);
-      z_x64_append_u8(text, 0xc1);
-      z_x64_append_u8(text, 0x58);
-      z_x64_append_u8(text, 0x39);
-      z_x64_append_u8(text, 0xc8);
-      z_x64_append_u8(text, 0x0f);
-      z_x64_append_u8(text, coff_setcc_opcode(value->compare_op));
-      z_x64_append_u8(text, 0xc0);
-      z_x64_append_u8(text, 0x0f);
-      z_x64_append_u8(text, 0xb6);
-      z_x64_append_u8(text, 0xc0);
+      z_x64_emit_mov_rcx_from_rax(text, false);
+      z_x64_emit_pop_rax(text);
+      z_x64_emit_cmp_rax_rcx_to_bool(text, coff_setcc_opcode(value->compare_op), false);
       return true;
     case IR_VALUE_CALL: {
       static const unsigned param_regs[] = {1, 2, 8, 9};

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -202,7 +202,7 @@ static void elf_emit_epilogue(ZBuf *code, const IrFunction *fun, const ElfEmitCo
 }
 
 static void elf_emit_push_rax(ZBuf *code) {
-  z_x64_append_u8(code, 0x50);
+  z_x64_emit_push_rax(code);
 }
 
 static void elf_emit_store_local_slot_reg(ZBuf *code, const IrLocal *local, unsigned slot_offset, unsigned reg, bool wide);
@@ -549,70 +549,24 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_BINARY: {
       bool wide = elf_type_is_i64(value->type);
       if (!elf_emit_value(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_value(code, fun, value->right, ctx, diag)) return false;
-      if (wide) z_x64_append_u8(code, 0x48);
-      z_x64_append_u8(code, 0x89);
-      z_x64_append_u8(code, 0xc1);
-      z_x64_append_u8(code, 0x58);
+      z_x64_emit_mov_rcx_from_rax(code, wide);
+      z_x64_emit_pop_rax(code);
       if (value->binary_op == IR_BIN_ADD) {
-        if (wide) z_x64_append_u8(code, 0x48);
-        z_x64_append_u8(code, 0x01);
-        z_x64_append_u8(code, 0xc8);
+        z_x64_emit_add_rax_rcx(code, wide);
       } else if (value->binary_op == IR_BIN_SUB) {
-        if (wide) z_x64_append_u8(code, 0x48);
-        z_x64_append_u8(code, 0x29);
-        z_x64_append_u8(code, 0xc8);
+        z_x64_emit_sub_rax_rcx(code, wide);
       } else if (value->binary_op == IR_BIN_MUL) {
-        if (wide) z_x64_append_u8(code, 0x48);
-        z_x64_append_u8(code, 0x0f);
-        z_x64_append_u8(code, 0xaf);
-        z_x64_append_u8(code, 0xc1);
-      } else if (value->binary_op == IR_BIN_AND || value->binary_op == IR_BIN_OR) {
-        if (wide) z_x64_append_u8(code, 0x48);
-        z_x64_append_u8(code, value->binary_op == IR_BIN_AND ? 0x21 : 0x09);
-        z_x64_append_u8(code, 0xc8);
+        z_x64_emit_imul_rax_rcx(code, wide);
+      } else if (value->binary_op == IR_BIN_AND) {
+        z_x64_emit_and_rax_rcx(code, wide);
+      } else if (value->binary_op == IR_BIN_OR) {
+        z_x64_emit_or_rax_rcx(code, wide);
       } else if (value->binary_op == IR_BIN_DIV) {
-        if (elf_type_is_unsigned(value->type)) {
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0x31);
-          z_x64_append_u8(code, 0xd2);
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0xf7);
-          z_x64_append_u8(code, 0xf1);
-        } else {
-          if (wide) {
-            z_x64_append_u8(code, 0x48);
-            z_x64_append_u8(code, 0x99);
-          } else {
-            z_x64_append_u8(code, 0x99);
-          }
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0xf7);
-          z_x64_append_u8(code, 0xf9);
-        }
+        z_x64_emit_div_rax_rcx(code, wide, elf_type_is_unsigned(value->type), false);
       } else if (value->binary_op == IR_BIN_MOD) {
-        if (elf_type_is_unsigned(value->type)) {
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0x31);
-          z_x64_append_u8(code, 0xd2);
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0xf7);
-          z_x64_append_u8(code, 0xf1);
-        } else {
-          if (wide) {
-            z_x64_append_u8(code, 0x48);
-            z_x64_append_u8(code, 0x99);
-          } else {
-            z_x64_append_u8(code, 0x99);
-          }
-          if (wide) z_x64_append_u8(code, 0x48);
-          z_x64_append_u8(code, 0xf7);
-          z_x64_append_u8(code, 0xf9);
-        }
-        if (wide) z_x64_append_u8(code, 0x48);
-        z_x64_append_u8(code, 0x89);
-        z_x64_append_u8(code, 0xd0);
+        z_x64_emit_div_rax_rcx(code, wide, elf_type_is_unsigned(value->type), true);
       } else {
         return elf_diag(diag, "direct ELF64 binary operator is unsupported", value->line, value->column, "unsupported operator");
       }
@@ -624,21 +578,11 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       }
       bool wide = elf_type_is_i64(value->left->type);
       if (!elf_emit_value(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_value(code, fun, value->right, ctx, diag)) return false;
-      if (wide) z_x64_append_u8(code, 0x48);
-      z_x64_append_u8(code, 0x89);
-      z_x64_append_u8(code, 0xc1);
-      z_x64_append_u8(code, 0x58);
-      if (wide) z_x64_append_u8(code, 0x48);
-      z_x64_append_u8(code, 0x39);
-      z_x64_append_u8(code, 0xc8);
-      z_x64_append_u8(code, 0x0f);
-      z_x64_append_u8(code, elf_setcc_opcode(value->compare_op, elf_type_is_unsigned(value->left->type)));
-      z_x64_append_u8(code, 0xc0);
-      z_x64_append_u8(code, 0x0f);
-      z_x64_append_u8(code, 0xb6);
-      z_x64_append_u8(code, 0xc0);
+      z_x64_emit_mov_rcx_from_rax(code, wide);
+      z_x64_emit_pop_rax(code);
+      z_x64_emit_cmp_rax_rcx_to_bool(code, elf_setcc_opcode(value->compare_op, elf_type_is_unsigned(value->left->type)), wide);
       return true;
     }
     case IR_VALUE_CALL: {

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -16,6 +16,10 @@ void z_x64_append_u64(ZBuf *buf, uint64_t value) {
   z_x64_append_u32(buf, (uint32_t)(value >> 32));
 }
 
+static void z_x64_emit_wide_prefix(ZBuf *buf, bool wide) {
+  if (wide) z_x64_append_u8(buf, 0x48);
+}
+
 void z_x64_patch_u32(ZBuf *buf, size_t offset, uint32_t value) {
   buf->data[offset + 0] = (char)(value & 0xffu);
   buf->data[offset + 1] = (char)((value >> 8) & 0xffu);
@@ -85,6 +89,85 @@ void z_x64_emit_push_reg64(ZBuf *buf, unsigned reg) {
 void z_x64_emit_pop_reg64(ZBuf *buf, unsigned reg) {
   if (reg >= 8) z_x64_append_u8(buf, 0x41);
   z_x64_append_u8(buf, 0x58 + (reg & 7u));
+}
+
+void z_x64_emit_push_rax(ZBuf *buf) {
+  z_x64_emit_push_reg64(buf, 0);
+}
+
+void z_x64_emit_pop_rax(ZBuf *buf) {
+  z_x64_emit_pop_reg64(buf, 0);
+}
+
+void z_x64_emit_mov_rcx_from_rax(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x89);
+  z_x64_append_u8(buf, 0xc1);
+}
+
+void z_x64_emit_add_rax_rcx(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x01);
+  z_x64_append_u8(buf, 0xc8);
+}
+
+void z_x64_emit_sub_rax_rcx(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x29);
+  z_x64_append_u8(buf, 0xc8);
+}
+
+void z_x64_emit_imul_rax_rcx(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x0f);
+  z_x64_append_u8(buf, 0xaf);
+  z_x64_append_u8(buf, 0xc1);
+}
+
+void z_x64_emit_and_rax_rcx(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x21);
+  z_x64_append_u8(buf, 0xc8);
+}
+
+void z_x64_emit_or_rax_rcx(ZBuf *buf, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x09);
+  z_x64_append_u8(buf, 0xc8);
+}
+
+void z_x64_emit_div_rax_rcx(ZBuf *buf, bool wide, bool uns, bool keep_remainder) {
+  if (uns) {
+    z_x64_emit_wide_prefix(buf, wide);
+    z_x64_append_u8(buf, 0x31);
+    z_x64_append_u8(buf, 0xd2);
+    z_x64_emit_wide_prefix(buf, wide);
+    z_x64_append_u8(buf, 0xf7);
+    z_x64_append_u8(buf, 0xf1);
+  } else {
+    z_x64_emit_wide_prefix(buf, wide);
+    z_x64_append_u8(buf, 0x99);
+    z_x64_emit_wide_prefix(buf, wide);
+    z_x64_append_u8(buf, 0xf7);
+    z_x64_append_u8(buf, 0xf9);
+  }
+  if (keep_remainder) {
+    z_x64_emit_wide_prefix(buf, wide);
+    z_x64_append_u8(buf, 0x89);
+    z_x64_append_u8(buf, 0xd0);
+  }
+}
+
+void z_x64_emit_cmp_rax_rcx_to_bool(ZBuf *buf, unsigned setcc_opcode, bool wide) {
+  z_x64_emit_wide_prefix(buf, wide);
+  z_x64_append_u8(buf, 0x39);
+  z_x64_append_u8(buf, 0xc8);
+  z_x64_append_u8(buf, 0x0f);
+  z_x64_append_u8(buf, setcc_opcode);
+  z_x64_append_u8(buf, 0xc0);
+  z_x64_append_u8(buf, 0x0f);
+  z_x64_append_u8(buf, 0xb6);
+  z_x64_append_u8(buf, 0xc0);
 }
 
 void z_x64_emit_prologue(ZBuf *buf, unsigned stack_size) {

--- a/native/zero-c/src/x64_emit.h
+++ b/native/zero-c/src/x64_emit.h
@@ -16,6 +16,16 @@ void z_x64_emit_rbp_disp_reg(ZBuf *buf, unsigned opcode, unsigned reg, unsigned 
 void z_x64_emit_load_rbp_positive_reg(ZBuf *buf, unsigned reg, unsigned offset, bool wide);
 void z_x64_emit_push_reg64(ZBuf *buf, unsigned reg);
 void z_x64_emit_pop_reg64(ZBuf *buf, unsigned reg);
+void z_x64_emit_push_rax(ZBuf *buf);
+void z_x64_emit_pop_rax(ZBuf *buf);
+void z_x64_emit_mov_rcx_from_rax(ZBuf *buf, bool wide);
+void z_x64_emit_add_rax_rcx(ZBuf *buf, bool wide);
+void z_x64_emit_sub_rax_rcx(ZBuf *buf, bool wide);
+void z_x64_emit_imul_rax_rcx(ZBuf *buf, bool wide);
+void z_x64_emit_and_rax_rcx(ZBuf *buf, bool wide);
+void z_x64_emit_or_rax_rcx(ZBuf *buf, bool wide);
+void z_x64_emit_div_rax_rcx(ZBuf *buf, bool wide, bool uns, bool keep_remainder);
+void z_x64_emit_cmp_rax_rcx_to_bool(ZBuf *buf, unsigned setcc_opcode, bool wide);
 void z_x64_emit_prologue(ZBuf *buf, unsigned stack_size);
 void z_x64_emit_epilogue(ZBuf *buf);
 void z_x64_emit_mov_eax_u32(ZBuf *buf, uint32_t value);

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -39,9 +39,9 @@ const fileBudgets = {
   "native/zero-c/src/emit_macho64.c": { maxLines: 1400, maxStrcmpCalls: 2 },
   "native/zero-c/src/macho_emit_state.c": { maxLines: 210, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
-  "native/zero-c/src/emit_elf64.c": { maxLines: 2560, maxStrcmpCalls: 3 },
+  "native/zero-c/src/emit_elf64.c": { maxLines: 2500, maxStrcmpCalls: 3 },
   "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 205, maxStrcmpCalls: 1 },
-  "native/zero-c/src/emit_coff.c": { maxLines: 1010, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff.c": { maxLines: 990, maxStrcmpCalls: 1 },
   "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 32 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1300, maxStrcmpCalls: 0 },
   "native/zero-c/src/mir_verify.h": { maxLines: 50, maxStrcmpCalls: 0 },
@@ -54,8 +54,8 @@ const fileBudgets = {
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/unify.c": { maxLines: 500, maxStrcmpCalls: 14 },
   "native/zero-c/src/unify.h": { maxLines: 75, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.c": { maxLines: 160, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.h": { maxLines: 30, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.c": { maxLines: 240, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.h": { maxLines: 45, maxStrcmpCalls: 0 },
 };
 
 const knownLargeFunctionLimits = new Map([
@@ -865,6 +865,16 @@ const backendFormats = {
       /\bz_x64_emit_epilogue\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_mov_eax_u32\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_ud2\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_push_rax\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_pop_rax\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_mov_rcx_from_rax\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_add_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_sub_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_imul_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_and_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_or_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_div_rax_rcx\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_cmp_rax_rcx_to_bool\s*\(/.test(x64EmitSource) &&
       /\bz_x64_patch_rel32\s*\(/.test(x64EmitSource),
     elfUsesSharedEncodingPrimitives: /\bz_x64_append_u8\s*\(/.test(elfX64Source) &&
       /\bz_x64_append_u32\s*\(/.test(elfX64Source) &&
@@ -874,6 +884,16 @@ const backendFormats = {
       /\bz_x64_emit_epilogue\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_mov_eax_u32\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_ud2\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_push_rax\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_pop_rax\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_mov_rcx_from_rax\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_add_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_sub_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_imul_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_and_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_or_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_div_rax_rcx\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_cmp_rax_rcx_to_bool\s*\(/.test(elfX64Source) &&
       /\bz_x64_patch_rel32\s*\(/.test(elfX64Source),
     coffUsesSharedEncodingPrimitives: /\bz_x64_append_u8\s*\(/.test(coffX64Source) &&
       /\bz_x64_append_u32\s*\(/.test(coffX64Source) &&
@@ -883,6 +903,13 @@ const backendFormats = {
       /\bz_x64_emit_epilogue\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_mov_eax_u32\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_ud2\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_push_rax\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_pop_rax\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_mov_rcx_from_rax\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_add_rax_rcx\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_sub_rax_rcx\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_imul_rax_rcx\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_cmp_rax_rcx_to_bool\s*\(/.test(coffX64Source) &&
       /\bz_x64_patch_rel32\s*\(/.test(coffX64Source),
     formatFilesWithLocalEncodingPrimitives: [
       ["native/zero-c/src/emit_elf64.c", elfX64Source],


### PR DESCRIPTION
- Move scalar arithmetic and comparison byte sequences into x64 emit helpers
- Route ELF and COFF value emitters through shared helper operations
- Tighten compiler metrics for the shared x64 helper surface