### PR TITLE
Extract x64 indexed byte helpers

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "dev": "next dev",

--- a/evals/package.json
+++ b/evals/package.json
@@ -2,6 +2,9 @@
   "name": "zero-evals",
   "private": true,
   "type": "module",
+  "engines": {
+    "node": ">=24"
+  },
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "eval": "pnpm run build && node dist/run.js",

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -14,7 +14,7 @@
     "test": "node --test tests/*.test.mjs"
   },
   "engines": {
-    "node": ">=22",
+    "node": ">=24",
     "vscode": "^1.100.0"
   },
   "contributes": {

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -286,7 +286,7 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       if (value->arg_len > 4) return coff_diag_at(diag, "direct COFF call supports at most four integer arguments", value->line, value->column, "too many arguments");
       for (size_t i = 0; i < value->arg_len; i++) {
         if (!coff_emit_value(text, fun, value->args[i], ctx, diag)) return false;
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
       }
       for (size_t i = value->arg_len; i > 0; i--) {
         z_x64_emit_pop_reg64(text, param_regs[i - 1]);
@@ -310,9 +310,9 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       z_x64_emit_mov_eax_u32(text, 0);
       size_t end_patch = z_x64_emit_jmp32_placeholder(text, 0xe9);
       z_x64_patch_rel32(text, ok_patch, text->len);
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x59);
+      z_x64_emit_pop_reg64(text, 1);
       coff_emit_load_local_slot_reg(text, fun, value->local_index, 0, 2, true);
       z_x64_emit_add_rdx_rcx(text, true);
       z_x64_emit_store_ptr_rdx_al(text);
@@ -340,17 +340,17 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
         return true;
       }
       if (!value->index || !coff_emit_value(text, fun, value->index, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
       z_x64_emit_mov_rcx_from_rax(text, false);
-      z_x64_append_u8(text, 0x58);
+      z_x64_emit_pop_rax(text);
       z_x64_emit_cmp_rax_rcx(text, false);
       size_t ok_patch = z_x64_emit_jcc32_placeholder(text, 0x82);
       z_x64_emit_ud2(text);
       z_x64_patch_rel32(text, ok_patch, text->len);
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x59);
+      z_x64_emit_pop_reg64(text, 1);
       z_x64_emit_add_rax_rcx(text, true);
       z_x64_emit_load_eax_ptr_rax_u8(text);
       return true;
@@ -366,9 +366,9 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) {
         if (!value->index || !coff_emit_value(text, fun, value->index, ctx, diag)) return false;
         coff_emit_u8_array_bounds_check(text, local);
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         coff_emit_array_base_rdx(text, fun, value->array_index);
-        z_x64_append_u8(text, 0x59);
+        z_x64_emit_pop_reg64(text, 1);
         z_x64_emit_shl_rcx_imm8(text, 2);
         z_x64_emit_add_rdx_rcx(text, true);
         z_x64_emit_load_eax_ptr_rdx(text);
@@ -377,9 +377,9 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       if (!local->is_array || local->element_type != IR_TYPE_U8) return coff_diag_at(diag, "direct COFF indexed load requires [N]u8 or integer arrays", value->line, value->column, "unsupported array local");
       if (!value->index || !coff_emit_value(text, fun, value->index, ctx, diag)) return false;
       coff_emit_u8_array_bounds_check(text, local);
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       coff_emit_array_base_rdx(text, fun, value->array_index);
-      z_x64_append_u8(text, 0x59);
+      z_x64_emit_pop_reg64(text, 1);
       z_x64_emit_add_rdx_rcx(text, true);
       z_x64_emit_load_eax_ptr_rdx_u8(text);
       return true;
@@ -402,12 +402,10 @@ static bool coff_emit_instrs(ZBuf *text, const IrFunction *fun, const IrInstr *i
 static bool coff_emit_world_write(ZBuf *text, const IrFunction *fun, const IrInstr *instr, CoffEmitContext *ctx, ZDiag *diag) {
   if (!instr || !instr->value) return coff_diag_at(diag, "direct COFF World write requires bytes", instr ? instr->line : 1, instr ? instr->column : 1, "missing byte view");
   if (!coff_emit_byte_view_ptr(text, fun, instr->value, ctx, diag)) return false;
-  z_x64_append_u8(text, 0x50); // push rax, preserve ptr while computing len
+  z_x64_emit_push_rax(text); // preserve ptr while computing len
   if (!coff_emit_byte_view_len(text, fun, instr->value, ctx, diag)) return false;
-  z_x64_append_u8(text, 0x41);
-  z_x64_append_u8(text, 0x89);
-  z_x64_append_u8(text, 0xc0); // mov r8d, eax
-  z_x64_append_u8(text, 0x5a); // pop rdx
+  z_x64_emit_mov_reg_from_rax(text, 8, false);
+  z_x64_emit_pop_reg64(text, 2);
   z_x64_append_u8(text, 0xb9);
   z_x64_append_u32(text, instr->field_offset == 2 ? 2u : 1u); // ecx = fd
   z_x64_emit_sub_rsp(text, 32);
@@ -456,10 +454,10 @@ static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *in
     if (fun->locals[instr->local_index].type == IR_TYPE_MAYBE_BYTE_VIEW) {
       if (!instr->value || instr->value->kind != IR_VALUE_ALLOC_BYTES || instr->value->local_index >= fun->local_len || fun->locals[instr->value->local_index].type != IR_TYPE_ALLOC) return coff_diag_at(diag, "direct COFF allocation source is invalid", instr->line, instr->column, "invalid allocation");
       if (!coff_emit_value(text, fun, instr->value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       coff_emit_load_local_slot_eax(text, fun, instr->value->local_index, 12);
       coff_emit_load_local_slot_reg(text, fun, instr->value->local_index, 8, 1, false);
-      z_x64_append_u8(text, 0x58);
+      z_x64_emit_pop_rax(text);
       z_x64_append_u8(text, 0x89);
       z_x64_append_u8(text, 0xc2);
       z_x64_emit_add_rax_rcx(text, false);
@@ -509,9 +507,9 @@ static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *in
     if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) {
       if (!instr->index || !coff_emit_value(text, fun, instr->index, ctx, diag)) return false;
       coff_emit_u8_array_bounds_check(text, local);
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       if (!coff_emit_value(text, fun, instr->value, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x59);
+      z_x64_emit_pop_reg64(text, 1);
       coff_emit_array_base_rdx(text, fun, instr->array_index);
       z_x64_emit_shl_rcx_imm8(text, 2);
       z_x64_emit_add_rdx_rcx(text, true);
@@ -521,9 +519,9 @@ static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *in
     if (!local->is_array || local->element_type != IR_TYPE_U8) return coff_diag_at(diag, "direct COFF indexed store requires [N]u8 or integer arrays", instr->line, instr->column, "unsupported array local");
     if (!instr->index || !coff_emit_value(text, fun, instr->index, ctx, diag)) return false;
     coff_emit_u8_array_bounds_check(text, local);
-    z_x64_append_u8(text, 0x50);
+    z_x64_emit_push_rax(text);
     if (!coff_emit_value(text, fun, instr->value, ctx, diag)) return false;
-    z_x64_append_u8(text, 0x59);
+    z_x64_emit_pop_reg64(text, 1);
     coff_emit_array_base_rdx(text, fun, instr->array_index);
     z_x64_emit_add_rdx_rcx(text, true);
     z_x64_emit_store_ptr_rdx_al(text);

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -238,10 +238,10 @@ static void elf_emit_maybe_scalar_clear(ZBuf *code, const IrLocal *local) {
 }
 
 static void elf_emit_maybe_scalar_store_rax(ZBuf *code, const IrLocal *local) {
-  z_x64_append_u8(code, 0x50);
+  z_x64_emit_push_rax(code);
   z_x64_emit_mov_eax_u32(code, 1);
   elf_emit_store_local_slot_reg(code, local, 0, 0, false);
-  z_x64_append_u8(code, 0x58);
+  z_x64_emit_pop_rax(code);
   elf_emit_store_local_slot_rax(code, local, 8);
 }
 
@@ -467,13 +467,13 @@ static bool elf_emit_byte_view_ptr(ZBuf *code, const IrFunction *fun, const IrVa
   }
   if (view->kind == IR_VALUE_BYTE_SLICE) {
     if (!elf_emit_byte_view_ptr(code, fun, view->left, ctx, diag)) return false;
-    z_x64_append_u8(code, 0x50);
+    z_x64_emit_push_rax(code);
     if (view->index) {
       if (!elf_emit_value(code, fun, view->index, ctx, diag)) return false;
     } else {
       z_x64_emit_mov_eax_u32(code, 0);
     }
-    z_x64_append_u8(code, 0x59);
+    z_x64_emit_pop_reg64(code, 1);
     z_x64_emit_add_rax_rcx(code, true);
     return true;
   }
@@ -763,10 +763,10 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       return true;
     case IR_VALUE_FS_RENAME:
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_rsi_from_rax(code);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_mov_eax_u32(code, 82);
       z_x64_emit_syscall(code);
       z_x64_emit_bool_from_nonnegative_rax(code);
@@ -837,11 +837,11 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       if (!elf_emit_openat_path(code, fun, value->right, 577, 0644, ctx, diag)) return false;
       z_x64_emit_test_rax_rax(code, true);
       size_t open_fail = elf_emit_js_placeholder(code);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->index, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->index, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       z_x64_emit_mov_rdx_from_rax(code);
       z_x64_emit_load_rsp_offset_reg(code, 6, 8, true);
       z_x64_emit_load_rsp_offset_reg(code, 7, 16, true);
@@ -858,10 +858,10 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       z_x64_emit_test_rax_rax(code, true);
       size_t close_fail = elf_emit_js_placeholder(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
       z_x64_emit_mov_rsi_from_rax(code);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_mov_eax_u32(code, 82);
       z_x64_emit_syscall(code);
       z_x64_emit_bool_from_nonnegative_rax(code);
@@ -903,13 +903,13 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_FS_READ_FILE:
       if (value->local_index >= fun->local_len) return elf_diag(diag, "direct ELF64 std.fs.read local is out of range", value->line, value->column, "invalid File");
       elf_emit_load_local_rax(code, fun, value->local_index);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_append_u8(code, 0x5e);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 6);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_xor_eax_eax(code);
       z_x64_emit_syscall(code);
       if (value->type == IR_TYPE_I64) {
@@ -926,17 +926,17 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_FS_WRITE_ALL_FILE:
       if (value->local_index >= fun->local_len) return elf_diag(diag, "direct ELF64 std.fs.writeAll local is out of range", value->line, value->column, "invalid File");
       elf_emit_load_local_rax(code, fun, value->local_index);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_append_u8(code, 0x5e);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 6);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_mov_eax_u32(code, 1);
       z_x64_emit_syscall(code);
-      z_x64_append_u8(code, 0x59);
+      z_x64_emit_pop_reg64(code, 1);
       z_x64_emit_cmp_rax_rcx(code, false);
       z_x64_append_u8(code, 0x0f);
       z_x64_append_u8(code, 0x94);
@@ -959,19 +959,19 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       if (!elf_emit_openat_path(code, fun, value->left, 0, 0, ctx, diag)) return false;
       z_x64_emit_test_rax_rax(code, true);
       size_t open_fail = elf_emit_js_placeholder(code);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_append_u8(code, 0x5e);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 6);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_xor_eax_eax(code);
       z_x64_emit_syscall(code);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       z_x64_emit_mov_rax_from_rdi(code);
       elf_emit_close_rax_fd(code);
-      z_x64_append_u8(code, 0x58);
+      z_x64_emit_pop_rax(code);
       size_t end = z_x64_emit_jmp32_placeholder(code, 0xe9);
       z_x64_patch_rel32(code, open_fail, code->len);
       z_x64_append_u8(code, 0x48);
@@ -986,19 +986,19 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       if (!elf_emit_openat_path(code, fun, value->left, 577, 0644, ctx, diag)) return false;
       z_x64_emit_test_rax_rax(code, true);
       size_t open_fail = elf_emit_js_placeholder(code);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_append_u8(code, 0x5e);
-      z_x64_append_u8(code, 0x5f);
+      z_x64_emit_pop_reg64(code, 6);
+      z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_mov_eax_u32(code, 1);
       z_x64_emit_syscall(code);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       z_x64_emit_mov_rax_from_rdi(code);
       elf_emit_close_rax_fd(code);
-      z_x64_append_u8(code, 0x58);
+      z_x64_emit_pop_rax(code);
       size_t end = z_x64_emit_jmp32_placeholder(code, 0xe9);
       z_x64_patch_rel32(code, open_fail, code->len);
       z_x64_append_u8(code, 0x48);
@@ -1034,9 +1034,9 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       z_x64_emit_mov_eax_u32(code, 0);
       size_t end_patch = z_x64_emit_jmp32_placeholder(code, 0xe9);
       z_x64_patch_rel32(code, ok_patch, code->len);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_value(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x59);
+      z_x64_emit_pop_reg64(code, 1);
       elf_emit_load_local_slot_reg(code, local, 0, 2, true);
       z_x64_emit_add_rdx_rcx(code, true);
       z_x64_emit_store_ptr_rdx_al(code);
@@ -1110,21 +1110,16 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_CRC32_BYTES: {
       if (!value->left) return elf_diag(diag, "direct ELF64 CRC32 requires a byte view", value->line, value->column, "missing byte view");
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
       z_x64_emit_mov_r9_from_rax(code);
-      z_x64_append_u8(code, 0x5e);
+      z_x64_emit_pop_reg64(code, 6);
       z_x64_emit_mov_eax_u32(code, 0xffffffffu);
       z_x64_emit_xor_ecx_ecx(code);
       size_t byte_loop = code->len;
-      z_x64_append_u8(code, 0x4c);
-      z_x64_append_u8(code, 0x39);
-      z_x64_append_u8(code, 0xc9);
+      z_x64_emit_cmp_reg_reg(code, 1, 9, true);
       size_t done = z_x64_emit_jcc32_placeholder(code, 0x83);
-      z_x64_append_u8(code, 0x0f);
-      z_x64_append_u8(code, 0xb6);
-      z_x64_append_u8(code, 0x14);
-      z_x64_append_u8(code, 0x0e);
+      z_x64_emit_movzx_reg32_base_index_u8(code, 2, 6, 1);
       z_x64_append_u8(code, 0x31);
       z_x64_append_u8(code, 0xd0);
       z_x64_append_u8(code, 0x41);
@@ -1158,36 +1153,26 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_BYTE_COPY: {
       if (!value->left || !value->right) return elf_diag(diag, "direct ELF64 byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x5f);
-      z_x64_append_u8(code, 0x59);
-      z_x64_append_u8(code, 0x5e);
+      z_x64_emit_pop_reg64(code, 7);
+      z_x64_emit_pop_reg64(code, 1);
+      z_x64_emit_pop_reg64(code, 6);
       z_x64_emit_cmp_rax_rcx(code, true);
       size_t keep_dst_len = z_x64_emit_jcc32_placeholder(code, 0x86);
       z_x64_emit_mov_rax_from_rcx(code);
       z_x64_patch_rel32(code, keep_dst_len, code->len);
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_append_u8(code, 0x45);
-      z_x64_append_u8(code, 0x31);
-      z_x64_append_u8(code, 0xc0);
+      z_x64_emit_xor_r8d_r8d(code);
       size_t loop = code->len;
-      z_x64_append_u8(code, 0x4c);
-      z_x64_append_u8(code, 0x39);
-      z_x64_append_u8(code, 0xc2);
+      z_x64_emit_cmp_reg_reg(code, 2, 8, true);
       size_t done = z_x64_emit_jcc32_placeholder(code, 0x86);
-      z_x64_append_u8(code, 0x42);
-      z_x64_append_u8(code, 0x8a);
-      z_x64_append_u8(code, 0x1c);
-      z_x64_append_u8(code, 0x06);
-      z_x64_append_u8(code, 0x42);
-      z_x64_append_u8(code, 0x88);
-      z_x64_append_u8(code, 0x1c);
-      z_x64_append_u8(code, 0x07);
+      z_x64_emit_load_reg8_base_index(code, 3, 6, 8);
+      z_x64_emit_store_base_index_reg8(code, 7, 8, 3);
       z_x64_emit_inc_r8(code);
       size_t back = z_x64_emit_jmp32_placeholder(code, 0xe9);
       z_x64_patch_rel32(code, back, loop);
@@ -1198,38 +1183,26 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
     case IR_VALUE_BYTE_VIEW_EQ: {
       if (!value->left || !value->right) return elf_diag(diag, "direct ELF64 byte-view equality requires two byte views", value->line, value->column, "missing byte view");
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->right, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x59);
+      z_x64_emit_pop_reg64(code, 1);
       z_x64_append_u8(code, 0x39);
       z_x64_append_u8(code, 0xc1);
       size_t same_len = z_x64_emit_jcc32_placeholder(code, 0x84);
       z_x64_emit_mov_eax_u32(code, 0);
       size_t end = z_x64_emit_jmp32_placeholder(code, 0xe9);
       z_x64_patch_rel32(code, same_len, code->len);
-      z_x64_append_u8(code, 0x49);
-      z_x64_append_u8(code, 0x89);
-      z_x64_append_u8(code, 0xc2);
+      z_x64_emit_mov_reg_from_rax(code, 10, true);
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x49);
-      z_x64_append_u8(code, 0x89);
-      z_x64_append_u8(code, 0xc0);
+      z_x64_emit_mov_reg_from_rax(code, 8, true);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_r9_from_rax(code);
       z_x64_emit_xor_ecx_ecx(code);
       size_t loop = code->len;
-      z_x64_append_u8(code, 0x4c);
-      z_x64_append_u8(code, 0x39);
-      z_x64_append_u8(code, 0xd1);
+      z_x64_emit_cmp_reg_reg(code, 1, 10, true);
       size_t equal = z_x64_emit_jcc32_placeholder(code, 0x83);
-      z_x64_append_u8(code, 0x41);
-      z_x64_append_u8(code, 0x8a);
-      z_x64_append_u8(code, 0x04);
-      z_x64_append_u8(code, 0x08);
-      z_x64_append_u8(code, 0x41);
-      z_x64_append_u8(code, 0x38);
-      z_x64_append_u8(code, 0x04);
-      z_x64_append_u8(code, 0x09);
+      z_x64_emit_load_reg8_base_index(code, 0, 8, 1);
+      z_x64_emit_cmp_base_index_reg8(code, 9, 1, 0);
       size_t mismatch = z_x64_emit_jcc32_placeholder(code, 0x85);
       z_x64_emit_inc_rcx(code);
       size_t back = z_x64_emit_jmp32_placeholder(code, 0xe9);
@@ -1252,17 +1225,17 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
         return true;
       }
       if (!value->index || !elf_emit_value(code, fun, value->index, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_len(code, fun, value->left, ctx, diag)) return false;
       z_x64_emit_mov_rcx_from_rax(code, false);
-      z_x64_append_u8(code, 0x58);
+      z_x64_emit_pop_rax(code);
       z_x64_emit_cmp_rax_rcx(code, false);
       size_t ok_patch = z_x64_emit_jcc32_placeholder(code, 0x82);
       z_x64_emit_ud2(code);
       z_x64_patch_rel32(code, ok_patch, code->len);
-      z_x64_append_u8(code, 0x50);
+      z_x64_emit_push_rax(code);
       if (!elf_emit_byte_view_ptr(code, fun, value->left, ctx, diag)) return false;
-      z_x64_append_u8(code, 0x59);
+      z_x64_emit_pop_reg64(code, 1);
       z_x64_emit_add_rax_rcx(code, true);
       z_x64_emit_load_eax_ptr_rax_u8(code);
       return true;
@@ -1305,9 +1278,9 @@ static bool elf_emit_instrs(ZBuf *text, const IrFunction *fun, const IrInstr *in
 static bool elf_emit_world_write(ZBuf *text, const IrFunction *fun, const IrInstr *instr, ElfEmitContext *ctx, ZDiag *diag) {
   if (!instr || !instr->value) return elf_diag(diag, "direct ELF64 World write requires bytes", instr ? instr->line : 1, instr ? instr->column : 1, "missing byte view");
   if (!elf_emit_byte_view_ptr(text, fun, instr->value, ctx, diag)) return false;
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   if (!elf_emit_byte_view_len(text, fun, instr->value, ctx, diag)) return false;
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   z_x64_emit_pop_reg64(text, 2);
   z_x64_emit_pop_reg64(text, 6);
   z_x64_append_u8(text, 0xbf);
@@ -1350,11 +1323,11 @@ static bool elf_emit_args_get_to_local(ZBuf *text, const IrFunction *fun, const 
     z_x64_append_u8(text, 0xc7);
     z_x64_append_u8(text, 0x08);
   }
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   elf_emit_strlen_rax_to_ecx(text);
   z_x64_emit_mov_eax_u32(text, 1);
   elf_emit_store_local_slot_reg(text, local, 0, 0, false);
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
   elf_emit_store_local_slot_rax(text, local, 8);
   elf_emit_store_local_slot_reg(text, local, 16, 1, false);
   z_x64_patch_rel32(text, end, text->len);
@@ -1401,39 +1374,24 @@ static bool elf_emit_env_get_to_local(ZBuf *text, const IrFunction *fun, const I
   z_x64_emit_xor_ecx_ecx(text);
 
   size_t compare_loop = text->len;
-  z_x64_append_u8(text, 0x4c);
-  z_x64_append_u8(text, 0x39);
-  z_x64_append_u8(text, 0xd1);
+  z_x64_emit_cmp_reg_reg(text, 1, 10, true);
   size_t key_done = z_x64_emit_jcc32_placeholder(text, 0x83);
-  z_x64_append_u8(text, 0x41);
-  z_x64_append_u8(text, 0x8a);
-  z_x64_append_u8(text, 0x04);
-  z_x64_append_u8(text, 0x09);
-  z_x64_append_u8(text, 0x38);
-  z_x64_append_u8(text, 0x04);
-  z_x64_append_u8(text, 0x0b);
+  z_x64_emit_load_reg8_base_index(text, 0, 9, 1);
+  z_x64_emit_cmp_base_index_reg8(text, 3, 1, 0);
   size_t next = z_x64_emit_jcc32_placeholder(text, 0x85);
   z_x64_emit_inc_rcx(text);
   size_t compare_back = z_x64_emit_jmp32_placeholder(text, 0xe9);
   z_x64_patch_rel32(text, compare_back, compare_loop);
 
   z_x64_patch_rel32(text, key_done, text->len);
-  z_x64_append_u8(text, 0x42);
-  z_x64_append_u8(text, 0x80);
-  z_x64_append_u8(text, 0x3c);
-  z_x64_append_u8(text, 0x13);
-  z_x64_append_u8(text, 0x3d);
+  z_x64_emit_cmp_base_index_u8(text, 3, 10, 0x3d);
   size_t next_after_key = z_x64_emit_jcc32_placeholder(text, 0x85);
-  z_x64_append_u8(text, 0x4a);
-  z_x64_append_u8(text, 0x8d);
-  z_x64_append_u8(text, 0x44);
-  z_x64_append_u8(text, 0x13);
-  z_x64_append_u8(text, 0x01);
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_lea_base_index_disp_reg(text, 0, 3, 10, 1);
+  z_x64_emit_push_rax(text);
   elf_emit_strlen_rax_to_ecx(text);
   z_x64_emit_mov_eax_u32(text, 1);
   elf_emit_store_local_slot_reg(text, local, 0, 0, false);
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
   elf_emit_store_local_slot_rax(text, local, 8);
   elf_emit_store_local_slot_reg(text, local, 16, 1, false);
   size_t end = z_x64_emit_jmp32_placeholder(text, 0xe9);
@@ -1475,7 +1433,7 @@ static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fu
   z_x64_emit_test_rax_rax(text, true);
   size_t open_fail = elf_emit_js_placeholder(text);
 
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   z_x64_emit_mov_rdi_from_rax(text);
   z_x64_append_u8(text, 0x48);
   z_x64_append_u8(text, 0x31);
@@ -1487,14 +1445,14 @@ static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fu
   z_x64_emit_test_rax_rax(text, true);
   size_t tell_fail = elf_emit_js_placeholder(text);
   if (value->right) {
-    z_x64_append_u8(text, 0x50);
+    z_x64_emit_push_rax(text);
     if (!elf_emit_value(text, fun, value->right, ctx, diag)) return false;
-    z_x64_append_u8(text, 0x59);
+    z_x64_emit_pop_reg64(text, 1);
     z_x64_append_u8(text, 0x48);
     z_x64_append_u8(text, 0x39);
     z_x64_append_u8(text, 0xc1);
     size_t size_ok = z_x64_emit_jcc32_placeholder(text, 0x83);
-    z_x64_append_u8(text, 0x58);
+    z_x64_emit_pop_rax(text);
     elf_emit_close_rax_fd(text);
     elf_emit_packed_error_rax(text, IR_ERROR_TOO_LARGE);
     if (!fun->raises) {
@@ -1503,10 +1461,10 @@ static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fu
     elf_emit_epilogue(text, fun, ctx);
     z_x64_patch_rel32(text, size_ok, text->len);
   }
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
 
-  z_x64_append_u8(text, 0x50);
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
+  z_x64_emit_push_rax(text);
   elf_emit_load_local_slot_reg(text, alloc, 0, 6, true);
   elf_emit_load_local_slot_reg(text, alloc, 12, 1, false);
   z_x64_append_u8(text, 0x48);
@@ -1524,23 +1482,23 @@ static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fu
     z_x64_append_u8(text, 0xc2);
     z_x64_patch_rel32(text, keep_capacity, text->len);
   }
-  z_x64_append_u8(text, 0x5f);
+  z_x64_emit_pop_reg64(text, 7);
   z_x64_emit_xor_eax_eax(text);
   z_x64_emit_syscall(text);
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   z_x64_emit_load_rsp_offset_reg(text, 0, 8, true);
   elf_emit_close_rax_fd(text);
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
   z_x64_emit_add_rsp(text, 8);
   z_x64_emit_test_rax_rax(text, true);
   size_t read_fail = elf_emit_js_placeholder(text);
 
-  z_x64_append_u8(text, 0x50);
+  z_x64_emit_push_rax(text);
   elf_emit_load_local_slot_rax(text, alloc, 0);
   elf_emit_load_local_slot_reg(text, alloc, 12, 1, false);
   z_x64_emit_add_rax_rcx(text, true);
   elf_emit_store_local_slot_rax(text, local, 0);
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
   elf_emit_store_local_slot_rax(text, local, 8);
   elf_emit_load_local_slot_reg(text, alloc, 12, 1, false);
   z_x64_emit_add_rax_rcx(text, false);
@@ -1555,7 +1513,7 @@ static bool elf_emit_read_all_or_raise_to_local(ZBuf *text, const IrFunction *fu
   elf_emit_epilogue(text, fun, ctx);
 
   z_x64_patch_rel32(text, tell_fail, text->len);
-  z_x64_append_u8(text, 0x58);
+  z_x64_emit_pop_rax(text);
   elf_emit_close_rax_fd(text);
   elf_emit_packed_error_rax(text, IR_ERROR_IO);
   if (!fun->raises) {
@@ -1652,10 +1610,10 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
           z_x64_append_u32(text, prefix_len + i);
           z_x64_append_u8(text, suffix[i]);
         }
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         z_x64_emit_mov_eax_u32(text, 1);
         elf_emit_store_local_slot_reg(text, local, 0, 0, false);
-        z_x64_append_u8(text, 0x58);
+        z_x64_emit_pop_rax(text);
         elf_emit_store_local_slot_rax(text, local, 8);
         z_x64_emit_mov_eax_u32(text, total_len);
         elf_emit_store_local_slot_reg(text, local, 16, 0, false);
@@ -1673,26 +1631,26 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
         if (!elf_emit_openat_path(text, fun, instr->value->left, 0, 0, ctx, diag)) return false;
         z_x64_emit_test_rax_rax(text, true);
         size_t open_fail = elf_emit_js_placeholder(text);
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         elf_emit_load_local_slot_reg(text, alloc, 0, 6, true);
         elf_emit_load_local_slot_reg(text, alloc, 8, 2, false);
-        z_x64_append_u8(text, 0x5f);
+        z_x64_emit_pop_reg64(text, 7);
         z_x64_emit_xor_eax_eax(text);
         z_x64_emit_syscall(text);
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         elf_emit_load_local_rax(text, fun, instr->value->local_index);
         (void)alloc;
         z_x64_emit_mov_rax_from_rdi(text);
         elf_emit_close_rax_fd(text);
-        z_x64_append_u8(text, 0x58);
+        z_x64_emit_pop_rax(text);
         z_x64_emit_test_rax_rax(text, true);
         size_t read_fail = elf_emit_js_placeholder(text);
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         z_x64_emit_mov_eax_u32(text, 1);
         elf_emit_store_local_slot_reg(text, local, 0, 0, false);
         elf_emit_load_local_slot_reg(text, alloc, 0, 0, true);
         elf_emit_store_local_slot_reg(text, local, 8, 0, true);
-        z_x64_append_u8(text, 0x58);
+        z_x64_emit_pop_rax(text);
         elf_emit_store_local_slot_reg(text, local, 16, 0, false);
         elf_emit_store_local_slot_reg(text, alloc, 12, 0, false);
         size_t end = z_x64_emit_jmp32_placeholder(text, 0xe9);
@@ -1705,14 +1663,14 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
       if (!instr->value || instr->value->kind != IR_VALUE_ALLOC_BYTES || instr->value->local_index >= fun->local_len || fun->locals[instr->value->local_index].type != IR_TYPE_ALLOC) return elf_diag(diag, "direct ELF64 allocation source is invalid", instr->line, instr->column, "invalid allocation");
       const IrLocal *alloc = &fun->locals[instr->value->local_index];
       if (!elf_emit_value(text, fun, instr->value->left, ctx, diag)) return false;
-      z_x64_append_u8(text, 0x50);
+      z_x64_emit_push_rax(text);
       elf_emit_load_local_slot_reg(text, alloc, 12, 1, false);
       elf_emit_load_local_slot_reg(text, alloc, 0, 2, true);
       z_x64_emit_add_rdx_rcx(text, true);
       z_x64_emit_mov_eax_u32(text, 1);
       elf_emit_store_local_slot_reg(text, local, 0, 0, false);
       elf_emit_store_local_slot_reg(text, local, 8, 2, true);
-      z_x64_append_u8(text, 0x58);
+      z_x64_emit_pop_rax(text);
       elf_emit_store_local_slot_reg(text, local, 16, 0, false);
       z_x64_append_u8(text, 0x01);
       z_x64_append_u8(text, 0xc1);
@@ -1737,7 +1695,7 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
         if (!elf_emit_value(text, fun, instr->value, ctx, diag)) return false;
         z_x64_emit_test_rax_rax(text, true);
         size_t fail = elf_emit_js_placeholder(text);
-        z_x64_append_u8(text, 0x50);
+        z_x64_emit_push_rax(text);
         elf_emit_load_local_slot_reg(text, alloc, 12, 1, false);
         z_x64_append_u8(text, 0x01);
         z_x64_append_u8(text, 0xc1);
@@ -1745,12 +1703,12 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
         z_x64_append_u8(text, 0x39);
         z_x64_append_u8(text, 0xd1);
         size_t overflow = z_x64_emit_jcc32_placeholder(text, 0x87);
-        z_x64_append_u8(text, 0x58);
+        z_x64_emit_pop_rax(text);
         elf_emit_maybe_scalar_store_rax(text, local);
         elf_emit_store_local_slot_reg(text, alloc, 12, 1, false);
         size_t end = z_x64_emit_jmp32_placeholder(text, 0xe9);
         z_x64_patch_rel32(text, overflow, text->len);
-        z_x64_append_u8(text, 0x58);
+        z_x64_emit_pop_rax(text);
         z_x64_patch_rel32(text, fail, text->len);
         elf_emit_maybe_scalar_clear(text, local);
         z_x64_patch_rel32(text, end, text->len);
@@ -1774,9 +1732,9 @@ static bool elf_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
     if (instr->array_index >= fun->local_len) return elf_diag(diag, "direct ELF64 indexed store array is out of range", instr->line, instr->column, "invalid array local");
     const IrLocal *local = &fun->locals[instr->array_index];
     if (!elf_emit_bounds_checked_address(text, fun, local, instr->index, ctx, diag)) return false;
-    z_x64_append_u8(text, 0x50);
+    z_x64_emit_push_rax(text);
     if (!elf_emit_value(text, fun, instr->value, ctx, diag)) return false;
-    z_x64_append_u8(text, 0x59);
+    z_x64_emit_pop_reg64(text, 1);
     if (local->element_type == IR_TYPE_U8) {
       z_x64_append_u8(text, 0x88);
       z_x64_append_u8(text, 0x01);

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -1,5 +1,7 @@
 #include "x64_emit.h"
 
+#include <stdlib.h>
+
 void z_x64_append_u8(ZBuf *buf, unsigned value) {
   zbuf_append_char(buf, (char)(value & 0xffu));
 }
@@ -18,6 +20,16 @@ void z_x64_append_u64(ZBuf *buf, uint64_t value) {
 
 static void z_x64_emit_wide_prefix(ZBuf *buf, bool wide) {
   if (wide) z_x64_append_u8(buf, 0x48);
+}
+
+static void z_x64_require_reg(unsigned reg) {
+  if (reg >= 16) abort();
+}
+
+static void z_x64_require_sib_index(unsigned reg) {
+  z_x64_require_reg(reg);
+  // SIB index field 4 without REX.X encodes no index, so rsp cannot be used here.
+  if (reg == 4) abort();
 }
 
 void z_x64_patch_u32(ZBuf *buf, size_t offset, uint32_t value) {
@@ -158,6 +170,8 @@ void z_x64_emit_cmp_rax_rsp_offset(ZBuf *buf, unsigned offset) {
 }
 
 void z_x64_emit_cmp_reg_reg(ZBuf *buf, unsigned lhs, unsigned rhs, bool wide) {
+  z_x64_require_reg(lhs);
+  z_x64_require_reg(rhs);
   unsigned rex = wide ? 0x48 : 0x40;
   if (rhs >= 8) rex |= 0x04;
   if (lhs >= 8) rex |= 0x01;
@@ -167,6 +181,7 @@ void z_x64_emit_cmp_reg_reg(ZBuf *buf, unsigned lhs, unsigned rhs, bool wide) {
 }
 
 void z_x64_emit_mov_reg_from_rax(ZBuf *buf, unsigned reg, bool wide) {
+  z_x64_require_reg(reg);
   unsigned rex = wide ? 0x48 : 0x40;
   if (reg >= 8) rex |= 0x01;
   if (rex != 0x40) z_x64_append_u8(buf, rex);
@@ -174,22 +189,31 @@ void z_x64_emit_mov_reg_from_rax(ZBuf *buf, unsigned reg, bool wide) {
   z_x64_append_u8(buf, 0xc0 | (reg & 7u));
 }
 
-static void z_x64_emit_base_index_reg(ZBuf *buf, unsigned opcode, unsigned reg, unsigned base_reg, unsigned index_reg, bool wide) {
+static void z_x64_emit_base_index_reg(ZBuf *buf, unsigned opcode, unsigned reg, unsigned base_reg, unsigned index_reg, bool wide, bool reg_is_byte) {
+  z_x64_require_reg(reg);
+  z_x64_require_reg(base_reg);
+  z_x64_require_sib_index(index_reg);
+  bool force_rex = !wide && reg_is_byte && reg >= 4 && reg < 8;
   unsigned rex = wide ? 0x48 : 0x40;
   if (reg >= 8) rex |= 0x04;
   if (index_reg >= 8) rex |= 0x02;
   if (base_reg >= 8) rex |= 0x01;
-  if (rex != 0x40) z_x64_append_u8(buf, rex);
+  if (rex != 0x40 || force_rex) z_x64_append_u8(buf, rex);
   z_x64_append_u8(buf, opcode);
-  z_x64_append_u8(buf, ((reg & 7u) << 3) | 0x04);
+  unsigned mod = (base_reg & 7u) == 5 ? 0x40 : 0x00;
+  z_x64_append_u8(buf, mod | ((reg & 7u) << 3) | 0x04);
   z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+  if (mod == 0x40) z_x64_append_u8(buf, 0);
 }
 
 void z_x64_emit_load_reg8_base_index(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg) {
-  z_x64_emit_base_index_reg(buf, 0x8a, dst_reg, base_reg, index_reg, false);
+  z_x64_emit_base_index_reg(buf, 0x8a, dst_reg, base_reg, index_reg, false, true);
 }
 
 void z_x64_emit_movzx_reg32_base_index_u8(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg) {
+  z_x64_require_reg(dst_reg);
+  z_x64_require_reg(base_reg);
+  z_x64_require_sib_index(index_reg);
   unsigned rex = 0x40;
   if (dst_reg >= 8) rex |= 0x04;
   if (index_reg >= 8) rex |= 0x02;
@@ -197,31 +221,38 @@ void z_x64_emit_movzx_reg32_base_index_u8(ZBuf *buf, unsigned dst_reg, unsigned 
   if (rex != 0x40) z_x64_append_u8(buf, rex);
   z_x64_append_u8(buf, 0x0f);
   z_x64_append_u8(buf, 0xb6);
-  z_x64_append_u8(buf, ((dst_reg & 7u) << 3) | 0x04);
+  unsigned mod = (base_reg & 7u) == 5 ? 0x40 : 0x00;
+  z_x64_append_u8(buf, mod | ((dst_reg & 7u) << 3) | 0x04);
   z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+  if (mod == 0x40) z_x64_append_u8(buf, 0);
 }
 
 void z_x64_emit_store_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned src_reg) {
-  z_x64_emit_base_index_reg(buf, 0x88, src_reg, base_reg, index_reg, false);
+  z_x64_emit_base_index_reg(buf, 0x88, src_reg, base_reg, index_reg, false, true);
 }
 
 void z_x64_emit_cmp_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned reg) {
-  z_x64_emit_base_index_reg(buf, 0x38, reg, base_reg, index_reg, false);
+  z_x64_emit_base_index_reg(buf, 0x38, reg, base_reg, index_reg, false, true);
 }
 
 void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned value) {
-  z_x64_emit_base_index_reg(buf, 0x80, 7, base_reg, index_reg, false);
+  if (value > 0xff) abort();
+  z_x64_emit_base_index_reg(buf, 0x80, 7, base_reg, index_reg, false, false);
   z_x64_append_u8(buf, value);
 }
 
 void z_x64_emit_lea_base_index_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned disp) {
+  z_x64_require_reg(dst_reg);
+  z_x64_require_reg(base_reg);
+  z_x64_require_sib_index(index_reg);
   unsigned rex = 0x48;
   if (dst_reg >= 8) rex |= 0x04;
   if (index_reg >= 8) rex |= 0x02;
   if (base_reg >= 8) rex |= 0x01;
   z_x64_append_u8(buf, rex);
   z_x64_append_u8(buf, 0x8d);
-  if (disp == 0) {
+  bool needs_base_disp = (base_reg & 7u) == 5;
+  if (disp == 0 && !needs_base_disp) {
     z_x64_append_u8(buf, ((dst_reg & 7u) << 3) | 0x04);
     z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
   } else if (disp <= 127) {

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -157,6 +157,90 @@ void z_x64_emit_cmp_rax_rsp_offset(ZBuf *buf, unsigned offset) {
   z_x64_emit_rsp_offset_reg(buf, 0x3b, 0, offset, true);
 }
 
+void z_x64_emit_cmp_reg_reg(ZBuf *buf, unsigned lhs, unsigned rhs, bool wide) {
+  unsigned rex = wide ? 0x48 : 0x40;
+  if (rhs >= 8) rex |= 0x04;
+  if (lhs >= 8) rex |= 0x01;
+  if (rex != 0x40) z_x64_append_u8(buf, rex);
+  z_x64_append_u8(buf, 0x39);
+  z_x64_append_u8(buf, 0xc0 | ((rhs & 7u) << 3) | (lhs & 7u));
+}
+
+void z_x64_emit_mov_reg_from_rax(ZBuf *buf, unsigned reg, bool wide) {
+  unsigned rex = wide ? 0x48 : 0x40;
+  if (reg >= 8) rex |= 0x01;
+  if (rex != 0x40) z_x64_append_u8(buf, rex);
+  z_x64_append_u8(buf, 0x89);
+  z_x64_append_u8(buf, 0xc0 | (reg & 7u));
+}
+
+static void z_x64_emit_base_index_reg(ZBuf *buf, unsigned opcode, unsigned reg, unsigned base_reg, unsigned index_reg, bool wide) {
+  unsigned rex = wide ? 0x48 : 0x40;
+  if (reg >= 8) rex |= 0x04;
+  if (index_reg >= 8) rex |= 0x02;
+  if (base_reg >= 8) rex |= 0x01;
+  if (rex != 0x40) z_x64_append_u8(buf, rex);
+  z_x64_append_u8(buf, opcode);
+  z_x64_append_u8(buf, ((reg & 7u) << 3) | 0x04);
+  z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+}
+
+void z_x64_emit_load_reg8_base_index(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg) {
+  z_x64_emit_base_index_reg(buf, 0x8a, dst_reg, base_reg, index_reg, false);
+}
+
+void z_x64_emit_movzx_reg32_base_index_u8(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg) {
+  unsigned rex = 0x40;
+  if (dst_reg >= 8) rex |= 0x04;
+  if (index_reg >= 8) rex |= 0x02;
+  if (base_reg >= 8) rex |= 0x01;
+  if (rex != 0x40) z_x64_append_u8(buf, rex);
+  z_x64_append_u8(buf, 0x0f);
+  z_x64_append_u8(buf, 0xb6);
+  z_x64_append_u8(buf, ((dst_reg & 7u) << 3) | 0x04);
+  z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+}
+
+void z_x64_emit_store_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned src_reg) {
+  z_x64_emit_base_index_reg(buf, 0x88, src_reg, base_reg, index_reg, false);
+}
+
+void z_x64_emit_cmp_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned reg) {
+  z_x64_emit_base_index_reg(buf, 0x38, reg, base_reg, index_reg, false);
+}
+
+void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned value) {
+  z_x64_emit_base_index_reg(buf, 0x80, 7, base_reg, index_reg, false);
+  z_x64_append_u8(buf, value);
+}
+
+void z_x64_emit_lea_base_index_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned disp) {
+  unsigned rex = 0x48;
+  if (dst_reg >= 8) rex |= 0x04;
+  if (index_reg >= 8) rex |= 0x02;
+  if (base_reg >= 8) rex |= 0x01;
+  z_x64_append_u8(buf, rex);
+  z_x64_append_u8(buf, 0x8d);
+  if (disp == 0) {
+    z_x64_append_u8(buf, ((dst_reg & 7u) << 3) | 0x04);
+    z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+  } else if (disp <= 127) {
+    z_x64_append_u8(buf, 0x40 | ((dst_reg & 7u) << 3) | 0x04);
+    z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+    z_x64_append_u8(buf, disp);
+  } else {
+    z_x64_append_u8(buf, 0x80 | ((dst_reg & 7u) << 3) | 0x04);
+    z_x64_append_u8(buf, ((index_reg & 7u) << 3) | (base_reg & 7u));
+    z_x64_append_u32(buf, disp);
+  }
+}
+
+void z_x64_emit_xor_r8d_r8d(ZBuf *buf) {
+  z_x64_append_u8(buf, 0x45);
+  z_x64_append_u8(buf, 0x31);
+  z_x64_append_u8(buf, 0xc0);
+}
+
 void z_x64_emit_push_reg64(ZBuf *buf, unsigned reg) {
   if (reg >= 8) z_x64_append_u8(buf, 0x41);
   z_x64_append_u8(buf, 0x50 + (reg & 7u));

--- a/native/zero-c/src/x64_emit.h
+++ b/native/zero-c/src/x64_emit.h
@@ -23,6 +23,15 @@ void z_x64_emit_mov_rsp_offset_u32(ZBuf *buf, unsigned offset, uint32_t value, b
 void z_x64_emit_inc_rsp_offset64(ZBuf *buf, unsigned offset);
 void z_x64_emit_add_rax_rsp_offset(ZBuf *buf, unsigned offset);
 void z_x64_emit_cmp_rax_rsp_offset(ZBuf *buf, unsigned offset);
+void z_x64_emit_cmp_reg_reg(ZBuf *buf, unsigned lhs, unsigned rhs, bool wide);
+void z_x64_emit_mov_reg_from_rax(ZBuf *buf, unsigned reg, bool wide);
+void z_x64_emit_load_reg8_base_index(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg);
+void z_x64_emit_movzx_reg32_base_index_u8(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg);
+void z_x64_emit_store_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned src_reg);
+void z_x64_emit_cmp_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned reg);
+void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned value);
+void z_x64_emit_lea_base_index_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned disp);
+void z_x64_emit_xor_r8d_r8d(ZBuf *buf);
 void z_x64_emit_push_reg64(ZBuf *buf, unsigned reg);
 void z_x64_emit_pop_reg64(ZBuf *buf, unsigned reg);
 void z_x64_emit_push_rax(ZBuf *buf);

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.1.3",
   "engines": {
-    "node": ">=22"
+    "node": ">=24"
   },
   "scripts": {
     "check": "pnpm --silent run native:smoke",

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -1045,7 +1045,7 @@ const backendFormats = {
       ["native/zero-c/src/emit_elf64.c", elfX64Source],
       ["native/zero-c/src/emit_coff.c", coffX64Source],
     ]
-      .filter(([, text]) => /\bz_x64_append_u8\s*\(\s*(?:code|text)\s*,\s*0x5[089a-f]\s*\)/i.test(text))
+      .filter(([, text]) => /\bz_x64_append_u8\s*\(\s*(?:code|text)\s*,\s*0x5[0-9a-f]\s*\)/i.test(text))
       .map(([path]) => path),
   },
   aarch64: {

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -39,9 +39,9 @@ const fileBudgets = {
   "native/zero-c/src/emit_macho64.c": { maxLines: 1400, maxStrcmpCalls: 2 },
   "native/zero-c/src/macho_emit_state.c": { maxLines: 210, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
-  "native/zero-c/src/emit_elf64.c": { maxLines: 2175, maxStrcmpCalls: 3 },
+  "native/zero-c/src/emit_elf64.c": { maxLines: 2130, maxStrcmpCalls: 3 },
   "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 205, maxStrcmpCalls: 1 },
-  "native/zero-c/src/emit_coff.c": { maxLines: 905, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff.c": { maxLines: 900, maxStrcmpCalls: 1 },
   "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 32 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1300, maxStrcmpCalls: 0 },
   "native/zero-c/src/mir_verify.h": { maxLines: 50, maxStrcmpCalls: 0 },
@@ -54,14 +54,14 @@ const fileBudgets = {
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/unify.c": { maxLines: 500, maxStrcmpCalls: 14 },
   "native/zero-c/src/unify.h": { maxLines: 75, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.c": { maxLines: 505, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.h": { maxLines: 80, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.c": { maxLines: 590, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.h": { maxLines: 95, maxStrcmpCalls: 0 },
 };
 
 const knownLargeFunctionLimits = new Map([
   ["native/zero-c/src/ir.c|static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunction *fun, const Expr *expr, IrValue **out) {", 1484],
   ["native/zero-c/src/checker.c|static bool check_expr_expected(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope, ZDiag *diag, const char *expected) {", 1170],
-  ["native/zero-c/src/emit_elf64.c|static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *value, ElfEmitContext *ctx, ZDiag *diag) {", 805],
+  ["native/zero-c/src/emit_elf64.c|static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *value, ElfEmitContext *ctx, ZDiag *diag) {", 770],
   ["native/zero-c/src/main.c|int main(int argc, char **argv) {", 924],
   ["native/zero-c/src/emit_macho64.c|bool z_emit_macho64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {", 157],
   ["native/zero-c/src/emit_elf64.c|bool z_emit_elf64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {", 125],
@@ -73,7 +73,7 @@ const knownLargeFunctionLimits = new Map([
   ["native/zero-c/src/checker.c|static const char *expr_type(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope) {", 205],
   ["native/zero-c/src/emit_macho64.c|static bool macho_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, bool restore_process_args, MachOEmitContext *ctx, ZDiag *diag) {", 193],
   ["native/zero-c/src/checker.c|static bool collect_return_value_provenance_from_stmt_vec(CheckContext *ctx, const Program *program, const Function *fun, const StmtVec *body, Scope *scope, GenericBinding *bindings, size_t binding_len, ValueProvenance *out, bool *may_return, bool *complete) {", 192],
-  ["native/zero-c/src/emit_coff.c|static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {", 160],
+  ["native/zero-c/src/emit_coff.c|static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {", 155],
   ["native/zero-c/src/row_syntax.c|ZRowTokenVec z_row_tokenize(const char *source, ZDiag *diag) {", 177],
   ["native/zero-c/src/ir.c|static bool ir_lower_stmt_to_vec(const Program *program, IrProgram *ir, IrFunction *mir_fun, const Stmt *stmt, IrInstr **out_items, size_t *out_len, size_t *out_cap, bool *saw_return) {", 172],
   ["native/zero-c/src/emit_coff.c|static bool coff_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, CoffEmitContext *ctx, ZDiag *diag) {", 155],
@@ -686,6 +686,12 @@ function budgetViolations(files, allLargeFunctions, stdlib, backendFormats) {
       paths: backendFormats.x64.formatFilesWithLocalEncodingPrimitives,
     });
   }
+  if (backendFormats.x64.formatFilesWithRawStackRegisterBytes.length > 0) {
+    violations.push({
+      kind: "x64-stack-register-byte-in-format-file",
+      paths: backendFormats.x64.formatFilesWithRawStackRegisterBytes,
+    });
+  }
   if (!backendFormats.aarch64.sharedEncodingPrimitives ||
       !backendFormats.aarch64.elfUsesSharedEncodingPrimitives ||
       !backendFormats.aarch64.machoUsesSharedEncodingPrimitives) {
@@ -867,6 +873,15 @@ const backendFormats = {
       /\bz_x64_emit_inc_rsp_offset64\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_add_rax_rsp_offset\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_cmp_rax_rsp_offset\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_cmp_reg_reg\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_mov_reg_from_rax\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_load_reg8_base_index\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_movzx_reg32_base_index_u8\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_store_base_index_reg8\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_cmp_base_index_reg8\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_cmp_base_index_u8\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_lea_base_index_disp_reg\s*\(/.test(x64EmitSource) &&
+      /\bz_x64_emit_xor_r8d_r8d\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_jcc32_placeholder\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_prologue\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_epilogue\s*\(/.test(x64EmitSource) &&
@@ -929,6 +944,15 @@ const backendFormats = {
       /\bz_x64_emit_inc_rsp_offset64\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_add_rax_rsp_offset\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_cmp_rax_rsp_offset\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_cmp_reg_reg\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_mov_reg_from_rax\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_load_reg8_base_index\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_movzx_reg32_base_index_u8\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_store_base_index_reg8\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_cmp_base_index_reg8\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_cmp_base_index_u8\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_lea_base_index_disp_reg\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_xor_r8d_r8d\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_jcc32_placeholder\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_prologue\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_epilogue\s*\(/.test(elfX64Source) &&
@@ -991,6 +1015,7 @@ const backendFormats = {
       /\bz_x64_emit_push_rax\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_pop_rax\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_mov_rcx_from_rax\s*\(/.test(coffX64Source) &&
+      /\bz_x64_emit_mov_reg_from_rax\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_mov_eax_from_ecx\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_shl_rcx_imm8\s*\(/.test(coffX64Source) &&
       /\bz_x64_emit_load_eax_ptr_rax_u8\s*\(/.test(coffX64Source) &&
@@ -1015,6 +1040,12 @@ const backendFormats = {
       ["native/zero-c/src/emit_coff.c", coffX64Source],
     ]
       .filter(([, text]) => /\bstatic\s+(?:void|size_t)\s+(?:z_x64_|elf_append_u(?:8|32|64)|elf_append_bytes|elf_append_zeros|elf_align|elf_pad_to|append_u8|append_u32le|append_bytes)\b/.test(text))
+      .map(([path]) => path),
+    formatFilesWithRawStackRegisterBytes: [
+      ["native/zero-c/src/emit_elf64.c", elfX64Source],
+      ["native/zero-c/src/emit_coff.c", coffX64Source],
+    ]
+      .filter(([, text]) => /\bz_x64_append_u8\s*\(\s*(?:code|text)\s*,\s*0x5[089a-f]\s*\)/i.test(text))
       .map(([path]) => path),
   },
   aarch64: {

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -54,7 +54,7 @@ const fileBudgets = {
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/unify.c": { maxLines: 500, maxStrcmpCalls: 14 },
   "native/zero-c/src/unify.h": { maxLines: 75, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.c": { maxLines: 590, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.c": { maxLines: 610, maxStrcmpCalls: 0 },
   "native/zero-c/src/x64_emit.h": { maxLines: 95, maxStrcmpCalls: 0 },
 };
 


### PR DESCRIPTION
- Share x64 indexed byte and stack register encodings
- Tighten compiler metrics for direct x64 emitters
- Require Node 24 across package manifests