### PR TITLE
fix: remove broken extern c from config-shape, add missing use types

### DIFF
--- a/examples/config-shape.0
+++ b/examples/config-shape.0
@@ -1,9 +1,3 @@
-extern c "stdint.h" as cstdint
-
-extern type CConfig
-  port i32
-  workers i32
-
 type Config
   port i32
   workers i32

--- a/examples/systems-package/src/helpers.0
+++ b/examples/systems-package/src/helpers.0
@@ -1,3 +1,5 @@
+use types
+
 fn cleanup Void
   ret
 


### PR DESCRIPTION
## Summary

Fix two broken examples that fail `zero check` on current main:

1. **`examples/config-shape.0`**: Remove broken `extern c` declarations that cause CGEN004 (unsupported backend type). The `extern` syntax for C FFI is not supported by the direct Mach-O backend.

2. **`examples/systems-package/src/helpers.0`**: Add missing `use types` import needed for `Status` type resolution.

## Validation

```sh
# Before: both files produce diagnostics
zero check --json examples/config-shape.0        # CGEN004
zero check --json examples/systems-package/       # NAM003 (Status unknown)

# After: both clean
zero check --json examples/config-shape.0         # 0 diagnostics
zero check --json examples/systems-package/       # 0 diagnostics
```

## Changes
- `examples/config-shape.0`: Removed 6 lines (extern c, extern type)
- `examples/systems-package/src/helpers.0`: Added 2 lines (use import)