### PR TITLE
fix(zero-c): fail closed for unsupported aarch64 ELF IR

### DIFF
--- a/native/zero-c/src/emit_elf_aarch64.c
+++ b/native/zero-c/src/emit_elf_aarch64.c
@@ -20,19 +20,53 @@ static bool a64_diag(ZDiag *diag, const char *message, int line, int column, con
   return false;
 }
 
+static const char *a64_instr_kind_name(IrInstrKind kind) {
+  switch (kind) {
+    case IR_INSTR_LOCAL_SET: return "IR_INSTR_LOCAL_SET";
+    case IR_INSTR_INDEX_STORE: return "IR_INSTR_INDEX_STORE";
+    case IR_INSTR_FIELD_STORE: return "IR_INSTR_FIELD_STORE";
+    case IR_INSTR_WORLD_WRITE: return "IR_INSTR_WORLD_WRITE";
+    case IR_INSTR_RAISE: return "IR_INSTR_RAISE";
+    case IR_INSTR_EXPR: return "IR_INSTR_EXPR";
+    case IR_INSTR_RETURN: return "IR_INSTR_RETURN";
+    case IR_INSTR_IF: return "IR_INSTR_IF";
+    case IR_INSTR_WHILE: return "IR_INSTR_WHILE";
+  }
+  return "unknown IR instruction";
+}
+
 static bool a64_return_literal(const IrFunction *fun, uint32_t *out, ZDiag *diag) {
   if (!fun) return a64_diag(diag, "direct AArch64 ELF object backend requires a function", 1, 1, "missing function");
   if (fun->return_type != IR_TYPE_VOID && fun->return_type != IR_TYPE_U8 && fun->return_type != IR_TYPE_I32 && fun->return_type != IR_TYPE_U32 && fun->return_type != IR_TYPE_USIZE) {
     return a64_diag(diag, "direct AArch64 ELF object backend currently supports primitive 32-bit-or-smaller integer returns", fun->line, fun->column, fun->name);
   }
   *out = 0;
+  bool saw_return = false;
   for (size_t i = 0; i < fun->instr_len; i++) {
     const IrInstr *instr = &fun->instrs[i];
-    if (instr->kind != IR_INSTR_RETURN || !instr->value || instr->value->kind != IR_VALUE_INT || instr->value->int_value > 65535) continue;
+    if (instr->kind != IR_INSTR_RETURN) {
+      return a64_diag(diag, "direct AArch64 ELF object backend does not yet support lowering this IR instruction", instr->line, instr->column, a64_instr_kind_name(instr->kind));
+    }
+    if (!instr->value) {
+      if (fun->return_type == IR_TYPE_VOID) {
+        saw_return = true;
+        continue;
+      }
+      return a64_diag(diag, "direct AArch64 ELF object backend does not yet support lowering this IR instruction", instr->line, instr->column, a64_instr_kind_name(instr->kind));
+    }
+    if (instr->value->kind != IR_VALUE_INT || instr->value->int_value > 65535) {
+      return a64_diag(diag, "direct AArch64 ELF object backend does not yet support lowering this IR instruction", instr->line, instr->column, a64_instr_kind_name(instr->kind));
+    }
     *out = (uint32_t)instr->value->int_value;
-    return true;
+    saw_return = true;
   }
-  return true;
+  if (saw_return || fun->return_type == IR_TYPE_VOID) return true;
+  return a64_diag(diag, "direct AArch64 ELF object backend currently requires a small integer literal return", fun->line, fun->column, fun->name);
+}
+
+static bool a64_validate_function(const IrFunction *fun, ZDiag *diag) {
+  uint32_t scratch = 0;
+  return a64_return_literal(fun, &scratch, diag);
 }
 
 static const IrFunction *a64_find_main(const IrProgram *ir, unsigned *out_index, ZDiag *diag) {
@@ -62,6 +96,10 @@ bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *di
     bool ok = a64_diag(diag, ir->mir_message[0] ? ir->mir_message : "direct backend lowering failed", ir->mir_line, ir->mir_column, ir->mir_actual);
     z_diag_set_backend_blocker(diag, &ir->backend_blocker);
     return ok;
+  }
+
+  for (size_t i = 0; i < ir->function_len; i++) {
+    if (!a64_validate_function(&ir->functions[i], diag)) return false;
   }
 
   ZBuf text;
@@ -150,6 +188,10 @@ bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag)
   }
   unsigned main_index = 0;
   if (!a64_find_main(ir, &main_index, diag)) return false;
+
+  for (size_t i = 0; i < ir->function_len; i++) {
+    if (!a64_validate_function(&ir->functions[i], diag)) return false;
+  }
 
   ZBuf text;
   zbuf_init(&text);


### PR DESCRIPTION
## Summary

Addresses #145.

This PR updates the AArch64 ELF backend so unsupported IR fails closed with a CGEN004 diagnostic instead of allowing successful emission of a misleading executable.

The change is intentionally limited to validation and diagnostic behavior. It does not add new AArch64 code generation support.

## What changed

- Added AArch64 ELF validation for every IR function before successful object or executable emission.
- Preserved the existing emitted-function behavior: non-exported functions are validated but not newly emitted.
- Preserved the currently supported small literal-return subset.
- Aligned unsupported-lowering diagnostic wording with existing native backend terminology.
- Kept the existing CGEN004 diagnostic path.
- Avoided adding `world.out.write` lowering, Linux write syscall lowering, general call lowering, or broader backend support.

## Validation

- Rebuilt the native compiler with `make -C native/zero-c`.
- Confirmed `bash bin/zero --version` succeeds.
- Confirmed `zero new cli hello` succeeds.
- Confirmed `zero check .` succeeds.
- Confirmed `zero test .` succeeds.
- Confirmed `zero build .` fails with CGEN004 for unsupported AArch64 ELF lowering.
- Confirmed `zero run .` fails with the same diagnostic.
- Confirmed the previous silent no-output executable behavior no longer reproduces.
- Confirmed the committed scope is limited to `native/zero-c/src/emit_elf_aarch64.c`.

## Scope

This PR does not change:

- IR generation
- checker behavior
- CLI behavior
- x64 ELF backend behavior
- Mach-O backend behavior
- COFF backend behavior
- WASM/WASI behavior
- documentation
- package files
- lockfiles
- build scripts

## Notes

This is the fail-closed compiler behavior fix. It does not make unsupported AArch64 programs run successfully. Follow-up work can add actual AArch64 lowering for specific constructs in separate PRs.
