### PR TITLE
Document internal C API contracts and IR string equality conventions

### DIFF
--- a/native/zero-c/docs/internal-c-contracts.md
+++ b/native/zero-c/docs/internal-c-contracts.md
@@ -1,0 +1,158 @@
+# Internal C Contracts
+
+This document defines the first-pass contract vocabulary for internal C APIs in
+`native/zero-c`. It documents current behavior where source inspection supports
+it. It does not change signatures, ownership, IR representation, parser,
+checker, lowering, or emitter behavior.
+
+## Vocabulary
+
+Use these tags in comments near boundary structs and functions:
+
+- `in`: borrowed input. Callee may read during the call.
+- `inout`: borrowed input/output. Callee may read and mutate during the call.
+- `out`: borrowed output slot. Callee writes the result as documented.
+- `opt out`: nullable output slot. Callee writes only when the pointer is not
+  `NULL`.
+- `sink`: callee takes ownership from caller.
+- `return owned`: caller receives ownership and must release it with the named
+  free function or `free()`.
+- `return borrowed`: caller must not free the returned pointer.
+- `retains`: callee stores the pointer or data beyond the call.
+- `no-retain`: callee does not store the pointer beyond return.
+- `nullable`: pointer may be `NULL`.
+- `non-null`: pointer must not be `NULL`.
+- `alias ok`: parameters may alias.
+- `no alias`: parameters must not alias.
+
+`const T *` means read-only through that pointer. It does not, by itself,
+document nullability, retention, ownership, or aliasing.
+
+## Comment Pattern
+
+Prefer short blocks near public/internal boundaries:
+
+```c
+// contract:
+// - input: in, non-null, no-retain
+// - out: out, non-null, written on success
+// - diag: opt out, no-retain
+// - returns: false on validation failure, true on success
+```
+
+When current behavior is unclear, prefer listing it in the follow-up section of
+this document. Use `TBD(contract)` in source comments only when local reasoning
+would otherwise be misleading.
+
+## Diagnostics
+
+Diagnostic pointers such as `ZDiag *diag` are diagnostic output channels unless
+a local comment says otherwise.
+
+- `diag`: normally `out` or `opt out` depending on implementation support.
+- Diagnostic buffers are written by the callee when reporting failure details.
+- Retention of diagnostic pointer arguments should be documented at each
+  boundary. Do not infer it from the type alone.
+
+## Parser And Row Syntax Boundary
+
+Observed from `row_syntax.c` and `ast.c`:
+
+- `z_row_tokenize` returns a `ZRowTokenVec` by value.
+- `z_free_row_tokens` releases token vector storage and token text.
+- `z_row_parse_layout` fills a caller-provided `ZRowTree`.
+- `z_free_row_tree` releases row tree storage.
+- `z_parse_row` returns a `Program` by value.
+- `z_free_program` releases `Program` storage and owned strings allocated by the
+  parser.
+
+Boundary convention for these APIs:
+
+- Source text and token/tree inputs are `in`, `non-null`, and read-only unless a
+  function-specific comment says otherwise.
+- Returned `ZRowTokenVec` and `Program` values are `return owned`.
+- Caller-provided `ZRowTree *`, `ZRowSyntaxFacts *`, and similar result slots
+  are `out` or `inout` as documented on the prototype.
+
+## Checker Boundary
+
+Observed from `checker.c`:
+
+- `z_check_program` takes `const Program *program`, but checker internals cast
+  selected expression nodes to annotate fields such as `Expr.resolved_type`,
+  `Expr.text`, `Expr.bool_value`, and `Expr.moves_ownership`.
+- The checker should therefore be treated as validating and annotating the AST,
+  not as a purely read-only pass, until this contract is changed.
+
+Boundary convention:
+
+- `program`: `inout` at the semantic level, `non-null`, no-retain. The C type is
+  `const Program *`, but current implementation mutates selected nested AST
+  fields.
+- `diag`: `out`, non-null in current callers unless a specific call path proves
+  nullable support.
+- `returns`: `true` when validation succeeds, `false` when a diagnostic is
+  reported.
+
+## IR Boundary
+
+Observed from `ir.c`:
+
+- `z_lower_program_with_source` returns `IrProgram` by value.
+- It duplicates many parser/checker strings with `z_strdup` while constructing
+  `ir.program`, `IrFunction`, and `IrLocal` values. It also copies read-only
+  data segment bytes.
+- `z_lower_program` delegates to `z_lower_program_with_source(program, NULL)`.
+- `z_free_ir_program` releases direct IR allocations and then calls
+  `z_free_program(&program->program)`.
+
+Boundary convention:
+
+- `program`: `in`, non-null, read during lowering. Current lowering clones many
+  retained AST strings instead of retaining the caller's `Program` pointer.
+- `input`: `in`, nullable, read during lowering for source metadata when
+  present.
+- `return owned`: returned `IrProgram` must be released with
+  `z_free_ir_program`.
+
+## IR String Value Matching
+
+Current observed behavior in `ir.c`:
+
+- Type and symbol decisions use `strcmp` and `strncmp` in helpers such as
+  `ir_type_kind`, `ir_std_http_error_code`, `ir_error_code_for_name`,
+  `ir_find_shape`, `ir_find_enum`, `ir_shape_field_info`,
+  `ir_shape_field_storage_info`, `ir_function_find_local`,
+  `ir_find_source_function`, and `ir_find_function_index`.
+- These call sites perform string value matching. They do not check pointer
+  identity.
+- This document does not claim that strings are interned, canonicalized, or
+  globally owned. Source comments should make only local, source-backed claims.
+
+## Emitter Boundary
+
+Emitter functions named `z_emit_*_from_ir` take an IR program and write output
+buffers.
+
+Boundary convention:
+
+- `program`: `in`, non-null, read-only, no-retain.
+- `out`: `inout`, non-null. Emitters append bytes to caller-owned `ZBuf`.
+- `diag`: `out`, non-null unless a function-specific comment proves nullable
+  behavior.
+- `returns`: `true` on emission success, `false` on failure with diagnostic
+  detail.
+
+## Follow-Up Questions
+
+- Which diagnostic APIs permit `diag == NULL`, and which require non-null?
+- Which output slots are written on failure versus success only?
+- Should checker AST annotation be reflected in the public C type of
+  `z_check_program`, or documented as an intentional exception?
+- Which `SourceInput` arrays own their strings, and which point into other
+  storage?
+- Which internal helpers retain strings, duplicate them, or return borrowed
+  pointers?
+- Should future IR use canonical symbol or type handles instead of repeated
+  string value matching?
+- Which APIs have aliasing restrictions between input and output parameters?

--- a/native/zero-c/docs/internal-c-contracts.md
+++ b/native/zero-c/docs/internal-c-contracts.md
@@ -1,158 +1,556 @@
 # Internal C Contracts
 
-This document defines the first-pass contract vocabulary for internal C APIs in
-`native/zero-c`. It documents current behavior where source inspection supports
-it. It does not change signatures, ownership, IR representation, parser,
-checker, lowering, or emitter behavior.
+## Purpose
 
-## Vocabulary
+This document records source-backed contracts for internal C APIs in
+`native/zero-c`.
 
-Use these tags in comments near boundary structs and functions:
+Scope:
+
+- Documents current behavior only.
+- Makes no semantic changes.
+- Makes no signature changes.
+- Makes no claim that is not supported by current source inspection.
+- Captures unresolved contract debt where source evidence is incomplete.
+
+This is a documentation contract. It does not authorize refactors, symbol IDs,
+IR representation changes, parser changes, checker changes, lowering changes,
+emitter changes, or compiler semantic changes.
+
+## Contract Vocabulary
+
+Use these tags in boundary comments:
 
 - `in`: borrowed input. Callee may read during the call.
 - `inout`: borrowed input/output. Callee may read and mutate during the call.
 - `out`: borrowed output slot. Callee writes the result as documented.
-- `opt out`: nullable output slot. Callee writes only when the pointer is not
+- `opt out`: nullable output slot. Callee writes only when pointer is not
   `NULL`.
 - `sink`: callee takes ownership from caller.
-- `return owned`: caller receives ownership and must release it with the named
-  free function or `free()`.
-- `return borrowed`: caller must not free the returned pointer.
-- `retains`: callee stores the pointer or data beyond the call.
-- `no-retain`: callee does not store the pointer beyond return.
+- `return owned`: caller receives ownership and must release it with named free
+  function or `free()`.
+- `return borrowed`: caller must not free returned pointer.
+- `retains`: callee stores pointer or data beyond call return.
+- `no-retain`: callee does not store pointer beyond call return.
 - `nullable`: pointer may be `NULL`.
 - `non-null`: pointer must not be `NULL`.
 - `alias ok`: parameters may alias.
 - `no alias`: parameters must not alias.
 
-`const T *` means read-only through that pointer. It does not, by itself,
-document nullability, retention, ownership, or aliasing.
+`const T *` means read-only through that pointer. It does not by itself define
+nullability, retention, ownership, mutation through nested pointers, or aliasing.
 
 ## Comment Pattern
 
-Prefer short blocks near public/internal boundaries:
+Preferred source comment shape:
 
 ```c
 // contract:
-// - input: in, non-null, no-retain
+// - input: in, non-null, read-only, no-retain
 // - out: out, non-null, written on success
 // - diag: opt out, no-retain
 // - returns: false on validation failure, true on success
 ```
 
-When current behavior is unclear, prefer listing it in the follow-up section of
-this document. Use `TBD(contract)` in source comments only when local reasoning
-would otherwise be misleading.
+If source evidence is incomplete, do not guess. Record a debt ID in this
+document.
 
-## Diagnostics
+## Pointer Effects
 
-Diagnostic pointers such as `ZDiag *diag` are diagnostic output channels unless
-a local comment says otherwise.
+Pointer effects are read as follows:
 
-- `diag`: normally `out` or `opt out` depending on implementation support.
-- Diagnostic buffers are written by the callee when reporting failure details.
-- Retention of diagnostic pointer arguments should be documented at each
-  boundary. Do not infer it from the type alone.
+- Pointer parameters without an `out` or `inout` tag are borrowed inputs.
+- Output slots are caller-owned storage passed to the callee for writes.
+- A function that appends to `ZBuf *out` uses `inout`: the buffer object and its
+  owned `data` field may change.
+- A destructor or free function consumes contents of an object but usually does
+  not consume the object pointer itself. It is modeled as `inout` and leaves the
+  object reset where source proves reset behavior.
+- `retains` requires source evidence of pointer storage beyond return. Without
+  that evidence, document `no-retain` or unresolved status.
+- `sink` requires source evidence that the callee takes ownership of a caller
+  allocation without duplicating it.
 
-## Parser And Row Syntax Boundary
+## Boundary Sections
 
-Observed from `row_syntax.c` and `ast.c`:
+### Diagnostics
 
-- `z_row_tokenize` returns a `ZRowTokenVec` by value.
-- `z_free_row_tokens` releases token vector storage and token text.
-- `z_row_parse_layout` fills a caller-provided `ZRowTree`.
-- `z_free_row_tree` releases row tree storage.
-- `z_parse_row` returns a `Program` by value.
-- `z_free_program` releases `Program` storage and owned strings allocated by the
-  parser.
+Diagnostic boundary type: `ZDiag`.
 
-Boundary convention for these APIs:
+Observed source:
 
-- Source text and token/tree inputs are `in`, `non-null`, and read-only unless a
-  function-specific comment says otherwise.
-- Returned `ZRowTokenVec` and `Program` values are `return owned`.
-- Caller-provided `ZRowTree *`, `ZRowSyntaxFacts *`, and similar result slots
-  are `out` or `inout` as documented on the prototype.
+- `diag_io` in `fs.c` writes `diag->path = path` without duplicating `path`.
+- `z_resolve_package_metadata` stores duplicated `manifest_path` in some
+  diagnostic paths with `z_strdup`.
+- `z_map_source_diag` rewrites `diag->path` and borrow trace declaration paths
+  to pointers from `SourceInput.source_line_paths`.
+- Emitter and checker helpers write diagnostic struct fields and do not retain
+  the `ZDiag *` pointer after return.
 
-## Checker Boundary
+Contract:
 
-Observed from `checker.c`:
+- `ZDiag *diag` is an output channel at parser, checker, lowering, filesystem,
+  and emitter boundaries.
+- Most public declarations currently use `diag` as `out, non-null`.
+- Some helper paths guard `diag == NULL`; nullability is not proven uniformly at
+  public boundaries.
+- `diag->path` and `ZBorrowTrace.binding_decl_path` are borrowed unless a local
+  producer documents ownership.
+- Caller must not infer that diagnostic path pointers are heap-owned.
 
-- `z_check_program` takes `const Program *program`, but checker internals cast
-  selected expression nodes to annotate fields such as `Expr.resolved_type`,
-  `Expr.text`, `Expr.bool_value`, and `Expr.moves_ownership`.
-- The checker should therefore be treated as validating and annotating the AST,
-  not as a purely read-only pass, until this contract is changed.
+Unresolved:
 
-Boundary convention:
+- `CONTRACT-DIAG-001` tracks public `diag` nullability and diagnostic pointer
+  ownership consistency.
 
-- `program`: `inout` at the semantic level, `non-null`, no-retain. The C type is
-  `const Program *`, but current implementation mutates selected nested AST
+### Parser And Row Syntax
+
+Parser boundary files are `row_syntax.c` and `ast.c`.
+
+Observed source:
+
+- `z_row_tokenize` returns `ZRowTokenVec` by value. Token text is allocated with
+  `z_strdup`.
+- `z_free_row_tokens` frees each token text and token array, then resets vector
   fields.
-- `diag`: `out`, non-null in current callers unless a specific call path proves
-  nullable support.
-- `returns`: `true` when validation succeeds, `false` when a diagnostic is
-  reported.
+- `z_row_analyze_layout` zeroes `ZRowSyntaxFacts` when the pointer is present.
+- `z_row_parse_layout` zeroes caller-provided `ZRowTree` and fills owned node
+  and trivia arrays.
+- `z_free_row_tree` frees row tree arrays and resets fields.
+- `z_parse_row` returns `Program` by value. Parser-built AST strings are
+  duplicated or builder-owned.
+- `z_free_program` releases owned AST strings, expression trees, statement
+  trees, and vector storage.
+- `z_format_row_layout` returns an owned string from `ZBuf` data or `z_strdup`.
 
-## IR Boundary
+Contract:
 
-Observed from `ir.c`:
+- Source text and token/tree inputs are `in, non-null, read-only, no-retain`
+  unless a specific declaration states nullable behavior.
+- `ZRowSyntaxFacts *facts` is `out, nullable` by source behavior.
+- `ZRowTree *tree` is `out, non-null`; tree content is owned by caller after
+  success and released with `z_free_row_tree`.
+- `ZRowTokenVec` and `Program` return values are `return owned`.
+- `z_format_row_layout` is `return owned`; caller frees with `free()`.
+- Parser APIs do not prove aliasing safety between token/tree inputs and output
+  slots.
+
+Unresolved:
+
+- `CONTRACT-PARSE-001` tracks failure-state guarantees for partially filled
+  parser output slots.
+
+### Checker
+
+Checker boundary file is `checker.c`.
+
+Observed source:
+
+- `z_check_program` takes `const Program *program`.
+- Checker internals cast selected `const Expr *` and `const Stmt *` values to
+  mutate semantic annotations.
+- Mutated fields include `Expr.resolved_type`, `Expr.checked_type_args`,
+  `Expr.text`, `Expr.bool_value`, `Expr.moves_ownership`, and
+  `Stmt.resolved_type`.
+- Checker scope and provenance structures duplicate strings for internal
+  storage and free them before return.
+- `z_set_check_target` stores a borrowed `const ZTargetInfo *` in static
+  process state.
+
+Contract:
+
+- `z_check_program` treats `program` as `inout` at the semantic level, even
+  though public C type is `const Program *`.
+- Checker does not retain `Program *` beyond the call.
+- Checker may retain the target pointer set by `z_set_check_target` until a
+  later call replaces it.
+- `diag` is `out, non-null` at the public checker boundary.
+
+Unresolved:
+
+- `CONTRACT-CHECK-001` tracks whether checker AST annotation should remain a
+  documented exception or be reflected in future API types.
+
+### IR Lowering
+
+IR boundary file is `ir.c`.
+
+Observed source:
 
 - `z_lower_program_with_source` returns `IrProgram` by value.
-- It duplicates many parser/checker strings with `z_strdup` while constructing
-  `ir.program`, `IrFunction`, and `IrLocal` values. It also copies read-only
-  data segment bytes.
+- Lowering clones retained `Program` strings with `z_strdup` and clones AST
+  expression/statement trees.
+- Lowering copies read-only data segment bytes into `IrDataSegment.bytes`.
 - `z_lower_program` delegates to `z_lower_program_with_source(program, NULL)`.
-- `z_free_ir_program` releases direct IR allocations and then calls
+- `z_free_ir_program` releases direct IR allocations and calls
   `z_free_program(&program->program)`.
+- Lookup helpers return borrowed pointers into input `Program` or `IrProgram`.
 
-Boundary convention:
+Contract:
 
-- `program`: `in`, non-null, read during lowering. Current lowering clones many
-  retained AST strings instead of retaining the caller's `Program` pointer.
-- `input`: `in`, nullable, read during lowering for source metadata when
-  present.
-- `return owned`: returned `IrProgram` must be released with
-  `z_free_ir_program`.
+- `program`: `in, non-null, read-only during lowering, no-retain`.
+- `input`: `in, nullable, read-only during lowering, no-retain`.
+- Return value is `return owned`; release with `z_free_ir_program`.
+- IR-owned strings and cloned AST strings are duplicated where source uses
+  `z_strdup`.
+- IR does not prove string interning or canonical symbolic identity.
 
-## IR String Value Matching
+Unresolved:
 
-Current observed behavior in `ir.c`:
+- `CONTRACT-IR-001` tracks incomplete helper-by-helper ownership comments for
+  internal lowering helpers that allocate temporary strings.
 
-- Type and symbol decisions use `strcmp` and `strncmp` in helpers such as
-  `ir_type_kind`, `ir_std_http_error_code`, `ir_error_code_for_name`,
-  `ir_find_shape`, `ir_find_enum`, `ir_shape_field_info`,
-  `ir_shape_field_storage_info`, `ir_function_find_local`,
-  `ir_find_source_function`, and `ir_find_function_index`.
-- These call sites perform string value matching. They do not check pointer
-  identity.
-- This document does not claim that strings are interned, canonicalized, or
-  globally owned. Source comments should make only local, source-backed claims.
+### Emitters
 
-## Emitter Boundary
+Emitter boundary files currently include target-specific files such as
+`emit_elf64.c`, `emit_elf_aarch64.c`, `emit_macho64.c`, and `emit_coff.c`.
+There is no `native/zero-c/src/emit.c` file in the inspected tree.
 
-Emitter functions named `z_emit_*_from_ir` take an IR program and write output
-buffers.
+Observed source:
 
-Boundary convention:
+- Public emitter functions are named `z_emit_*_from_ir`.
+- Emitters validate `IrProgram` metadata and append object or executable bytes
+  to `ZBuf *out`.
+- Emitters write diagnostics and return `false` on failure.
 
-- `program`: `in`, non-null, read-only, no-retain.
-- `out`: `inout`, non-null. Emitters append bytes to caller-owned `ZBuf`.
-- `diag`: `out`, non-null unless a function-specific comment proves nullable
-  behavior.
-- `returns`: `true` on emission success, `false` on failure with diagnostic
-  detail.
+Contract:
 
-## Follow-Up Questions
+- `program`: `in, non-null, read-only, no-retain`.
+- `out`: `inout, non-null`; emitter appends bytes to caller-owned `ZBuf`.
+- `diag`: `out, non-null` unless a specific emitter helper proves nullable
+  support.
+- Stack query helpers return sizes and do not mutate the program.
 
-- Which diagnostic APIs permit `diag == NULL`, and which require non-null?
-- Which output slots are written on failure versus success only?
-- Should checker AST annotation be reflected in the public C type of
-  `z_check_program`, or documented as an intentional exception?
-- Which `SourceInput` arrays own their strings, and which point into other
-  storage?
-- Which internal helpers retain strings, duplicate them, or return borrowed
-  pointers?
-- Should future IR use canonical symbol or type handles instead of repeated
-  string value matching?
-- Which APIs have aliasing restrictions between input and output parameters?
+Unresolved:
+
+- Emitter aliasing between `program`, `out`, and `diag` is not documented by
+  source comments. This is covered by `CONTRACT-ALIAS-001`.
+
+### Buffers And Output Builders
+
+Buffer boundary type: `ZBuf`.
+
+Observed source:
+
+- `zbuf_init` initializes `data = NULL`, `len = 0`, and `cap = 0`.
+- `zbuf_append_char`, `zbuf_append`, and `zbuf_appendf` grow `buf->data`.
+- `zbuf_append` reads from `text` until NUL.
+- `zbuf_free` frees `buf->data` and resets fields.
+- Several helpers return `buf.data` directly as an owned string.
+
+Contract:
+
+- `ZBuf *buf`: `inout, non-null`.
+- Append inputs are `in, non-null, read-only, no-retain`.
+- `ZBuf.data` is owned by the buffer after initialization and append calls.
+- Returning `buf.data` transfers ownership to the caller as `return owned`.
+- `zbuf_free` releases owned buffer data and resets the buffer.
+
+Unresolved:
+
+- Alias behavior when `text` aliases `buf->data` is not proven.
+
+### Source Input Lifetime
+
+Source boundary type: `SourceInput`.
+
+Observed source:
+
+- `z_resolve_package_metadata` fills `SourceInput metadata` with duplicated
+  package and dependency strings, assigns it to `*out`, and expects
+  `z_free_source` to release fields.
+- `z_free_source` frees source strings, path arrays, import arrays, symbol
+  arrays, dependency fields, and related vectors.
+- `z_map_source_diag` assigns diagnostic paths from `SourceInput` arrays without
+  duplicating them.
+- `ir_stable_id_for_source_function` reads `SourceInput.symbol_names`,
+  `symbol_kinds`, and `symbol_modules` to build an owned stable ID string.
+
+Contract:
+
+- `SourceInput *out` produced by metadata resolution is `out, non-null` and
+  owned by caller after success.
+- `SourceInput *input` passed to diagnostic mapping and lowering is
+  `in, nullable, read-only, no-retain`.
+- Diagnostic paths mapped from `SourceInput` are borrowed and valid only while
+  corresponding `SourceInput` storage remains alive.
+
+Unresolved:
+
+- `CONTRACT-SRC-001` tracks exact ownership for all `SourceInput` arrays when
+  populated outside `z_resolve_package_metadata`.
+
+## Contract Coverage Table
+
+| API or struct | Contract status | Ownership status | Mutation status | Retention status | Source evidence | Unresolved questions |
+| --- | --- | --- | --- | --- | --- | --- |
+| `ZBuf` | Documented | Owns `data` after init/append; freed by `zbuf_free` | `inout` builder | No pointer retention for append text | `fs.c` `zbuf_init`, append, free | Alias behavior when appended text aliases buffer data |
+| `ZDiag` | Partial | Path fields are borrowed unless producer duplicates | `out` diagnostic record | Producers do not retain `ZDiag *` | `fs.c` `diag_io`, `z_map_source_diag`; checker/emitter writes | `CONTRACT-DIAG-001` |
+| `ZRowTokenVec` | Documented | Return owned; token text freed by `z_free_row_tokens` | Tokenizer fills returned value | No-retain for source text | `row_syntax.c` `z_row_tokenize`, `z_free_row_tokens` | Failure-state token ownership on partial diagnostics |
+| `ZRowTree` | Documented | Caller owns arrays after layout parse | `out` tree slot reset and filled | No-retain for token vector | `row_syntax.c` `z_row_parse_layout`, `z_free_row_tree` | `CONTRACT-PARSE-001` |
+| `ZRowSyntaxFacts` | Documented | Caller-owned struct | `out, nullable`; zeroed when present | No-retain | `row_syntax.c` `z_row_analyze_layout` | None known |
+| `Program` | Documented | Parser returns owned AST; `z_free_program` frees nested strings and nodes | Checker annotates selected nested fields | Parser does not retain token/tree inputs | `row_syntax.c` `z_parse_row`; `ast.c` `z_free_program`; `checker.c` casts | `CONTRACT-CHECK-001` |
+| `SourceInput` | Partial | Resolver-produced value is caller-owned and released by `z_free_source` | Metadata resolver writes `out`; diag mapper reads input and mutates diag | `z_map_source_diag` returns borrowed paths through diag | `fs.c` `z_resolve_package_metadata`, `z_free_source`, `z_map_source_diag` | `CONTRACT-SRC-001` |
+| `ZManifest` | Documented | Parser fills owned strings and arrays; freed by `z_free_manifest` | `out` is zeroed then filled | No-retain for manifest JSON text | `fs.c` `z_parse_manifest_json`, `z_free_manifest` | Failure cleanup expectations if parse stops early |
+| `IrValue` | Documented | Owned by containing instruction or value tree | Mutated during construction only | No borrowed child ownership | `zero.h` comments; `ir.c` `ir_free_value` | None known |
+| `IrInstr` | Documented | Owned by containing `IrFunction` instruction array | Mutated during construction only | Owns nested instruction arrays | `zero.h` comments; `ir.c` `ir_free_instrs` | None known |
+| `IrLocal` | Documented | Owned by containing `IrFunction`; name and shape name duplicated | Filled during lowering | No-retain for source AST names | `ir.c` `ir_function_push_local`, `z_free_ir_program` | None known |
+| `IrDataSegment` | Documented | Owns copied bytes | Filled during lowering | No-retain for source literal bytes | `ir.c` `ir_add_readonly_data`, `z_free_ir_program` | None known |
+| `IrFunction` | Documented | Owned by `IrProgram`; strings duplicated or built | Filled during lowering | No-retain for source function pointers | `ir.c` `ir_program_push_function`, `z_free_ir_program` | None known |
+| `IrProgram` | Documented | Return owned from `z_lower_program*`; freed by `z_free_ir_program` | Lowering fills program and MIR fields | No-retain for caller `Program` or `SourceInput` | `ir.c` `z_lower_program_with_source`, `z_free_ir_program` | `CONTRACT-IR-001` |
+| `z_check_program` | Partial | Does not own caller `Program`; owns temporary checker state | Semantic `inout` on nested AST annotations | No-retain for `Program`; target pointer may be retained separately | `checker.c` `set_expr_resolved_type`, `set_expr_checked_type_args`, `mark_owned_move_if_needed` | `CONTRACT-CHECK-001` |
+| `z_set_check_target` | Documented | Does not own target pointer | Mutates static checker state | Retains borrowed pointer until replaced | `checker.c` assignment to `configured_check_target` | Lifetime responsibility for caller |
+| `z_lower_program*` | Documented | Return owned `IrProgram` | Writes returned IR only | No-retain for inputs | `ir.c` lowering clone paths | `CONTRACT-IR-001` |
+| `z_emit_*_from_ir` | Documented | Caller owns output buffer | `out` is `inout`; program read-only | No-retain for IR | target-specific emitter source | `CONTRACT-ALIAS-001` |
+
+## IR String Equality
+
+Current `ir.c` string comparisons are value comparisons. They use `strcmp`,
+`strncmp`, or byte equality with `memcmp`. They do not prove interning. They do
+not prove canonical symbolic identity. They compare string contents or byte
+contents available at the call site.
+
+Important string and byte equality sites:
+
+| Site | Compared values | Equality kind | Observed origin | Ownership or lifetime |
+| --- | --- | --- | --- | --- |
+| `ir_type_kind` | Type text against built-in type spellings such as `Void`, `Bool`, `u8`, `String`, `Maybe<u8>` | String value equality | Parser type strings and checker `resolved_type` strings | Borrowed input; not retained |
+| `ir_maybe_scalar_element_type` | `Maybe<` prefix and trailing `>` | Prefix/value shape check | Checker/parser type string | Borrowed input; temporary inner string is duplicated and freed |
+| `ir_error_code_for_name` | Error names `NotFound`, `TooLarge`, `Io` | String value equality | Statement error name from AST | Borrowed input; not retained |
+| `ir_find_shape` | `program->shapes.items[i].name` against lookup name | String value equality | Parser AST shape names, cloned in IR program as needed | Returns borrowed `Shape` from input `Program` |
+| `ir_shape_arg_for_param` | Shape type parameter names against lookup name | String value equality | Parser AST shape type parameter names | Returns borrowed type arg string |
+| `ir_find_enum` | `program->enums.items[i].name` against lookup name | String value equality | Parser AST enum names | Returns borrowed `EnumDecl` |
+| `ir_enum_case_value` | Enum case names against case name | String value equality | Parser AST enum case names and expression member text | Borrowed inputs; writes optional scalar output |
+| `ir_shape_field_info` | Shape field names against field name | String value equality | Parser AST field names and expression member text | Borrowed field metadata; optional out slots |
+| `ir_shape_field_storage_info` | Shape field names against field name | String value equality | Parser AST field names and expression member text | Borrowed field metadata; optional out slots |
+| `ir_function_find_local` | MIR local names against lookup name | String value equality | IR local names duplicated with `z_strdup` from parser/checker AST names | Returns borrowed `IrLocal` |
+| `ir_find_source_function` | Source function names against lookup name | String value equality | Parser AST function names | Returns borrowed `Function` |
+| `ir_find_function_index` | IR function names against lookup name | String value equality | IR function names duplicated from source or specialization names | Writes optional index on success |
+| `ir_function_order_compare` | Stable ID strings | String value equality for sort ordering | `SourceInput` symbol metadata or `main.` fallback | Stable ID strings are owned temporaries during ordering |
+| `ir_stable_id_for_source_function` | `SourceInput.symbol_names` against function name and kind against `function` | String value equality | Source metadata arrays and parser AST function name | Returns owned stable ID string |
+| `ir_add_readonly_data` | Data segment bytes against incoming bytes | Byte value equality with `memcmp` | String literals, byte array literals, or lowered byte views | Segment stores copied bytes |
+| `ir_expr_is_byte_view_source` | Callee names such as `std.mem.span` and `std.mem.bufBytes`; resolved type text against byte-view type map | String value equality | Temporary callee name built from expression text; checker type annotation | Temporary callee string is owned and freed |
+| `ir_expr_is_mutable_byte_view_dest` | Member text `value`; local name lookup | String value equality | Expression member/identifier text and IR local names | Borrowed expression text; local result borrowed |
+| `ir_is_hosted_world_main` | Function name `main`, param type `World`, return type `Void` | String value equality | Parser/checker function signature strings | Borrowed source function fields |
+| `ir_is_world_stream_write` | Member text `write`, stream member text, world param name | String value equality | Expression member text and IR function world parameter name | Borrowed expression text; world param duplicated in IR function |
+| `ir_lower_byte_view` | String literal handling, member names `span`/`bufBytes`, callee names such as `std.mem.span`, `std.io.bufferedReader` | String value equality and length by `strlen` | Expression text and temporary callee names | Literal bytes copied into IR data segment when retained |
+| `ir_binary_op` | Operator text `+`, `-`, `*`, `/`, `%`, `&&`, `||` | String value equality | Parser expression operator text | Borrowed input; not retained |
+| `ir_compare_op` | Operator text `==`, `!=`, `<`, `<=`, `>`, `>=` | String value equality | Parser expression operator text | Borrowed input; not retained |
+| `ir_substitute_type_param` | Function type parameter names against type text | String value equality | Parser AST type parameter names and type arg strings | Returns borrowed input/type arg pointer |
+| `ir_expr_callee_name` | Builds dotted names from identifier/member text for later comparison | String construction, not equality | Parser expression text | Returns owned string that caller frees |
+| `ir_lower_expr` std dispatch | `callee_name` against `std.codec.*`, `std.parse.*`, `std.mem.*`, `std.time.*`, `std.rand.*`, `std.proc.*`, `std.crypto.*`, `std.json.*`, `std.net.*`, `std.http.*`, `std.args.*`, `std.env.*`, `std.fs.*`, `std.io.*` | String value equality and `std.parse.` prefix match | Temporary callee name from expression tree | Temporary callee string is owned and freed in each path |
+| `ir_lower_expr` member dispatch | Member text `has`, `value`, enum case names, record fields | String value equality | Parser member text, checker resolved type, parser enum/shape fields | Borrowed source strings; no interning claimed |
+| `ir_shape_literal_find_field` | Shape literal field names against expected field name | String value equality | Parser AST field initializer names and shape fields | Returns borrowed `FieldInit` |
+| `ir_collect_function_locals` | Hosted world param type `World` | String value equality | Parser/checker param type string | Borrowed source param field |
+| `ir_collect_stmt_locals` | Local statement type `MutSpan<u8>` and type-map lookups | String value equality | Checker `Stmt.resolved_type` or parser `Stmt.type` | Duplicates names into IR locals |
+| `ir_function_vec_has_name` | Cloned function names against specialization name | String value equality | Cloned parser function names and generated specialization names | Borrowed vector fields; specialization temp freed by caller |
+| `ir_collect_generic_specializations_from_expr` | Callee lookup by expression identifier text | String value equality through `ir_find_source_function` and specialization plan | Parser expression/function names and type args | Specialized functions are cloned; temp names freed |
+
+### IR String Origin Summary
+
+Observed origins:
+
+- Parser-created AST names, operators, type strings, string literals, and member
+  text.
+- Checker annotations such as `Expr.resolved_type`, `Stmt.resolved_type`, and
+  `Expr.checked_type_args`.
+- Lowering-generated temporary strings such as dotted callee names and stable
+  IDs.
+- `SourceInput` symbol metadata when available for stable IDs.
+- Copied data segment bytes derived from string literals or byte array literals.
+
+Observed retention:
+
+- IR retains many AST-derived names and types by duplicating them with
+  `z_strdup`.
+- Lookup helpers usually borrow input strings and return borrowed source
+  objects.
+- Temporary callee names and specialization names are owned by the caller and
+  freed in `ir.c`.
+- Read-only data segment bytes are copied into IR-owned storage.
+
+Unproven:
+
+- No source proves global string interning.
+- No source proves canonical symbolic identity.
+- No source proves pointer identity is valid for type, name, field, function,
+  or callee comparisons.
+
+## Why IR Currently Deals With Strings
+
+Observed source shows that current lowering consumes parser and checker text:
+
+- Parser AST nodes carry names, type strings, operator text, member names, and
+  string literal bytes.
+- Checker annotates AST nodes with resolved type strings and checked type
+  argument strings.
+- IR lowering maps those strings into direct backend MIR categories with
+  `ir_type_kind`, function/local lookup helpers, field lookup helpers, and
+  string-based standard library dispatch.
+- `SourceInput` symbol strings are used to derive stable function ordering IDs
+  when present.
+- String literal text and byte array literals become copied read-only data
+  segments.
+
+Current practical role:
+
+- Type strings select `IrTypeKind`.
+- Name strings resolve functions, locals, fields, enum cases, and shapes.
+- Callee strings select supported direct backend standard helper lowering.
+- Operator strings select binary and comparison operations.
+- Source metadata strings help produce stable emitted function order.
+
+Future symbol or type-handle designs are possible follow-up questions. Current
+source does not require a rewrite, does not introduce symbol IDs, and does not
+prove that IR can stop accepting strings without separate design work.
+
+## Unresolved Contract Debt
+
+### CONTRACT-DIAG-001
+
+Question: Which public diagnostic APIs permit `diag == NULL`, and what owns
+`ZDiag.path` after each producer writes it?
+
+Current source evidence: Some helpers guard null diagnostics. Public parser,
+checker, filesystem, and emitter functions often dereference `diag` directly or
+pass it to helpers that write fields. `diag_io` borrows `path`; metadata
+resolution sometimes duplicates paths; `z_map_source_diag` borrows
+`SourceInput` paths.
+
+Why unresolved: Ownership and nullability are not uniform across producers and
+are not documented per function.
+
+Recommended future resolution path: Audit each public function that accepts
+`ZDiag *`, document `out` versus `opt out`, and document each diagnostic path
+producer as borrowed or owned. Prefer a single diagnostic path ownership rule if
+API compatibility allows.
+
+### CONTRACT-PARSE-001
+
+Question: What exact output state is guaranteed after parser/tokenizer failure?
+
+Current source evidence: Row tokenizer may return partially filled tokens after
+diagnostics. Layout parse zeroes `ZRowTree` before filling it. Program parsing
+returns a by-value `Program` that may contain partial allocations before an
+early diagnostic return.
+
+Why unresolved: Source shows cleanup functions exist, but boundary comments do
+not yet state whether callers must always free partial outputs after failure.
+
+Recommended future resolution path: Document failure cleanup obligations for
+`ZRowTokenVec`, `ZRowTree`, and `Program`; add focused tests only under a later
+test-authorized directive.
+
+### CONTRACT-CHECK-001
+
+Question: Should checker AST annotation be represented in the public C type
+instead of using a `const Program *` boundary?
+
+Current source evidence: Checker casts through `const` to update expression and
+statement annotations, including resolved types, checked type args, meta result
+text, boolean values, and ownership move markers.
+
+Why unresolved: Changing the signature or AST model would be a public API and
+semantic design change, which is outside this documentation pass.
+
+Recommended future resolution path: Decide whether `z_check_program` remains a
+documented semantic `inout` exception or changes to `Program *` in a dedicated
+API migration.
+
+### CONTRACT-IR-001
+
+Question: Which internal IR helpers return borrowed pointers, return owned
+strings, or duplicate strings for retention?
+
+Current source evidence: Several helpers have source comments. Examples:
+lookup helpers return borrowed objects, specialization and callee-name helpers
+return owned strings, and clone/lowering paths use `z_strdup`.
+
+Why unresolved: The helper set is large and not every allocation helper has a
+local comment. Full helper-by-helper comments risk noisy churn.
+
+Recommended future resolution path: Add comments only when a helper crosses a
+boundary, returns ownership, or stores data beyond the call.
+
+### CONTRACT-IR-STRING-001
+
+Question: Should IR keep using string value equality for names and types, or
+should a future design introduce symbols/type handles?
+
+Current source evidence: `ir.c` uses `strcmp`, `strncmp`, and `memcmp` for type
+mapping, helper dispatch, function/local/field lookup, stable ordering, and
+data deduplication. No current source proves interning or canonical identity.
+
+Why unresolved: Symbol IDs and type handles would alter IR representation and
+compiler internals. That is outside this documentation-only pass.
+
+Recommended future resolution path: Open a dedicated design issue for symbol
+identity and type representation. Keep any migration separate from contract
+documentation.
+
+### CONTRACT-SRC-001
+
+Question: Which `SourceInput` arrays own strings in all producer paths?
+
+Current source evidence: `z_resolve_package_metadata` constructs owned metadata
+and `z_free_source` frees many arrays. Other producer paths may populate source
+metadata in `main.c` and should be audited before broad claims.
+
+Why unresolved: This pass inspected core ownership and free behavior but did
+not exhaustively prove every producer of every `SourceInput` field.
+
+Recommended future resolution path: Audit all assignments to `SourceInput`
+fields and annotate producer ownership near each population boundary.
+
+### CONTRACT-ALIAS-001
+
+Question: Which APIs explicitly allow or forbid aliasing between input pointers,
+output slots, diagnostics, and buffers?
+
+Current source evidence: Many APIs use separate pointers but do not document
+alias handling. `ZBuf` append behavior reads from `text` while mutating buffer
+storage. Emitters append to `out` while reading `program`.
+
+Why unresolved: Source does not contain explicit alias checks or comments for
+most public boundaries.
+
+Recommended future resolution path: Add `alias ok` or `no alias` only where
+source behavior is tested or structurally obvious. Treat all other aliasing
+claims as unresolved.
+
+## Out Of Scope
+
+This contract pass does not:
+
+- Change executable behavior.
+- Change signatures.
+- Refactor checker mutation.
+- Add symbol IDs.
+- Change IR representation.
+- Change string equality behavior.
+- Change parser, checker, lowering, emitter, or codegen semantics.
+- Add tests or generated artifacts.
+
+## Acceptance Coverage
+
+- Pointer parameter effects are documented through shared vocabulary and
+  boundary comments.
+- Ownership and lifetime are documented where source proves them.
+- Nullable versus non-null status is documented where source proves it and
+  captured as unresolved where not proven.
+- Borrowed, retained, duplicated, and owned string behavior is documented for
+  parser, checker, IR, diagnostics, source input, and buffers.
+- Output slot behavior is documented for row syntax, manifest parsing, source
+  metadata, diagnostics, IR lowering, and emitters.
+- Aliasing expectations are stated only where source-backed. Unknown aliasing is
+  captured under `CONTRACT-ALIAS-001`.
+- Parser, checker, IR, diagnostic, emitter, buffer, and source input boundaries
+  are covered.
+- IR string equality expectations are listed with comparison sites, compared
+  values, origin, equality kind, and ownership status.
+- Current reasons IR deals with strings are explained from observed source.
+- Future symbol/type-handle design is listed only as a possible follow-up
+  question.
+- Core header and source comments demonstrate the convention without changing
+  executable C code.
+- Unresolved items are captured with stable debt IDs without overclaiming.

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -31,6 +31,10 @@ typedef struct {
   char unsupported_feature[128];
 } ZBackendBlocker;
 
+// contract:
+// - diagnostic output record used by parser, checker, lowering, and emitters
+// - path and *_decl_path fields are borrowed string pointers unless a producer
+//   documents a different ownership rule
 typedef struct {
   int code;
   char code_text[16];
@@ -540,6 +544,9 @@ typedef enum {
 typedef struct IrValue IrValue;
 typedef struct IrInstr IrInstr;
 
+// contract:
+// - tree-shaped MIR value node owned by its containing IrInstr or IrValue
+// - child pointers are released by z_free_ir_program through ir.c helpers
 struct IrValue {
   IrValueKind kind;
   IrTypeKind type;
@@ -576,6 +583,10 @@ typedef enum {
   IR_INSTR_WHILE
 } IrInstrKind;
 
+// contract:
+// - MIR instruction node owned by its containing IrFunction instruction array
+// - value/index child pointers and nested instruction arrays are released by
+//   z_free_ir_program through ir.c helpers
 struct IrInstr {
   IrInstrKind kind;
   unsigned local_index;
@@ -594,6 +605,9 @@ struct IrInstr {
   int column;
 };
 
+// contract:
+// - local metadata owned by its containing IrFunction
+// - release with z_free_ir_program
 typedef struct {
   char *name;
   IrTypeKind type;
@@ -613,12 +627,18 @@ typedef struct {
   int column;
 } IrLocal;
 
+// contract:
+// - bytes points to data copied for the IrProgram result
+// - release with z_free_ir_program
 typedef struct {
   unsigned offset;
   unsigned len;
   unsigned char *bytes;
 } IrDataSegment;
 
+// contract:
+// - function metadata, locals, and instruction arrays are owned by IrProgram
+// - release with z_free_ir_program
 typedef struct {
   char *name;
   char *stable_id;
@@ -639,6 +659,9 @@ typedef struct {
   int column;
 } IrFunction;
 
+// contract:
+// - return owned from z_lower_program*; release with z_free_ir_program
+// - embeds a cloned Program plus direct MIR arrays and metadata
 typedef struct {
   Program program;
   IrFunction *functions;
@@ -835,9 +858,27 @@ bool z_toolchain_compile_c_object(const ZToolchainPlan *plan, const char *profil
 bool z_toolchain_link_objects(const ZToolchainPlan *plan, const ZTargetInfo *target, const char *const *object_files, size_t object_count, const char *exe_file, const char *pre_link_flags, const char *post_object_flags);
 bool z_run_cc(const char *c_file, const char *exe_file, const char *cc, const char *profile, const ZTargetInfo *target);
 
+// contract:
+// - source: in, non-null, read-only, no-retain
+// - diag: out, non-null
+// - returns: return owned; release with z_free_row_tokens
 ZRowTokenVec z_row_tokenize(const char *source, ZDiag *diag);
+// contract:
+// - tokens: in, non-null, read-only, no-retain
+// - facts: out, non-null
+// - diag: out, non-null
+// - returns: false on layout failure, true on success
 bool z_row_analyze_layout(const ZRowTokenVec *tokens, ZRowSyntaxFacts *facts, ZDiag *diag);
+// contract:
+// - tokens: in, non-null, read-only, no-retain
+// - tree: out, non-null; release with z_free_row_tree after success
+// - diag: out, non-null
+// - returns: false on layout parse failure, true on success
 bool z_row_parse_layout(const ZRowTokenVec *tokens, ZRowTree *tree, ZDiag *diag);
+// contract:
+// - tokens/tree: in, non-null, read-only, no-retain
+// - diag: out, non-null
+// - returns: return owned; release with z_free_program
 Program z_parse_row(const ZRowTokenVec *tokens, const ZRowTree *tree, ZDiag *diag);
 char *z_format_row_layout(const ZRowTokenVec *tokens, const ZRowTree *tree);
 void z_free_row_tree(ZRowTree *tree);
@@ -845,14 +886,32 @@ void z_free_row_tokens(ZRowTokenVec *tokens);
 
 void z_free_program(Program *program);
 
+// contract:
+// - program: inout, non-null, no-retain; current checker annotates selected
+//   nested Expr fields despite the const-qualified public type
+// - diag: out, non-null
+// - returns: false on validation failure, true on success
 bool z_check_program(const Program *program, ZDiag *diag);
 void z_set_check_target(const ZTargetInfo *target);
 ZMetaCacheStats z_meta_cache_stats(void);
 void z_backend_blocker_set(ZBackendBlocker *blocker, const char *target, const char *object_format, const char *backend, const char *stage, const char *unsupported_feature);
 void z_diag_set_backend_blocker(ZDiag *diag, const ZBackendBlocker *blocker);
+// contract:
+// - program: in, non-null, read-only during lowering, no-retain
+// - returns: return owned; release with z_free_ir_program
 IrProgram z_lower_program(const Program *program);
+// contract:
+// - program: in, non-null, read-only during lowering, no-retain
+// - input: in, nullable, read-only during lowering, no-retain
+// - returns: return owned; release with z_free_ir_program
 IrProgram z_lower_program_with_source(const Program *program, const SourceInput *input);
 void z_free_ir_program(IrProgram *program);
+// contract:
+// - applies to the z_emit_*_from_ir declarations below
+// - program: in, non-null, read-only, no-retain
+// - out: inout, non-null; emitter appends object or executable bytes
+// - diag: out, non-null
+// - returns: false on emission failure, true on success
 bool z_emit_elf64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_elf64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_elf_aarch64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -4,6 +4,10 @@
 #include <stdbool.h>
 #include <stddef.h>
 
+// contract:
+// - buffer builder with owned data after zbuf_init/zbuf_append*
+// - data is released by zbuf_free or transferred when a function returns it
+// - append inputs are borrowed and not retained
 typedef struct {
   char *data;
   size_t len;
@@ -35,6 +39,7 @@ typedef struct {
 // - diagnostic output record used by parser, checker, lowering, and emitters
 // - path and *_decl_path fields are borrowed string pointers unless a producer
 //   documents a different ownership rule
+// - do not infer that path fields are heap-owned from the type alone
 typedef struct {
   int code;
   char code_text[16];
@@ -408,6 +413,9 @@ typedef struct {
   size_t cap;
 } UseImportVec;
 
+// contract:
+// - parser-owned AST root returned by z_parse_row and released by z_free_program
+// - checker currently annotates selected nested Expr and Stmt fields
 typedef struct {
   UseImportVec use_imports;
   CImportVec c_imports;
@@ -705,6 +713,10 @@ typedef struct {
   bool direct;
 } SourceDependency;
 
+// contract:
+// - source metadata object; producer ownership is source-backed per field
+// - z_free_source releases owned fields populated by current metadata resolver
+// - diagnostic mapping may return borrowed pointers into source_line_paths
 typedef struct {
   char *source_file;
   char *source;
@@ -832,26 +844,78 @@ typedef struct {
   size_t entries;
 } ZMetaCacheStats;
 
+// contract:
+// - buf: inout, non-null; initialized to empty
 void zbuf_init(ZBuf *buf);
+// contract:
+// - buf: inout, non-null
+// - text: in, non-null, read-only, no-retain
 void zbuf_append(ZBuf *buf, const char *text);
+// contract:
+// - buf: inout, non-null
 void zbuf_append_char(ZBuf *buf, char ch);
+// contract:
+// - buf: inout, non-null
+// - fmt and varargs: in, non-null, read during call, no-retain
 void zbuf_appendf(ZBuf *buf, const char *fmt, ...);
+// contract:
+// - buf: inout, non-null; releases owned data and resets fields
 void zbuf_free(ZBuf *buf);
 
 void *z_checked_malloc(size_t size);
 void *z_checked_calloc(size_t count, size_t item_size);
 void *z_checked_reallocarray(void *ptr, size_t count, size_t item_size);
 size_t z_grow_capacity(size_t current, size_t required, size_t initial);
+// contract:
+// - text: in, non-null, read-only, no-retain
+// - returns: return owned duplicate; caller frees
 char *z_strdup(const char *text);
+// contract:
+// - text: in, non-null, read-only for len bytes, no-retain
+// - returns: return owned NUL-terminated duplicate; caller frees
 char *z_strndup(const char *text, size_t len);
+// contract:
+// - path: in, non-null, read-only, no-retain
+// - diag: out, non-null on failure paths
+// - returns: return owned file contents or NULL on failure
 char *z_read_file(const char *path, ZDiag *diag);
+// contract:
+// - path/text: in, non-null, read-only, no-retain
+// - diag: out, non-null on failure paths
+// - returns: false on write failure, true on success
 bool z_write_file(const char *path, const char *text, ZDiag *diag);
+// contract:
+// - path: in, non-null, read-only, no-retain
+// - data: in, non-null when len > 0, read-only, no-retain
+// - diag: out, non-null on failure paths
+// - returns: false on write failure, true on success
 bool z_write_binary_file(const char *path, const unsigned char *data, size_t len, ZDiag *diag);
+// contract:
+// - input: in, nullable, read-only, no-retain
+// - diag: inout, non-null; path fields may become borrowed from input
+// - returns: false when mapping is not possible, true when remapped
 bool z_map_source_diag(const SourceInput *input, ZDiag *diag);
+// contract:
+// - input: inout, non-null; releases owned source metadata fields
 void z_free_source(SourceInput *input);
+// contract:
+// - manifest: in, non-null, read-only, no-retain
+// - out: out, non-null; zeroed then filled with owned strings on success
+// - diag: opt out by source guard on some parse failures
+// - returns: false on malformed manifest, true on success
 bool z_parse_manifest_json(const char *manifest, ZManifest *out, ZDiag *diag);
+// contract:
+// - manifest_path/manifest/parsed_manifest: in, non-null, read-only, no-retain
+// - out: out, non-null; receives owned SourceInput released by z_free_source
+// - diag: out, non-null on failure paths
+// - returns: false on metadata resolution failure, true on success
 bool z_resolve_package_metadata(const char *manifest_path, const char *manifest, const ZManifest *parsed_manifest, SourceInput *out, ZDiag *diag);
+// contract:
+// - manifest: inout, non-null; releases owned strings and arrays, then resets
 void z_free_manifest(ZManifest *manifest);
+// contract:
+// - source_file: in, non-null, read-only, no-retain
+// - returns: return owned default path; caller frees
 char *z_default_out_path(const char *source_file);
 ZToolchainPlan z_plan_toolchain(const char *cc, const char *profile, const ZTargetInfo *target);
 bool z_toolchain_compile_c_object(const ZToolchainPlan *plan, const char *profile, const ZTargetInfo *target, const char *c_file, const char *object_file, const char *include_dir, const char *extra_c_flags);
@@ -880,10 +944,19 @@ bool z_row_parse_layout(const ZRowTokenVec *tokens, ZRowTree *tree, ZDiag *diag)
 // - diag: out, non-null
 // - returns: return owned; release with z_free_program
 Program z_parse_row(const ZRowTokenVec *tokens, const ZRowTree *tree, ZDiag *diag);
+// contract:
+// - tokens/tree: in, non-null, read-only, no-retain
+// - returns: return owned layout text; caller frees
 char *z_format_row_layout(const ZRowTokenVec *tokens, const ZRowTree *tree);
+// contract:
+// - tree: inout, nullable; releases owned row tree arrays and resets fields
 void z_free_row_tree(ZRowTree *tree);
+// contract:
+// - tokens: inout, nullable; releases token text and vector storage
 void z_free_row_tokens(ZRowTokenVec *tokens);
 
+// contract:
+// - program: inout, non-null; releases parser-owned AST strings and nodes
 void z_free_program(Program *program);
 
 // contract:
@@ -892,9 +965,18 @@ void z_free_program(Program *program);
 // - diag: out, non-null
 // - returns: false on validation failure, true on success
 bool z_check_program(const Program *program, ZDiag *diag);
+// contract:
+// - target: in, nullable, read-only
+// - retains: stores borrowed pointer in checker process state until replaced
 void z_set_check_target(const ZTargetInfo *target);
 ZMetaCacheStats z_meta_cache_stats(void);
+// contract:
+// - blocker: inout, nullable; copied text into fixed arrays when non-null
+// - input strings: in, nullable, read-only, no-retain
 void z_backend_blocker_set(ZBackendBlocker *blocker, const char *target, const char *object_format, const char *backend, const char *stage, const char *unsupported_feature);
+// contract:
+// - diag: inout, nullable
+// - blocker: in, nullable, read-only, no-retain
 void z_diag_set_backend_blocker(ZDiag *diag, const ZBackendBlocker *blocker);
 // contract:
 // - program: in, non-null, read-only during lowering, no-retain
@@ -905,6 +987,8 @@ IrProgram z_lower_program(const Program *program);
 // - input: in, nullable, read-only during lowering, no-retain
 // - returns: return owned; release with z_free_ir_program
 IrProgram z_lower_program_with_source(const Program *program, const SourceInput *input);
+// contract:
+// - program: inout, nullable; releases IR-owned data and cloned Program
 void z_free_ir_program(IrProgram *program);
 // contract:
 // - applies to the z_emit_*_from_ir declarations below

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -9180,6 +9180,11 @@ static bool validate_c_imports(const Program *program, ZDiag *diag) {
   return true;
 }
 
+// contract:
+// - program: inout, non-null, no-retain; checker currently annotates selected
+//   nested Expr fields while validating
+// - diag: out, non-null
+// - returns: false after writing diagnostic details, true on success
 bool z_check_program(const Program *program, ZDiag *diag) {
   meta_cache_free(&default_meta_cache);
   DiagSink diag_sink = {.diag = diag};

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -11,6 +11,12 @@
 #include <stdlib.h>
 #include <string.h>
 
+// contract:
+// - checker validates Program and annotates selected AST nodes in place
+// - public boundary is const Program *, but source casts nested Expr/Stmt
+//   pointers to write resolved semantic fields
+// - no broad ownership transfer of Program occurs at checker boundary
+
 typedef struct Scope Scope;
 
 typedef struct {
@@ -475,6 +481,9 @@ static void function_provenance_summary_free(FunctionProvenanceSummary *summary)
   *summary = (FunctionProvenanceSummary){0};
 }
 
+// contract:
+// - target: in, nullable, read-only
+// - retains: stores borrowed pointer in checker process state until replaced
 void z_set_check_target(const ZTargetInfo *target) {
   configured_check_target = target;
 }
@@ -4549,6 +4558,10 @@ static bool resolve_choice_constructor_call(const Program *program, const Expr *
   return true;
 }
 
+// contract:
+// - expr: inout at semantic level despite const-qualified helper signature
+// - type: in, nullable, read-only, no-retain
+// - retains: duplicates type into Expr.resolved_type
 static void set_expr_resolved_type(const Expr *expr, const char *type) {
   if (!expr) return;
   Expr *mutable_expr = (Expr *)expr;
@@ -4573,6 +4586,10 @@ static void type_arg_vec_push_copy(TypeArgVec *args, const char *type, int line,
   };
 }
 
+// contract:
+// - expr: inout at semantic level despite const-qualified helper signature
+// - bindings: in, nullable, read-only, no-retain
+// - retains: duplicates binding types into Expr.checked_type_args
 static void set_expr_checked_type_args(const Expr *expr, GenericBinding *bindings, size_t binding_len) {
   if (!expr) return;
   Expr *mutable_expr = (Expr *)expr;
@@ -4582,6 +4599,10 @@ static void set_expr_checked_type_args(const Expr *expr, GenericBinding *binding
   }
 }
 
+// contract:
+// - stmt: inout at semantic level despite const-qualified helper signature
+// - type: in, nullable, read-only, no-retain
+// - retains: duplicates type into Stmt.resolved_type
 static void set_stmt_resolved_type(const Stmt *stmt, const char *type) {
   if (!stmt) return;
   Stmt *mutable_stmt = (Stmt *)stmt;
@@ -6709,6 +6730,7 @@ static void mark_owned_move_if_needed(const Expr *expr, Scope *scope, const char
   const char *source_type = scope_type(scope, expr->text);
   if (source_type && type_is_owned(source_type)) {
     scope_set_moved(scope, expr->text, true);
+    // contract: records checker-proven ownership transfer on source Expr.
     ((Expr *)expr)->moves_ownership = true;
   }
 }
@@ -9182,8 +9204,10 @@ static bool validate_c_imports(const Program *program, ZDiag *diag) {
 
 // contract:
 // - program: inout, non-null, no-retain; checker currently annotates selected
-//   nested Expr fields while validating
+//   nested Expr and Stmt fields while validating
 // - diag: out, non-null
+// - ownership: does not take ownership of Program; checker temporaries are
+//   released before return
 // - returns: false after writing diagnostic details, true on success
 bool z_check_program(const Program *program, ZDiag *diag) {
   meta_cache_free(&default_meta_cache);

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -9,6 +9,12 @@
 #include <stdio.h>
 #include <string.h>
 
+// contract:
+// - see docs/internal-c-contracts.md for tag vocabulary
+// - current observed string matching in this file uses strcmp/strncmp value
+//   comparisons at the documented call sites
+// - this file does not document strings as interned or canonicalized
+
 #define IR_READONLY_DATA_BASE 1024u
 #define IR_READONLY_DATA_LIMIT 65536u
 #define IR_SPECIALIZATION_PLAN_LIMIT 1024u
@@ -142,6 +148,10 @@ static Stmt *clone_stmt(const Stmt *stmt) {
   return copy;
 }
 
+// contract:
+// - type: in, nullable, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: IR_TYPE_UNSUPPORTED when type is NULL or not in this direct map
 static IrTypeKind ir_type_kind(const char *type) {
   if (!type) return IR_TYPE_UNSUPPORTED;
   if (strcmp(type, "Void") == 0) return IR_TYPE_VOID;
@@ -183,6 +193,10 @@ static IrTypeKind ir_type_kind(const char *type) {
   return IR_TYPE_UNSUPPORTED;
 }
 
+// contract:
+// - name: in, nullable, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: runtime HTTP error code or -1 when not matched
 static int ir_std_http_error_code(const char *name) {
   if (!name) return -1;
   if (strcmp(name, "std.http.errorNone") == 0) return 0;
@@ -241,6 +255,10 @@ static const EnumDecl *ir_find_enum(const Program *program, const char *name);
 static IrTypeKind ir_type_kind_for_program(const Program *program, const char *type);
 static bool ir_parse_fixed_array_type_for_program(const Program *program, const char *type, unsigned *out_len, IrTypeKind *out_element);
 
+// contract:
+// - program/name: in, non-null, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: return borrowed Shape from program or NULL
 static const Shape *ir_find_shape(const Program *program, const char *name) {
   if (!program || !name) return NULL;
   for (size_t i = 0; i < program->shapes.len; i++) {
@@ -283,6 +301,11 @@ static bool ir_split_generic_args(const char *start, const char *end, TypeArgVec
   return angle_depth == 0 && array_depth == 0;
 }
 
+// contract:
+// - program/type: in, non-null, read-only, no-retain
+// - out_shape: out, non-null; receives borrowed Shape on success
+// - out_args: out, non-null; receives owned type arg strings on generic success
+// - returns: false when type does not name a supported shape instance
 static bool ir_shape_instance(const Program *program, const char *type, const Shape **out_shape, TypeArgVec *out_args) {
   const Shape *exact = ir_find_shape(program, type);
   if (exact && exact->type_params.len == 0) {
@@ -307,6 +330,10 @@ static bool ir_shape_instance(const Program *program, const char *type, const Sh
   return true;
 }
 
+// contract:
+// - shape/args/name: in, non-null, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: return borrowed type argument string or NULL
 static const char *ir_shape_arg_for_param(const Shape *shape, const TypeArgVec *args, const char *name) {
   if (!shape || !args || !name) return NULL;
   for (size_t i = 0; i < shape->type_params.len && i < args->len; i++) {
@@ -317,6 +344,10 @@ static const char *ir_shape_arg_for_param(const Shape *shape, const TypeArgVec *
   return NULL;
 }
 
+// contract:
+// - shape/args: in, non-null, read-only, no-retain
+// - type: in, nullable, read-only, no-retain
+// - returns: return owned substituted type string; caller frees
 static char *ir_shape_substitute_type(const Shape *shape, const TypeArgVec *args, const char *type) {
   if (!type) return z_strdup("Unknown");
   const char *direct = ir_shape_arg_for_param(shape, args, type);
@@ -341,6 +372,10 @@ static char *ir_shape_substitute_type(const Shape *shape, const TypeArgVec *args
   return z_strdup(type);
 }
 
+// contract:
+// - program/name: in, non-null, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: return borrowed EnumDecl from program or NULL
 static const EnumDecl *ir_find_enum(const Program *program, const char *name) {
   if (!program || !name) return NULL;
   for (size_t i = 0; i < program->enums.len; i++) {
@@ -512,6 +547,11 @@ static bool ir_shape_field_storage_info(const Program *program, const char *shap
   return false;
 }
 
+// contract:
+// - program: in, nullable, read-only, no-retain
+// - type: in, non-null, read-only, no-retain
+// - out_len/out_element: out, non-null, written on success
+// - string matching: observed prefix value matching via strncmp
 static bool ir_parse_fixed_array_type_for_program(const Program *program, const char *type, unsigned *out_len, IrTypeKind *out_element) {
   if (!type || type[0] != '[') return false;
   const char *close = strchr(type, ']');
@@ -718,6 +758,10 @@ static void ir_function_push_local(IrProgram *ir, IrFunction *fun, const char *n
   if (is_param) fun->param_count++;
 }
 
+// contract:
+// - fun/name: in, non-null, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: return borrowed local from fun or NULL
 static const IrLocal *ir_function_find_local(const IrFunction *fun, const char *name) {
   for (size_t i = fun ? fun->local_len : 0; i > 0; i--) {
     if (strcmp(fun->locals[i - 1].name, name) == 0) return &fun->locals[i - 1];
@@ -725,6 +769,11 @@ static const IrLocal *ir_function_find_local(const IrFunction *fun, const char *
   return NULL;
 }
 
+// contract:
+// - program/name: in, non-null, read-only, no-retain
+// - out_index: opt out, written on success when non-null
+// - string matching: observed value equality via strcmp
+// - returns: return borrowed Function from program or NULL
 static const Function *ir_find_source_function(const Program *program, const char *name, unsigned *out_index) {
   if (!program || !name) return NULL;
   for (size_t i = 0; i < program->functions.len; i++) {
@@ -736,6 +785,10 @@ static const Function *ir_find_source_function(const Program *program, const cha
   return NULL;
 }
 
+// contract:
+// - ir/name: in, non-null, read-only, no-retain
+// - out_index: out, non-null, written on success
+// - string matching: observed value equality via strcmp
 static bool ir_find_function_index(const IrProgram *ir, const char *name, unsigned *out_index) {
   if (!ir || !name) return false;
   for (size_t i = 0; i < ir->function_len; i++) {
@@ -763,6 +816,11 @@ static int ir_function_order_compare(const void *left, const void *right) {
   return 0;
 }
 
+// contract:
+// - input: in, nullable, read-only, no-retain
+// - source: in, non-null, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: return owned stable id string; caller frees
 static char *ir_stable_id_for_source_function(const SourceInput *input, const Function *source) {
   if (input && source && source->name) {
     for (size_t i = 0; i < input->symbol_count; i++) {
@@ -3547,6 +3605,12 @@ static void push_function_clone(FunctionVec *vec, const Function *source) {
   };
 }
 
+// contract:
+// - program: in, non-null, read-only during lowering, no-retain
+// - input: in, nullable, read-only during lowering, no-retain
+// - returns: return owned IrProgram; release with z_free_ir_program
+// - observed ownership: current body clones retained Program strings with
+//   z_strdup before storing them in ir.program
 IrProgram z_lower_program_with_source(const Program *program, const SourceInput *input) {
   IrProgram ir = {0};
   for (size_t i = 0; i < program->c_imports.len; i++) {
@@ -3643,6 +3707,9 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   return ir;
 }
 
+// contract:
+// - program: in, non-null, read-only during lowering, no-retain
+// - returns: return owned IrProgram; release with z_free_ir_program
 IrProgram z_lower_program(const Program *program) {
   return z_lower_program_with_source(program, NULL);
 }

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -14,6 +14,8 @@
 // - current observed string matching in this file uses strcmp/strncmp value
 //   comparisons at the documented call sites
 // - this file does not document strings as interned or canonicalized
+// - lowering reads parser/checker AST text and writes an owned IrProgram result
+// - standard helper dispatch currently uses callee string value matching
 
 #define IR_READONLY_DATA_BASE 1024u
 #define IR_READONLY_DATA_LIMIT 65536u
@@ -23,6 +25,9 @@ static Expr *clone_expr(const Expr *expr);
 static Stmt *clone_stmt(const Stmt *stmt);
 static void push_function_clone(FunctionVec *vec, const Function *source);
 
+// contract:
+// - local grow helpers mutate caller-owned arrays and do not retain input
+//   pointers beyond the resized array returned to the caller
 static void *ir_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
   if (len + 1 > *cap) {
     *cap = z_grow_capacity(*cap, len + 1, initial);
@@ -42,6 +47,10 @@ static void *ir_grow_tracked_items(IrProgram *ir, void *items, size_t len, size_
   return items;
 }
 
+// contract:
+// - clone helpers duplicate retained parser/checker strings with z_strdup
+// - cloned trees are owned by the containing Program or IrProgram
+// - no interning or canonical pointer identity is claimed
 static void push_param_clone(ParamVec *vec, const Param *param) {
   vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
   vec->items[vec->len++] = (Param){
@@ -232,6 +241,10 @@ static bool ir_type_is_direct_fallible_value(IrTypeKind type) {
          type == IR_TYPE_U32;
 }
 
+// contract:
+// - type: in, nullable, read-only, no-retain
+// - string matching: observed prefix value matching for Maybe<T>
+// - returns: element type for supported Maybe scalar strings
 static IrTypeKind ir_maybe_scalar_element_type(const char *type) {
   const char *prefix = "Maybe<";
   size_t prefix_len = strlen(prefix);
@@ -243,6 +256,10 @@ static IrTypeKind ir_maybe_scalar_element_type(const char *type) {
   return ir_type_is_value(element) ? element : IR_TYPE_UNSUPPORTED;
 }
 
+// contract:
+// - name: in, nullable, read-only, no-retain
+// - string matching: observed value equality via strcmp
+// - returns: direct backend error code fallback for raise lowering
 static unsigned ir_error_code_for_name(const char *name) {
   if (!name) return IR_ERROR_UNKNOWN;
   if (strcmp(name, "NotFound") == 0) return IR_ERROR_NOT_FOUND;
@@ -403,6 +420,10 @@ static IrTypeKind ir_enum_backing_type(const EnumDecl *item_enum) {
   return IR_TYPE_UNSUPPORTED;
 }
 
+// contract:
+// - item_enum/case_name: in, nullable, read-only, no-retain
+// - out: opt out, written on success when non-null
+// - string matching: observed enum case value equality via strcmp
 static bool ir_enum_case_value(const EnumDecl *item_enum, const char *case_name, unsigned long long *out) {
   if (!item_enum || !case_name) return false;
   for (size_t i = 0; i < item_enum->cases.len; i++) {
@@ -441,6 +462,10 @@ static size_t ir_align_to(size_t value, size_t alignment) {
   return remainder == 0 ? value : value + (alignment - remainder);
 }
 
+// contract:
+// - program/shape_name: in, non-null, read-only, no-retain
+// - out_size/out_align: opt out, written on success when non-null
+// - string matching: delegated shape/type value matching
 static bool ir_shape_layout(const Program *program, const char *shape_name, unsigned *out_size, unsigned *out_align) {
   const Shape *shape = NULL;
   TypeArgVec args = {0};
@@ -472,6 +497,10 @@ static bool ir_shape_layout(const Program *program, const char *shape_name, unsi
   return offset <= UINT_MAX;
 }
 
+// contract:
+// - program/shape_name/field_name: in, non-null, read-only, no-retain
+// - out_offset/out_type: opt out, written on success when non-null
+// - string matching: observed field name value equality via strcmp
 static bool ir_shape_field_info(const Program *program, const char *shape_name, const char *field_name, unsigned *out_offset, IrTypeKind *out_type) {
   const Shape *shape = NULL;
   TypeArgVec args = {0};
@@ -510,6 +539,10 @@ static bool ir_shape_field_info(const Program *program, const char *shape_name, 
   return false;
 }
 
+// contract:
+// - program/shape_name/field_name: in, non-null, read-only, no-retain
+// - out_* slots: opt out, written on success when non-null
+// - string matching: observed field name value equality via strcmp
 static bool ir_shape_field_storage_info(const Program *program, const char *shape_name, const char *field_name, unsigned *out_offset, IrTypeKind *out_type, bool *out_is_array, unsigned *out_array_len, IrTypeKind *out_element_type) {
   const Shape *shape = NULL;
   TypeArgVec args = {0};
@@ -682,6 +715,9 @@ static size_t ir_scan_identifier_bytes(const unsigned char *bytes, size_t len) {
 
 static IrValue *ir_new_value(IrProgram *ir, IrValueKind kind, IrTypeKind type, int line, int column);
 
+// contract:
+// - value constructors return owned IrValue nodes released by ir_free_value
+// - ir: inout, nullable; receives allocation accounting when non-null
 static IrValue *ir_new_bool_literal(IrProgram *ir, bool enabled, int line, int column) {
   IrValue *value = ir_new_value(ir, IR_VALUE_BOOL, IR_TYPE_BOOL, line, column);
   value->int_value = enabled ? 1 : 0;
@@ -854,6 +890,11 @@ static IrValue *ir_new_index_literal(IrProgram *ir, unsigned index, int line, in
   return value;
 }
 
+// contract:
+// - bytes: in, non-null when len > 0, read-only, no-retain
+// - out_offset: opt out, written on success when non-null
+// - byte matching: observed data value equality via memcmp for deduplication
+// - retains: copies bytes into IrProgram-owned data segment on insert
 static bool ir_add_readonly_data(IrProgram *ir, const unsigned char *bytes, unsigned len, int line, int column, unsigned *out_offset) {
   for (size_t i = 0; i < ir->data_segment_len; i++) {
     IrDataSegment *segment = &ir->data_segments[i];
@@ -882,6 +923,10 @@ static bool ir_add_readonly_data(IrProgram *ir, const unsigned char *bytes, unsi
 
 static char *ir_expr_callee_name(const Expr *expr);
 
+// contract:
+// - expr: in, nullable, read-only, no-retain
+// - string matching: observed callee and resolved type value equality
+// - returns: true when expression can lower as a byte-view source
 static bool ir_expr_is_byte_view_source(const Expr *expr) {
   if (expr && expr->kind == EXPR_CALL && expr->args.len == 1) {
     char *callee = ir_expr_callee_name(expr->left);
@@ -900,6 +945,10 @@ static bool ir_expr_is_byte_view_source(const Expr *expr) {
                   (expr->kind == EXPR_MEMBER && expr->resolved_type && ir_type_kind(expr->resolved_type) == IR_TYPE_BYTE_VIEW));
 }
 
+// contract:
+// - fun/expr: in, nullable, read-only, no-retain
+// - string matching: observed member/local name value equality
+// - returns: true when expression can be a mutable byte-view destination
 static bool ir_expr_is_mutable_byte_view_dest(const IrFunction *fun, const Expr *expr) {
   if (!fun || !expr) return false;
   if (expr->kind == EXPR_MEMBER && expr->left && expr->left->kind == EXPR_IDENT && strcmp(expr->text ? expr->text : "", "value") == 0) {
@@ -913,6 +962,9 @@ static bool ir_expr_is_mutable_byte_view_dest(const IrFunction *fun, const Expr 
   return local->type == IR_TYPE_BYTE_VIEW && local->is_mutable;
 }
 
+// contract:
+// - source: in, nullable, read-only, no-retain
+// - string matching: observed hosted main signature value equality
 static bool ir_is_hosted_world_main(const Function *source) {
   return source &&
          source->is_public &&
@@ -922,6 +974,9 @@ static bool ir_is_hosted_world_main(const Function *source) {
          source->return_type && strcmp(source->return_type, "Void") == 0;
 }
 
+// contract:
+// - fun/expr/stream: in, nullable, read-only, no-retain
+// - string matching: observed member and world parameter value equality
 static bool ir_is_world_stream_write(const IrFunction *fun, const Expr *expr, const char *stream) {
   if (!expr || expr->kind != EXPR_CALL || expr->args.len != 1) return false;
   const Expr *write = expr->left;
@@ -993,6 +1048,11 @@ static bool ir_lower_array_literal_byte_view(IrProgram *ir, const Expr *expr, Ir
   return true;
 }
 
+// contract:
+// - program/fun/expr: in, read-only, no-retain
+// - ir: inout, non-null lowering context
+// - out: out, non-null; receives owned IrValue on success
+// - string matching: observed callee/member/type value equality
 static bool ir_lower_byte_view(const Program *program, IrProgram *ir, const IrFunction *fun, const Expr *expr, IrValue **out) {
   if (!expr) {
     ir_mark_unsupported(ir, "direct backend byte view is missing", 1, 1, "missing expression");
@@ -1123,6 +1183,10 @@ static void ir_instr_vec_push(IrProgram *ir, IrInstr **items, size_t *len, size_
   (*items)[(*len)++] = instr;
 }
 
+// contract:
+// - text: in, nullable, read-only, no-retain
+// - out: out, non-null, written on success
+// - string matching: observed operator value equality via strcmp
 static bool ir_binary_op(const char *text, IrBinaryOp *out) {
   if (!text) return false;
   if (strcmp(text, "+") == 0) *out = IR_BIN_ADD;
@@ -1136,6 +1200,10 @@ static bool ir_binary_op(const char *text, IrBinaryOp *out) {
   return true;
 }
 
+// contract:
+// - text: in, nullable, read-only, no-retain
+// - out: out, non-null, written on success
+// - string matching: observed comparison operator value equality via strcmp
 static bool ir_compare_op(const char *text, IrCompareOp *out) {
   if (!text) return false;
   if (strcmp(text, "==") == 0) *out = IR_CMP_EQ;
@@ -1163,6 +1231,10 @@ static char *ir_specialized_function_name(const Function *fun, const TypeArgVec 
 
 static char *ir_specialize_type_text(const char *type, const Function *fun, const TypeArgVec *type_args);
 
+// contract:
+// - fun/type_args/type: in, nullable, read-only, no-retain
+// - string matching: observed type parameter name value equality
+// - returns: borrowed input or borrowed type argument string
 static const char *ir_substitute_type_param(const Function *fun, const TypeArgVec *type_args, const char *type) {
   if (!fun || !type_args || !type) return type;
   for (size_t i = 0; i < fun->type_params.len && i < type_args->len; i++) {
@@ -1173,6 +1245,10 @@ static const char *ir_substitute_type_param(const Function *fun, const TypeArgVe
   return type;
 }
 
+// contract:
+// - expr: in, nullable, read-only, no-retain
+// - returns: return owned dotted callee name; caller frees
+// - observed origin: parser expression identifier/member text
 static char *ir_expr_callee_name(const Expr *expr) {
   if (!expr) return z_strdup("");
   if (expr->kind == EXPR_IDENT) return z_strdup(expr->text ? expr->text : "");
@@ -1188,6 +1264,12 @@ static char *ir_expr_callee_name(const Expr *expr) {
   return z_strdup("");
 }
 
+// contract:
+// - program/fun/expr: in, non-null on supported paths, read-only, no-retain
+// - ir: inout, non-null; accumulates MIR and unsupported diagnostics
+// - out: out, non-null; receives owned IrValue on success
+// - string matching: observed value equality for std helper dispatch,
+//   member dispatch, type mapping, local/function lookup, and operators
 static bool ir_lower_expr(const Program *program, IrProgram *ir, const IrFunction *fun, const Expr *expr, IrValue **out) {
   if (!expr) {
     ir_mark_unsupported(ir, "direct backend expression is missing", 1, 1, "missing expression");
@@ -2757,6 +2839,10 @@ static bool ir_lower_array_initializer(const Program *program, IrProgram *ir, Ir
   return true;
 }
 
+// contract:
+// - expr/name: in, nullable, read-only, no-retain
+// - string matching: observed shape literal field value equality via strcmp
+// - returns: return borrowed field initializer or NULL
 static const FieldInit *ir_shape_literal_find_field(const Expr *expr, const char *name) {
   if (!expr || !name) return NULL;
   for (size_t i = 0; i < expr->fields.len; i++) {
@@ -3118,6 +3204,10 @@ static bool ir_lower_stmt_vec(const Program *program, IrProgram *ir, IrFunction 
   return true;
 }
 
+// contract:
+// - ir: inout, non-null; receives owned function metadata
+// - source/stable_id_text: in, read-only, no-retain
+// - retains: duplicates function names and world parameter name when stored
 static IrFunction *ir_program_push_function(IrProgram *ir, const Function *source, const char *stable_id_text) {
   ir->functions = ir_grow_tracked_items(ir, ir->functions, ir->function_len, &ir->function_cap, 4, sizeof(IrFunction));
   IrFunction *fun = &ir->functions[ir->function_len++];
@@ -3141,6 +3231,10 @@ static IrFunction *ir_program_push_function(IrProgram *ir, const Function *sourc
 
 static bool ir_collect_stmt_locals(const Program *program, IrProgram *ir, IrFunction *mir_fun, const StmtVec *body);
 
+// contract:
+// - source/program: in, non-null, read-only, no-retain
+// - ir/mir_fun: inout, non-null
+// - string matching: observed parameter/type value equality
 static bool ir_collect_function_locals(const Program *program, IrProgram *ir, IrFunction *mir_fun, const Function *source) {
   bool hosted_world_main = ir_is_hosted_world_main(source);
   for (size_t i = 0; i < source->params.len; i++) {
@@ -3168,6 +3262,10 @@ static bool ir_collect_function_locals(const Program *program, IrProgram *ir, Ir
   return true;
 }
 
+// contract:
+// - body/program: in, non-null, read-only, no-retain
+// - ir/mir_fun: inout, non-null
+// - string matching: observed local type value equality
 static bool ir_collect_stmt_locals(const Program *program, IrProgram *ir, IrFunction *mir_fun, const StmtVec *body) {
   for (size_t i = 0; i < body->len; i++) {
     const Stmt *stmt = body->items[i];
@@ -3442,6 +3540,9 @@ static void ir_push_specialized_function(FunctionVec *functions, const Function 
   fun->is_public = false;
 }
 
+// contract:
+// - functions/name: in, nullable, read-only, no-retain
+// - string matching: observed function name value equality via strcmp
 static bool ir_function_vec_has_name(const FunctionVec *functions, const char *name) {
   for (size_t i = 0; functions && i < functions->len; i++) {
     if (functions->items[i].name && name && strcmp(functions->items[i].name, name) == 0) return true;
@@ -3507,6 +3608,11 @@ static bool ir_collect_generic_specializations_from_expr(FunctionVec *functions,
   return true;
 }
 
+// contract:
+// - ir: inout, non-null; receives direct MIR subset metadata
+// - program: in, non-null, read-only, no-retain
+// - input: in, nullable, read-only, no-retain
+// - string matching: delegated lookup and stable ID value matching
 static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program, const SourceInput *input) {
   ir->mir_valid = true;
   ir->mir_line = 1;
@@ -3714,6 +3820,11 @@ IrProgram z_lower_program(const Program *program) {
   return z_lower_program_with_source(program, NULL);
 }
 
+// contract:
+// - program: inout, nullable
+// - releases IR-owned function metadata, locals, instructions, data segments,
+//   and cloned Program storage
+// - does not release the IrProgram pointer itself
 void z_free_ir_program(IrProgram *program) {
   if (!program) return;
   for (size_t i = 0; i < program->function_len; i++) {


### PR DESCRIPTION
## Summary

Addresses #181.

This PR addresses #181 by documenting the internal C API contract vocabulary, pointer access effects, ownership/lifetime conventions, boundary expectations, and observed IR string equality behavior. It also records unresolved contract debt.

The change is documentation/comment-only.

## What changed

- Added internal C contract documentation under `native/zero-c/docs/internal-c-contracts.md`.
- Documented contract vocabulary such as `in`, `inout`, `out`, `opt out`, `sink`, `return owned`, `return borrowed`, `retains`, `no-retain`, `nullable`, `non-null`, `alias ok`, and `no alias`.
- Added targeted contract comments around public/internal C boundaries in `zero.h`.
- Added targeted comments in `checker.c` for checker boundary behavior and source-backed AST annotation mutation.
- Added targeted comments in `ir.c` for IR lowering, lookup helpers, string equality sites, ownership/copy behavior, and destructor behavior.
- Documented why IR currently deals with strings based on observed source behavior.
- Documented observed IR string equality as value equality where source shows `strcmp`, `strncmp`, or equivalent comparison.
- Recorded unresolved follow-up questions with stable contract debt IDs.

## Scope

This PR does not change:

- compiler behavior
- parser behavior
- checker behavior
- IR representation
- code generation
- function signatures
- public CLI behavior
- dependencies
- lockfiles
- build scripts

## Validation

- Confirmed the committed scope is limited to four documentation/comment files.
- Confirmed the C diff is comment-only, with no executable code, declarations, signatures, includes, macros, or behavior changes.
- Confirmed no local validation artifacts are included in the public repository.
- Local validation passed using the native Zero CLI through a custom validation harness with strict scope separation, receipt capture, and independent review.

## Notes

The IR string section intentionally documents current observed behavior only. It does not claim string interning, canonical symbolic identity, or future symbol-handle design. Those are recorded as follow-up design questions where appropriate.
