### PR TITLE
Strengthen direct backend routing

### DIFF
--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -813,6 +813,48 @@ typedef struct {
 } ZToolchainPlan;
 
 typedef struct {
+  const char *selected_emitter;
+  const char *artifact_kind;
+  const char *linker_flavor;
+  const char *artifact_libc_mode;
+  const char *sysroot_status;
+  bool direct_selected;
+  bool target_requires_sysroot;
+  bool artifact_requires_sysroot;
+} ZDirectReleaseTargetFacts;
+
+typedef struct {
+  ZDirectBackend backend;
+  const char *selected_emitter;
+  const char *artifact_path;
+  const char *linker_flavor;
+  bool active;
+} ZDirectObjectBackendFacts;
+
+typedef struct {
+  ZDirectBackend backend;
+  const char *artifact_path;
+  const char *unsupported_reason;
+  bool available;
+} ZDirectObjectTargetFacts;
+
+typedef struct {
+  ZDirectBackend backend;
+  const char *cache_key;
+  const char *blocker;
+  bool supported;
+} ZDirectRuntimeObjectFacts;
+
+typedef struct {
+  ZDirectBackend backend;
+  const char *default_request_name;
+  const char *artifact_path;
+  bool requested;
+  bool requested_name;
+  bool request_supported;
+} ZDirectExecutableTargetFacts;
+
+typedef struct {
   size_t hits;
   size_t misses;
   size_t entries;
@@ -841,6 +883,7 @@ void z_free_manifest(ZManifest *manifest);
 char *z_default_out_path(const char *source_file);
 ZToolchainPlan z_plan_toolchain(const char *cc, const char *profile, const ZTargetInfo *target);
 ZToolchainPlan z_direct_backend_toolchain_plan(ZDirectBackend backend, const ZTargetInfo *target);
+bool z_direct_backend_toolchain_plan_for_emit_kind(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, ZToolchainPlan *out);
 size_t z_direct_target_stack_bytes(const ZTargetInfo *target, const IrProgram *program);
 size_t z_direct_target_max_frame_bytes(const ZTargetInfo *target, const IrProgram *program);
 bool z_toolchain_compile_c_object(const ZToolchainPlan *plan, const char *profile, const ZTargetInfo *target, const char *c_file, const char *object_file, const char *include_dir, const char *extra_c_flags);
@@ -875,6 +918,8 @@ bool z_emit_macho64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *d
 bool z_emit_macho64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
+bool z_emit_direct_object_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag);
+bool z_emit_direct_executable_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag);
 
 const char *z_host_target(void);
 size_t z_target_count(void);
@@ -896,6 +941,7 @@ const char *z_direct_backend_artifact_path(ZDirectBackend backend, bool executab
 const char *z_direct_backend_runtime_object_cache_key(ZDirectBackend backend);
 size_t z_direct_backend_symbol_overhead(ZDirectBackend backend, bool has_readonly_data);
 bool z_direct_backend_supports_runtime_object(ZDirectBackend backend);
+const char *z_direct_runtime_link_blocker(const ZTargetInfo *target, bool needs_http_runtime);
 bool z_direct_backend_emitter_is_executable(const char *emitter);
 bool z_direct_backend_is_request_name(const char *requested_backend);
 bool z_direct_requested_backend_matches(const char *requested_backend, ZDirectBackend backend);
@@ -906,6 +952,11 @@ const char *z_direct_backend_reason(const ZTargetInfo *target);
 ZDirectBackend z_direct_backend_for_emit_kind(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend);
 const char *z_direct_backend_emitter_for_emit_kind(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend);
 const char *z_direct_backend_name_for_emit_kind(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend);
+ZDirectReleaseTargetFacts z_direct_release_target_facts(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, const ZToolchainPlan *fallback_plan);
+ZDirectObjectBackendFacts z_direct_object_backend_facts(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, bool has_runtime_imports);
+ZDirectObjectTargetFacts z_direct_object_target_facts(const ZTargetInfo *target);
+ZDirectRuntimeObjectFacts z_direct_runtime_object_facts(const ZTargetInfo *target, bool needs_http_runtime);
+ZDirectExecutableTargetFacts z_direct_executable_target_facts(const ZTargetInfo *target, const char *requested_backend);
 const char *z_direct_backend_expected(const ZTargetInfo *target);
 const char *z_direct_backend_help(const ZTargetInfo *target);
 void z_append_http_runtime_json(ZBuf *buf, const ZTargetInfo *target);

--- a/native/zero-c/src/direct_emit.c
+++ b/native/zero-c/src/direct_emit.c
@@ -1,0 +1,23 @@
+#include "zero.h"
+
+bool z_emit_direct_object_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag) {
+  switch (backend) {
+    case Z_DIRECT_BACKEND_ELF64: return z_emit_elf64_object_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_ELF_AARCH64: return z_emit_elf_aarch64_object_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_MACHO64: return z_emit_macho64_object_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_COFF_X64: return z_emit_coff_x64_object_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_NONE: return false;
+  }
+  return false;
+}
+
+bool z_emit_direct_executable_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag) {
+  switch (backend) {
+    case Z_DIRECT_BACKEND_ELF64: return z_emit_elf64_exe_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_ELF_AARCH64: return z_emit_elf_aarch64_exe_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_MACHO64: return z_emit_macho64_exe_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_COFF_X64: return z_emit_coff_x64_exe_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_NONE: return false;
+  }
+  return false;
+}

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -4857,14 +4857,6 @@ static void append_portable_runtime_json(ZBuf *buf, const IrProgram *ir, const S
   zbuf_append(buf, "}");
 }
 
-static const char *release_artifact_kind_for_emit(const ZTargetInfo *target, const char *emit_kind) {
-  const char *object_format = target && target->object_format ? target->object_format : "unknown";
-  (void)object_format;
-  if (emit_kind && strcmp(emit_kind, "obj") == 0) return "native-object";
-  if (emit_kind && strcmp(emit_kind, "exe") == 0) return "native-executable";
-  return "artifact";
-}
-
 static void append_target_capability_contract_json(ZBuf *buf, const ZTargetInfo *target) {
   const char *capabilities[] = {"memory", "stdio", "args", "env", "fs", "net", "proc", "time", "rand", "web", NULL};
   zbuf_append(buf, "[");
@@ -4893,20 +4885,9 @@ static void append_target_capability_names_json(ZBuf *buf, const ZTargetInfo *ta
 }
 
 static void append_release_target_contract_json(ZBuf *buf, const SourceInput *input, const ZTargetInfo *target, const Command *command, const char *emit_kind) {
-  ZDirectBackend selected_backend = z_direct_backend_for_emit_kind(target, emit_kind, command ? command->backend : NULL);
   const char *object_format = target && target->object_format ? target->object_format : "unknown";
-  bool selected_executable = emit_kind && strcmp(emit_kind, "exe") == 0;
-  if (selected_backend == Z_DIRECT_BACKEND_NONE && selected_executable) selected_backend = z_direct_exe_backend(target);
-  const char *selected_emitter = selected_backend == Z_DIRECT_BACKEND_NONE
-                                   ? "none"
-                                   : (selected_executable ? z_direct_backend_exe_emitter(selected_backend) : z_direct_backend_object_emitter(selected_backend));
-  bool direct_selected = selected_backend != Z_DIRECT_BACKEND_NONE;
   ZToolchainPlan plan = z_plan_toolchain(command ? command->cc : NULL, command ? command->profile : NULL, target);
-  bool target_requires_sysroot = z_target_requires_sysroot(target);
-  bool artifact_requires_sysroot = !direct_selected && plan.requires_sysroot;
-  const char *linker_flavor = direct_selected ? z_direct_backend_linker_flavor(selected_backend) : plan.linker_flavor;
-  const char *artifact_libc_mode = direct_selected ? "none" : plan.libc_mode;
-  const char *sysroot_status = artifact_requires_sysroot ? plan.sysroot_status : (target_requires_sysroot ? "not-used-by-direct-artifact" : "not-required");
+  ZDirectReleaseTargetFacts release = z_direct_release_target_facts(target, emit_kind, command ? command->backend : NULL, &plan);
 
   zbuf_append(buf, "{\"schemaVersion\":1,\"target\":");
   append_json_string(buf, target ? target->name : z_host_target());
@@ -4916,7 +4897,7 @@ static void append_release_target_contract_json(ZBuf *buf, const SourceInput *in
   zbuf_append(buf, ",\"emit\":");
   append_json_string(buf, emit_kind ? emit_kind : "exe");
   zbuf_append(buf, ",\"artifactKind\":");
-  append_json_string(buf, release_artifact_kind_for_emit(target, emit_kind));
+  append_json_string(buf, release.artifact_kind);
   zbuf_append(buf, ",\"objectFormat\":");
   append_json_string(buf, object_format);
   zbuf_append(buf, ",\"os\":");
@@ -4926,11 +4907,11 @@ static void append_release_target_contract_json(ZBuf *buf, const SourceInput *in
   zbuf_append(buf, ",\"abi\":");
   append_json_string(buf, target && target->abi ? target->abi : "");
   zbuf_append(buf, ",\"linkerFlavor\":");
-  append_json_string(buf, linker_flavor);
+  append_json_string(buf, release.linker_flavor);
   zbuf_append(buf, ",\"targetLinker\":");
   append_json_string(buf, target && target->linker ? target->linker : "");
   zbuf_append(buf, ",\"selectedEmitter\":");
-  append_json_string(buf, selected_emitter);
+  append_json_string(buf, release.selected_emitter);
   zbuf_append(buf, ",\"directObjectEmitter\":");
   append_json_string(buf, z_direct_object_emitter(target));
   zbuf_append(buf, ",\"directExeEmitter\":");
@@ -4943,46 +4924,32 @@ static void append_release_target_contract_json(ZBuf *buf, const SourceInput *in
   zbuf_append(buf, ",\"targetMode\":");
   append_json_string(buf, z_target_libc_mode(target));
   zbuf_append(buf, ",\"artifactMode\":");
-  append_json_string(buf, artifact_libc_mode);
+  append_json_string(buf, release.artifact_libc_mode);
   zbuf_appendf(buf, ",\"hostReusable\":%s}", target && z_target_is_host(target) ? "true" : "false");
   zbuf_appendf(buf, ",\"sysroot\":{\"requiredByTarget\":%s,\"requiredByArtifact\":%s,\"env\":",
-               target_requires_sysroot ? "true" : "false",
-               artifact_requires_sysroot ? "true" : "false");
-  append_json_string(buf, target_requires_sysroot || artifact_requires_sysroot ? plan.sysroot_env : "");
+               release.target_requires_sysroot ? "true" : "false",
+               release.artifact_requires_sysroot ? "true" : "false");
+  append_json_string(buf, release.target_requires_sysroot || release.artifact_requires_sysroot ? plan.sysroot_env : "");
   zbuf_append(buf, ",\"status\":");
-  append_json_string(buf, sysroot_status);
-  zbuf_appendf(buf, ",\"missing\":%s}", artifact_requires_sysroot && strcmp(plan.sysroot_status, "missing") == 0 ? "true" : "false");
+  append_json_string(buf, release.sysroot_status);
+  zbuf_appendf(buf, ",\"missing\":%s}", release.artifact_requires_sysroot && strcmp(plan.sysroot_status, "missing") == 0 ? "true" : "false");
   zbuf_append(buf, ",\"capabilities\":");
   append_target_capability_names_json(buf, target);
   zbuf_append(buf, ",\"capabilityFacts\":");
   append_target_capability_contract_json(buf, target);
   zbuf_append(buf, ",\"readiness\":{\"status\":");
-  append_json_string(buf, direct_selected ? "supported" : "unsupported");
+  append_json_string(buf, release.direct_selected ? "supported" : "unsupported");
   zbuf_appendf(buf, ",\"directArtifact\":%s,\"missingSysroot\":%s,\"unsupportedReason\":",
-               direct_selected ? "true" : "false",
-               artifact_requires_sysroot && strcmp(plan.sysroot_status, "missing") == 0 ? "true" : "false");
-  append_json_string(buf, direct_selected ? "" : z_direct_backend_reason(target));
+               release.direct_selected ? "true" : "false",
+               release.artifact_requires_sysroot && strcmp(plan.sysroot_status, "missing") == 0 ? "true" : "false");
+  append_json_string(buf, release.direct_selected ? "" : z_direct_backend_reason(target));
   zbuf_append(buf, "},\"determinism\":{\"reproducible\":true,\"stableArtifactNames\":true,\"repeatBuildHash\":\"checked-by-command-contracts\"}");
   zbuf_appendf(buf, ",\"sourceFileCount\":%zu,\"moduleCount\":%zu}", input ? input->source_file_count : 0, input ? input->module_count : 0);
 }
 
 static void append_object_backend_json(ZBuf *buf, const SourceInput *input, const ZTargetInfo *target, const Command *command, const char *emit_kind) {
-  ZDirectBackend direct_backend = z_direct_backend_for_emit_kind(target, emit_kind, command ? command->backend : NULL);
-  const char *direct_emitter = z_direct_backend_emitter_for_emit_kind(target, emit_kind, command ? command->backend : NULL);
-  bool metadata_only_direct = emit_kind && (strcmp(emit_kind, "mem") == 0 || strcmp(emit_kind, "size") == 0);
-  bool runtime_linked_exe = emit_kind && strcmp(emit_kind, "exe") == 0 && input && input->direct_host_runtime_import_count > 0;
-  if (runtime_linked_exe) {
-    direct_backend = z_direct_object_backend(target);
-    direct_emitter = z_direct_backend_object_emitter(direct_backend);
-  }
-  if (metadata_only_direct || runtime_linked_exe || (direct_backend != Z_DIRECT_BACKEND_NONE &&
-      ((emit_kind && strcmp(emit_kind, "obj") == 0) ||
-       (emit_kind && strcmp(emit_kind, "exe") == 0 && command && command->backend)))) {
-    if (metadata_only_direct) {
-      direct_backend = z_direct_object_backend(target);
-      direct_emitter = z_direct_backend_object_emitter(direct_backend);
-      if (!direct_emitter || strcmp(direct_emitter, "none") == 0) direct_emitter = "metadata-only";
-    }
+  ZDirectObjectBackendFacts direct = z_direct_object_backend_facts(target, emit_kind, command ? command->backend : NULL, input && input->direct_host_runtime_import_count > 0);
+  if (direct.active) {
     const char *object_format = target && target->object_format ? target->object_format : "unknown";
     const char *arch = target && target->arch ? target->arch : "unknown";
     size_t direct_symbol_count = input ? input->direct_function_count : 0;
@@ -4995,19 +4962,16 @@ static void append_object_backend_json(ZBuf *buf, const SourceInput *input, cons
     zbuf_append(buf, "{\"internalIr\":{\"typeRepresentation\":\"MIR primitive value types\",\"controlFlowRepresentation\":\"MIR instruction stream lowered to target machine/module code\",\"callRepresentation\":\"same-object direct calls for supported direct subsets\",\"functionIdentity\":\"module-qualified-stable-sorted\",\"debugRepresentation\":\"source spans retained on MIR nodes\"}");
     bool direct_has_data = input && input->direct_readonly_data_bytes > 0;
     direct_symbol_count += input ? input->direct_runtime_helper_count : 0;
-    direct_symbol_count += z_direct_backend_symbol_overhead(direct_backend, direct_has_data);
-    bool direct_executable_artifact = emit_kind && strcmp(emit_kind, "exe") == 0 && !runtime_linked_exe && command && command->backend;
-    const char *direct_artifact_path = direct_backend != Z_DIRECT_BACKEND_NONE ? z_direct_backend_artifact_path(direct_backend, direct_executable_artifact) : "unsupported";
-    const char *direct_linker_flavor = direct_backend != Z_DIRECT_BACKEND_NONE ? z_direct_backend_linker_flavor(direct_backend) : "none";
+    direct_symbol_count += z_direct_backend_symbol_overhead(direct.backend, direct_has_data);
     zbuf_appendf(buf, ",\"objectEmission\":{\"path\":\"%s\",\"functions\":true,\"dataSections\":%s,\"symbols\":%s,\"relocations\":\"%s\",\"symbolCount\":%zu,\"internalHelperCount\":%zu}",
-                 direct_artifact_path,
+                 direct.artifact_path,
                  direct_has_data ? "true" : "false",
                  "true",
                  uses_zero_runtime ? "patched-runtime-import-relocations" : (direct_has_data ? "patched-internal-calls-and-data-relocations" : "patched-internal-calls-or-none-in-mvp"),
                  direct_symbol_count,
                  input && input->direct_function_count > input->direct_export_count ? input->direct_function_count - input->direct_export_count : 0);
     zbuf_append(buf, ",\"linking\":{\"linkerFlavor\":");
-    append_json_string(buf, direct_linker_flavor);
+    append_json_string(buf, direct.linker_flavor);
     zbuf_append(buf, ",\"objectFormat\":");
     append_json_string(buf, object_format);
     zbuf_append(buf, ",\"targetLibraries\":");
@@ -5026,7 +4990,7 @@ static void append_object_backend_json(ZBuf *buf, const SourceInput *input, cons
     zbuf_append(buf, ",\"linkerPlan\":{\"format\":");
     append_json_string(buf, object_format);
     zbuf_append(buf, ",\"flavor\":");
-    append_json_string(buf, direct_linker_flavor);
+    append_json_string(buf, direct.linker_flavor);
     zbuf_append(buf, ",\"archives\":[],\"staticLibraries\":");
     zbuf_append(buf, links_http_runtime ? "[\"zero_runtime.o\",\"zero_http_curl.o\"]" : (links_zero_runtime ? "[\"zero_runtime.o\"]" : "[]"));
     zbuf_append(buf, ",\"importLibraries\":[],\"systemLibraries\":");
@@ -5044,7 +5008,7 @@ static void append_object_backend_json(ZBuf *buf, const SourceInput *input, cons
     zbuf_append(buf, ",\"targetFacts\":{\"directAvailable\":true,\"status\":");
     append_json_string(buf, z_direct_backend_status(target));
     zbuf_append(buf, ",\"selectedEmitter\":");
-    append_json_string(buf, direct_emitter);
+    append_json_string(buf, direct.selected_emitter);
     zbuf_append(buf, ",\"objectFormat\":");
     append_json_string(buf, object_format);
     zbuf_append(buf, ",\"arch\":");
@@ -5330,18 +5294,17 @@ static void print_build_json(const Command *command, const SourceInput *input, c
   printf(",\n  \"legacyBackend\": null");
   printf(",\n  \"warnings\": []");
   printf(",\n  \"compiler\": ");
-  ZDirectBackend direct_backend = z_direct_backend_for_emit_kind(target, emit_kind, command ? command->backend : NULL);
-  const char *driver_kind = z_direct_backend_object_emitter(direct_backend);
-  if (direct_backend != Z_DIRECT_BACKEND_NONE) print_json_string(driver_kind);
+  ZToolchainPlan direct_plan;
+  bool direct_toolchain = z_direct_backend_toolchain_plan_for_emit_kind(target, emit_kind, command ? command->backend : NULL, &direct_plan);
+  if (direct_toolchain) print_json_string(direct_plan.driver_kind);
   else print_json_string(build_compiler_label(command, target));
   printf(",\n  \"toolchain\": ");
-  if (direct_backend != Z_DIRECT_BACKEND_NONE) {
-    ZBuf direct_toolchain;
-    ZToolchainPlan direct_plan = z_direct_backend_toolchain_plan(direct_backend, target);
-    zbuf_init(&direct_toolchain);
-    append_toolchain_plan_value_json(&direct_toolchain, &direct_plan);
-    fputs(direct_toolchain.data, stdout);
-    zbuf_free(&direct_toolchain);
+  if (direct_toolchain) {
+    ZBuf direct_toolchain_json;
+    zbuf_init(&direct_toolchain_json);
+    append_toolchain_plan_value_json(&direct_toolchain_json, &direct_plan);
+    fputs(direct_toolchain_json.data, stdout);
+    zbuf_free(&direct_toolchain_json);
   } else {
     ZBuf toolchain_json;
     zbuf_init(&toolchain_json);
@@ -8401,9 +8364,9 @@ static bool target_readiness_select_emit_target(const Command *command, const So
   EmitKind emit = command ? command->emit : EMIT_EXE;
   const char *emit_kind = emit_kind_name(emit);
   if (emit == EMIT_OBJ) {
-    const char *emitter = z_direct_object_emitter(target);
-    if (emitter && strcmp(emitter, "none") != 0) return true;
-    init_direct_backend_diag(diag, command, input, target, emit_kind, z_direct_backend_reason(target));
+    ZDirectObjectTargetFacts direct_obj = z_direct_object_target_facts(target);
+    if (direct_obj.available) return true;
+    init_direct_backend_diag(diag, command, input, target, emit_kind, direct_obj.unsupported_reason);
     return false;
   }
   if (emit == EMIT_C) {
@@ -8433,23 +8396,18 @@ static bool target_readiness_select_diag(const Command *command, const SourceInp
   if (ir && ir_needs_zero_runtime_object(ir)) {
     RuntimeImportAudit audit = runtime_import_audit_from_ir(ir);
     bool needs_http_runtime = runtime_import_audit_uses_http_provider(&audit);
-    ZDirectBackend object_backend = z_direct_object_backend(target);
-    if (!z_direct_backend_supports_runtime_object(object_backend)) {
-      init_direct_backend_diag(diag, command, input, target, emit_kind, "runtime helpers currently require the Mach-O or ELF64 object link plan");
-      return false;
-    }
-    if (needs_http_runtime && !z_target_is_host(target)) {
-      init_direct_backend_diag(diag, command, input, target, emit_kind, "HTTP runtime provider is host-only for direct executable links");
+    ZDirectRuntimeObjectFacts runtime_object = z_direct_runtime_object_facts(target, needs_http_runtime);
+    if (!runtime_object.supported) {
+      init_direct_backend_diag(diag, command, input, target, emit_kind, runtime_object.blocker);
       return false;
     }
     return target_readiness_buildability_check(command, target, ir, diag);
   }
 
-  ZDirectBackend exe_backend = z_direct_exe_backend(target);
-  bool supported_exe = exe_backend != Z_DIRECT_BACKEND_NONE && z_direct_requested_backend_matches(command ? command->backend : NULL, exe_backend);
+  ZDirectExecutableTargetFacts direct_exe = z_direct_executable_target_facts(target, command ? command->backend : NULL);
   CapabilitySummary caps = program_capabilities(program);
-  bool default_direct_exe = supported_exe && (!command || !command->backend) && self_host_subset_compatible(program, &caps);
-  bool requested_direct_exe = supported_exe && command && command->backend && command->backend[0];
+  bool default_direct_exe = direct_exe.request_supported && (!command || !command->backend) && self_host_subset_compatible(program, &caps);
+  bool requested_direct_exe = direct_exe.request_supported && direct_exe.requested;
   if (default_direct_exe || requested_direct_exe) return target_readiness_buildability_check(command, target, ir, diag);
   init_direct_backend_diag(diag, command, input, target, emit_kind, "direct executable backend is not implemented for this target/backend pair; use --emit obj for direct target objects or choose a supported direct executable target");
   return false;
@@ -9461,23 +9419,16 @@ int main(int argc, char **argv) {
       z_free_source(&input);
       return 1;
     }
-    ZDirectBackend object_backend = z_direct_object_backend(target);
-    if (object_backend == Z_DIRECT_BACKEND_NONE) {
-      int rc = return_direct_backend_error(&command, &input, target, "obj", z_direct_backend_reason(target), &ir, &program);
+    ZDirectObjectTargetFacts direct_obj = z_direct_object_target_facts(target);
+    if (!direct_obj.available) {
+      int rc = return_direct_backend_error(&command, &input, target, "obj", direct_obj.unsupported_reason, &ir, &program);
       z_free_source(&input);
       return rc;
     }
     if (!direct_buildability_preflight(&command, &input, target, "obj", &ir, &diag)) { int rc = return_buildability_error(&command, &input, &diag, &ir, &program); z_free_source(&input); return rc; }
     ZBuf object;
     phase_started = now_ms();
-    bool emitted_object = false;
-    switch (object_backend) {
-      case Z_DIRECT_BACKEND_ELF64: emitted_object = z_emit_elf64_object_from_ir(&ir, &object, &diag); break;
-      case Z_DIRECT_BACKEND_ELF_AARCH64: emitted_object = z_emit_elf_aarch64_object_from_ir(&ir, &object, &diag); break;
-      case Z_DIRECT_BACKEND_MACHO64: emitted_object = z_emit_macho64_object_from_ir(&ir, &object, &diag); break;
-      case Z_DIRECT_BACKEND_COFF_X64: emitted_object = z_emit_coff_x64_object_from_ir(&ir, &object, &diag); break;
-      case Z_DIRECT_BACKEND_NONE: emitted_object = false; break;
-    }
+    bool emitted_object = z_emit_direct_object_from_ir(direct_obj.backend, &ir, &object, &diag);
     input.codegen_ms = now_ms() - phase_started;
     if (!emitted_object) {
       z_map_source_diag(&input, &diag);
@@ -9493,7 +9444,7 @@ int main(int argc, char **argv) {
     char *base_object_file = command.out ? z_strdup(command.out) : z_default_out_path(input.source_file);
     char *object_file = base_object_file;
     phase_started = now_ms();
-    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, z_direct_backend_artifact_path(object_backend, false)));
+    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, direct_obj.artifact_path));
     bool wrote_object = z_write_binary_file(object_file, (const unsigned char *)object.data, object.len, &diag);
     input.object_ms = now_ms() - phase_started;
     input.link_ms = 0;
@@ -9526,20 +9477,14 @@ int main(int argc, char **argv) {
   if (needs_zero_runtime) {
     RuntimeImportAudit runtime_audit = runtime_import_audit_from_ir(&ir);
     bool needs_http_runtime = runtime_import_audit_uses_http_provider(&runtime_audit);
-    ZDirectBackend object_backend = z_direct_object_backend(target);
-    bool runtime_object_emitter_supported = z_direct_backend_supports_runtime_object(object_backend);
+    ZDirectRuntimeObjectFacts runtime_object = z_direct_runtime_object_facts(target, needs_http_runtime);
     if (ship_command) {
       int rc = return_direct_backend_error(&command, &input, target, "exe", "host runtime link plan is not wired into ship yet; use zero build or zero run", &ir, &program);
       z_free_source(&input);
       return rc;
     }
-    if (!runtime_object_emitter_supported) {
-      int rc = return_direct_backend_error(&command, &input, target, "exe", "runtime helpers currently require the Mach-O or ELF64 object link plan", &ir, &program);
-      z_free_source(&input);
-      return rc;
-    }
-    if (needs_http_runtime && !z_target_is_host(target)) {
-      int rc = return_direct_backend_error(&command, &input, target, "exe", "HTTP runtime provider is host-only for direct executable links", &ir, &program);
+    if (!runtime_object.supported) {
+      int rc = return_direct_backend_error(&command, &input, target, "exe", runtime_object.blocker, &ir, &program);
       z_free_source(&input);
       return rc;
     }
@@ -9547,9 +9492,7 @@ int main(int argc, char **argv) {
     ZBuf object;
     zbuf_init(&object);
     phase_started = now_ms();
-    bool emitted_object = object_backend == Z_DIRECT_BACKEND_MACHO64
-                            ? z_emit_macho64_object_from_ir(&ir, &object, &diag)
-                            : z_emit_elf64_object_from_ir(&ir, &object, &diag);
+    bool emitted_object = z_emit_direct_object_from_ir(runtime_object.backend, &ir, &object, &diag);
     input.codegen_ms = now_ms() - phase_started;
     if (!emitted_object) {
       z_map_source_diag(&input, &diag);
@@ -9573,7 +9516,7 @@ int main(int argc, char **argv) {
     ZToolchainPlan runtime_toolchain = z_plan_toolchain(command.cc, command.profile, target);
 
     phase_started = now_ms();
-    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, z_direct_backend_runtime_object_cache_key(object_backend)));
+    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, runtime_object.cache_key));
     bool wrote_object = z_write_binary_file(object_file, (const unsigned char *)object.data, object.len, &diag);
     if (wrote_object) wrote_object = compile_zero_runtime_object(runtime_object_file, &runtime_toolchain, &command, target, &diag);
     if (wrote_object && needs_http_runtime) wrote_object = compile_zero_http_curl_object(http_object_file, &runtime_toolchain, &command, target, &diag);
@@ -9639,31 +9582,21 @@ int main(int argc, char **argv) {
     z_free_source(&input);
     return 0;
   }
-  ZDirectBackend direct_exe_backend = command.emit == EMIT_EXE ? z_direct_exe_backend(target) : Z_DIRECT_BACKEND_NONE;
-  bool direct_exe_available = direct_exe_backend != Z_DIRECT_BACKEND_NONE;
-  bool default_direct_exe = artifact_command && command.emit == EMIT_EXE && direct_exe_available && !command.backend && self_host_subset_compatible(&program, &direct_exe_caps);
-  bool requested_direct_exe = artifact_command && command.emit == EMIT_EXE && command.backend &&
-                              z_direct_backend_is_request_name(command.backend);
+  ZDirectExecutableTargetFacts direct_exe = z_direct_executable_target_facts(target, command.emit == EMIT_EXE ? command.backend : NULL);
+  bool default_direct_exe = artifact_command && command.emit == EMIT_EXE && direct_exe.request_supported && !command.backend && self_host_subset_compatible(&program, &direct_exe_caps);
+  bool requested_direct_exe = artifact_command && command.emit == EMIT_EXE && direct_exe.requested_name;
   if (default_direct_exe || requested_direct_exe) {
-    ZDirectBackend exe_backend = direct_exe_backend;
-    bool supported_exe = direct_exe_available && z_direct_requested_backend_matches(command.backend, exe_backend);
-    if (!supported_exe) {
+    ZDirectBackend exe_backend = direct_exe.backend;
+    if (!direct_exe.request_supported) {
       int rc = return_direct_backend_error(&command, &input, target, "exe", "direct executable backend is not implemented for this target/backend pair; use --emit obj for direct target objects or choose a supported direct executable target", &ir, &program);
       z_free_source(&input);
       return rc;
     }
-    if (!command.backend) command.backend = z_direct_backend_object_emitter(exe_backend);
+    if (!command.backend) command.backend = direct_exe.default_request_name;
     if (!direct_buildability_preflight(&command, &input, target, "exe", &ir, &diag)) { int rc = return_buildability_error(&command, &input, &diag, &ir, &program); z_free_source(&input); return rc; }
     ZBuf exe;
     phase_started = now_ms();
-    bool emitted_exe = false;
-    switch (exe_backend) {
-      case Z_DIRECT_BACKEND_ELF_AARCH64: emitted_exe = z_emit_elf_aarch64_exe_from_ir(&ir, &exe, &diag); break;
-      case Z_DIRECT_BACKEND_MACHO64: emitted_exe = z_emit_macho64_exe_from_ir(&ir, &exe, &diag); break;
-      case Z_DIRECT_BACKEND_COFF_X64: emitted_exe = z_emit_coff_x64_exe_from_ir(&ir, &exe, &diag); break;
-      case Z_DIRECT_BACKEND_ELF64: emitted_exe = z_emit_elf64_exe_from_ir(&ir, &exe, &diag); break;
-      case Z_DIRECT_BACKEND_NONE: emitted_exe = false; break;
-    }
+    bool emitted_exe = z_emit_direct_executable_from_ir(exe_backend, &ir, &exe, &diag);
     input.codegen_ms = now_ms() - phase_started;
     if (!emitted_exe) {
       z_map_source_diag(&input, &diag);
@@ -9681,7 +9614,7 @@ int main(int argc, char **argv) {
     char *exe_file = apply_target_suffix(base_exe_file, target);
     free(base_exe_file);
     phase_started = now_ms();
-    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, z_direct_backend_artifact_path(exe_backend, true)));
+    input.emitted_object_cache_hit = compiler_cache_touch("emitted-object", compile_cache_key(&input, target, command.profile, direct_exe.artifact_path));
     bool wrote_exe = z_write_binary_file(exe_file, (const unsigned char *)exe.data, exe.len, &diag);
     if (wrote_exe) chmod(exe_file, 0755);
     input.object_ms = now_ms() - phase_started;

--- a/native/zero-c/src/target_backend.c
+++ b/native/zero-c/src/target_backend.c
@@ -124,6 +124,13 @@ ZToolchainPlan z_direct_backend_toolchain_plan(ZDirectBackend backend, const ZTa
   return plan;
 }
 
+bool z_direct_backend_toolchain_plan_for_emit_kind(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, ZToolchainPlan *out) {
+  ZDirectBackend backend = z_direct_backend_for_emit_kind(target, emit_kind, requested_backend);
+  if (backend == Z_DIRECT_BACKEND_NONE) return false;
+  if (out) *out = z_direct_backend_toolchain_plan(backend, target);
+  return true;
+}
+
 const char *z_direct_backend_runtime_object_cache_key(ZDirectBackend backend) {
   const ZDirectBackendDescriptor *descriptor = direct_backend_descriptor(backend);
   return descriptor ? descriptor->runtime_object_cache_key : "unsupported";
@@ -143,6 +150,13 @@ size_t z_direct_backend_symbol_overhead(ZDirectBackend backend, bool has_readonl
 bool z_direct_backend_supports_runtime_object(ZDirectBackend backend) {
   const ZDirectBackendDescriptor *descriptor = direct_backend_descriptor(backend);
   return descriptor ? descriptor->runtime_object_supported : false;
+}
+
+const char *z_direct_runtime_link_blocker(const ZTargetInfo *target, bool needs_http_runtime) {
+  ZDirectBackend object_backend = z_direct_object_backend(target);
+  if (!z_direct_backend_supports_runtime_object(object_backend)) return "runtime helpers currently require the Mach-O or ELF64 object link plan";
+  if (needs_http_runtime && !z_target_is_host(target)) return "HTTP runtime provider is host-only for direct executable links";
+  return NULL;
 }
 
 bool z_direct_backend_emitter_is_executable(const char *emitter) {
@@ -215,6 +229,99 @@ const char *z_direct_backend_name_for_emit_kind(const ZTargetInfo *target, const
     return z_direct_exe_emitter(target);
   }
   return "none";
+}
+
+static const char *direct_artifact_kind_for_emit_kind(const char *emit_kind) {
+  if (emit_kind && strcmp(emit_kind, "obj") == 0) return "native-object";
+  if (emit_kind && strcmp(emit_kind, "exe") == 0) return "native-executable";
+  return "artifact";
+}
+
+ZDirectReleaseTargetFacts z_direct_release_target_facts(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, const ZToolchainPlan *fallback_plan) {
+  bool selected_executable = emit_kind && strcmp(emit_kind, "exe") == 0;
+  ZDirectBackend selected_backend = z_direct_backend_for_emit_kind(target, emit_kind, requested_backend);
+  if (selected_backend == Z_DIRECT_BACKEND_NONE && selected_executable) selected_backend = z_direct_exe_backend(target);
+  bool direct_selected = selected_backend != Z_DIRECT_BACKEND_NONE;
+  bool target_requires_sysroot = z_target_requires_sysroot(target);
+  bool artifact_requires_sysroot = !direct_selected && fallback_plan && fallback_plan->requires_sysroot;
+  const char *fallback_linker = fallback_plan ? fallback_plan->linker_flavor : "none";
+  const char *fallback_libc = fallback_plan ? fallback_plan->libc_mode : "";
+  const char *fallback_sysroot_status = fallback_plan ? fallback_plan->sysroot_status : "not-required";
+  ZDirectReleaseTargetFacts facts = {
+    .selected_emitter = selected_backend == Z_DIRECT_BACKEND_NONE ? "none" : (selected_executable ? z_direct_backend_exe_emitter(selected_backend) : z_direct_backend_object_emitter(selected_backend)),
+    .artifact_kind = direct_artifact_kind_for_emit_kind(emit_kind),
+    .linker_flavor = direct_selected ? z_direct_backend_linker_flavor(selected_backend) : fallback_linker,
+    .artifact_libc_mode = direct_selected ? "none" : fallback_libc,
+    .sysroot_status = artifact_requires_sysroot ? fallback_sysroot_status : (target_requires_sysroot ? "not-used-by-direct-artifact" : "not-required"),
+    .direct_selected = direct_selected,
+    .target_requires_sysroot = target_requires_sysroot,
+    .artifact_requires_sysroot = artifact_requires_sysroot
+  };
+  return facts;
+}
+
+ZDirectObjectBackendFacts z_direct_object_backend_facts(const ZTargetInfo *target, const char *emit_kind, const char *requested_backend, bool has_runtime_imports) {
+  bool emit_obj = emit_kind && strcmp(emit_kind, "obj") == 0;
+  bool emit_exe = emit_kind && strcmp(emit_kind, "exe") == 0;
+  bool metadata_only = emit_kind && (strcmp(emit_kind, "mem") == 0 || strcmp(emit_kind, "size") == 0);
+  bool runtime_linked_exe = emit_exe && has_runtime_imports;
+  bool requested_exe = emit_exe && requested_backend;
+  ZDirectBackend backend = z_direct_backend_for_emit_kind(target, emit_kind, requested_backend);
+  const char *emitter = z_direct_backend_emitter_for_emit_kind(target, emit_kind, requested_backend);
+  if (metadata_only || runtime_linked_exe) {
+    backend = z_direct_object_backend(target);
+    emitter = z_direct_backend_object_emitter(backend);
+    if (metadata_only && (!emitter || strcmp(emitter, "none") == 0)) emitter = "metadata-only";
+  }
+  bool active = metadata_only || runtime_linked_exe || (backend != Z_DIRECT_BACKEND_NONE && (emit_obj || requested_exe));
+  bool executable_artifact = requested_exe && !runtime_linked_exe;
+  ZDirectObjectBackendFacts facts = {
+    .backend = backend,
+    .selected_emitter = emitter,
+    .artifact_path = backend != Z_DIRECT_BACKEND_NONE ? z_direct_backend_artifact_path(backend, executable_artifact) : "unsupported",
+    .linker_flavor = backend != Z_DIRECT_BACKEND_NONE ? z_direct_backend_linker_flavor(backend) : "none",
+    .active = active
+  };
+  return facts;
+}
+
+ZDirectObjectTargetFacts z_direct_object_target_facts(const ZTargetInfo *target) {
+  ZDirectBackend backend = z_direct_object_backend(target);
+  bool available = backend != Z_DIRECT_BACKEND_NONE;
+  ZDirectObjectTargetFacts facts = {
+    .backend = backend,
+    .artifact_path = available ? z_direct_backend_artifact_path(backend, false) : "unsupported",
+    .unsupported_reason = available ? "" : z_direct_backend_reason(target),
+    .available = available
+  };
+  return facts;
+}
+
+ZDirectRuntimeObjectFacts z_direct_runtime_object_facts(const ZTargetInfo *target, bool needs_http_runtime) {
+  ZDirectBackend backend = z_direct_object_backend(target);
+  const char *blocker = z_direct_runtime_link_blocker(target, needs_http_runtime);
+  ZDirectRuntimeObjectFacts facts = {
+    .backend = backend,
+    .cache_key = backend != Z_DIRECT_BACKEND_NONE ? z_direct_backend_runtime_object_cache_key(backend) : "unsupported",
+    .blocker = blocker,
+    .supported = blocker == NULL
+  };
+  return facts;
+}
+
+ZDirectExecutableTargetFacts z_direct_executable_target_facts(const ZTargetInfo *target, const char *requested_backend) {
+  ZDirectBackend backend = z_direct_exe_backend(target);
+  bool requested = requested_backend && requested_backend[0];
+  bool available = backend != Z_DIRECT_BACKEND_NONE;
+  ZDirectExecutableTargetFacts facts = {
+    .backend = backend,
+    .default_request_name = available ? z_direct_backend_object_emitter(backend) : "none",
+    .artifact_path = available ? z_direct_backend_artifact_path(backend, true) : "unsupported",
+    .requested = requested,
+    .requested_name = z_direct_backend_is_request_name(requested_backend),
+    .request_supported = available && z_direct_requested_backend_matches(requested_backend, backend)
+  };
+  return facts;
 }
 
 const char *z_direct_backend_expected(const ZTargetInfo *target) {

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -15,10 +15,10 @@ type CScanState = {
 };
 
 const fileBudgets = {
-  "native/zero-c/include/zero.h": { maxLines: 915, maxStrcmpCalls: 0 },
+  "native/zero-c/include/zero.h": { maxLines: 966, maxStrcmpCalls: 0 },
   "native/zero-c/include/zero_runtime.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/checker.c": { maxLines: 9395, maxStrcmpCalls: 403 },
-  "native/zero-c/src/main.c": { maxLines: 9938, maxStrcmpCalls: 451 },
+  "native/zero-c/src/main.c": { maxLines: 9872, maxStrcmpCalls: 441 },
   "native/zero-c/src/ir.c": { maxLines: 3700, maxStrcmpCalls: 224 },
   "native/zero-c/src/row_syntax.c": { maxLines: 2150, maxStrcmpCalls: 11 },
   "native/zero-c/src/ast.c": { maxLines: 250, maxStrcmpCalls: 0 },
@@ -33,6 +33,7 @@ const fileBudgets = {
   "native/zero-c/src/coff_format.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_emit_state.c": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_emit_state.h": { maxLines: 70, maxStrcmpCalls: 0 },
+  "native/zero-c/src/direct_emit.c": { maxLines: 35, maxStrcmpCalls: 0 },
   "native/zero-c/src/direct_metrics.c": { maxLines: 20, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.c": { maxLines: 220, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.h": { maxLines: 60, maxStrcmpCalls: 0 },
@@ -55,7 +56,7 @@ const fileBudgets = {
   "native/zero-c/src/specialize.h": { maxLines: 50, maxStrcmpCalls: 0 },
   "native/zero-c/src/std_sig.c": { maxLines: 180, maxStrcmpCalls: 2 },
   "native/zero-c/src/std_sig.h": { maxLines: 40, maxStrcmpCalls: 0 },
-  "native/zero-c/src/target_backend.c": { maxLines: 241, maxStrcmpCalls: 24 },
+  "native/zero-c/src/target_backend.c": { maxLines: 348, maxStrcmpCalls: 32 },
   "native/zero-c/src/target.c": { maxLines: 465, maxStrcmpCalls: 15 },
   "native/zero-c/src/type_core.c": { maxLines: 900, maxStrcmpCalls: 8 },
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
@@ -610,7 +611,15 @@ function budgetViolations(files, allLargeFunctions, stdlib, backendFormats) {
       backendFormats.directTarget.mainManualDirectToolchainJson > 0 ||
       backendFormats.directTarget.mainDirectMetricMachoChecks > 0 ||
       backendFormats.directTarget.mainDirectBackendNameHelpers > 0 ||
-      backendFormats.directTarget.mainDirectEmitSelectionHelpers > 0) {
+      backendFormats.directTarget.mainDirectEmitSelectionHelpers > 0 ||
+      backendFormats.directTarget.mainDirectReleaseTargetHelpers > 0 ||
+      backendFormats.directTarget.mainDirectRuntimeLinkBlockers > 0 ||
+      backendFormats.directTarget.mainDirectObjectSelectionHelpers > 0 ||
+      backendFormats.directTarget.mainDirectBuildToolchainSelectionHelpers > 0 ||
+      backendFormats.directTarget.mainDirectExecutableSelectionHelpers > 0 ||
+      backendFormats.directTarget.mainDirectEmitDispatchHelpers > 0 ||
+      backendFormats.directTarget.mainDirectBuildArtifactSelectionHelpers > 0 ||
+      backendFormats.directTarget.mainDirectReadinessSelectionHelpers > 0) {
     violations.push({
       kind: "direct-target-backend-matrix",
       directTarget: backendFormats.directTarget,
@@ -914,6 +923,14 @@ const backendFormats = {
     mainDirectMetricMachoChecks: countMatches(cCodeText(main), /z_(?:direct_object_backend|direct_exe_backend)\s*\([^)]*\)\s*==\s*Z_DIRECT_BACKEND_MACHO64/g),
     mainDirectBackendNameHelpers: countMatches(cCodeText(main), /static const char \*(?:backend_blocker_backend_name|target_readiness_backend)\s*\(/g),
     mainDirectEmitSelectionHelpers: countMatches(cCodeText(main), /static (?:ZDirectBackend|const char \*)direct_emit_(?:backend|emitter)\s*\(/g),
+    mainDirectReleaseTargetHelpers: countMatches(cCodeText(main), /static const char \*release_artifact_kind_for_emit\s*\(|selected_backend\s*==\s*Z_DIRECT_BACKEND_NONE\s*&&\s*selected_executable/g),
+    mainDirectRuntimeLinkBlockers: countMatches(cCodeText(main), /runtime helpers currently require the Mach-O or ELF64 object link plan|HTTP runtime provider is host-only for direct executable links/g),
+    mainDirectObjectSelectionHelpers: countMatches(cCodeText(main), /metadata_only_direct|runtime_linked_exe|direct_executable_artifact/g),
+    mainDirectBuildToolchainSelectionHelpers: countMatches(cCodeText(main), /ZDirectBackend\s+direct_backend\s*=\s*z_direct_backend_for_emit_kind/g),
+    mainDirectExecutableSelectionHelpers: countMatches(cCodeText(main), /z_direct_exe_backend\s*\(\s*target\s*\)|z_direct_backend_is_request_name\s*\(\s*command\.backend\s*\)|z_direct_requested_backend_matches\s*\(\s*command\.backend/g),
+    mainDirectEmitDispatchHelpers: countMatches(cCodeText(main), /switch\s*\(\s*(?:object_backend|exe_backend)\s*\)|object_backend\s*==\s*Z_DIRECT_BACKEND_MACHO64/g),
+    mainDirectBuildArtifactSelectionHelpers: countMatches(cCodeText(main), /z_direct_object_backend\s*\(\s*target\s*\)|z_direct_backend_artifact_path\s*\([^)]*\)|z_direct_backend_runtime_object_cache_key\s*\([^)]*\)/g),
+    mainDirectReadinessSelectionHelpers: countMatches(cCodeText(main), /const char \*emitter\s*=\s*z_direct_object_emitter\s*\(\s*target\s*\)|z_direct_runtime_link_blocker\s*\(\s*target/g),
   },
   elf: {
     sharedWriter: /\bz_elf_write_object64\s*\(/.test(elfFormatSource) && /\bz_elf_write_executable64\s*\(/.test(elfFormatSource),


### PR DESCRIPTION
- Move direct backend routing facts into target helpers
- Centralize direct IR emitter dispatch
- Guard command driver backend-selection boundaries