### PR TITLE
Prepare v0.1.4 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## 0.1.3
+## 0.1.4
 
 <!-- release:start -->
+
+- Adopts row syntax as the current Zero surface across parsing, import resolution, package manifests, command workflows, docs, fixtures, trivia preservation, and artifact contracts.
+- Rebuilds checker internals around TypeCore, binder-aware unification, generic inference, static interface validation, provenance substitution, and shared call-resolution facts.
+- Hardens direct emitters and native artifacts through MIR verifier contracts, direct specialization metadata, target buildability checks, and shared x64, AArch64, ELF, Mach-O, and COFF emission helpers.
+- Adds clearer direct backend selection, target readiness, and buildability reporting so command JSON and failed native builds expose deterministic blocker facts.
+- Removes stale wasm, compiler-zero, and superseded parser surfaces while refreshing public docs, README guidance, and zerolang branding around the current system.
+- Strengthens compiler structure guardrails, metrics budgets, TypeScript-based repo scripts, docs build infrastructure, CI workspace commands, and eval harness isolation.
+- Renames bundled version-matched skills to the current flat skill names while keeping `zero skills` discovery focused on the native compiler.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.1.3
 
 - Adds hosted HTTP client runtime support, including runtime packaging fixes, JSON byte helpers for wasm, HTTP final-header parsing fixes, and direct array span lowering repairs.
 - Parses `use` declarations into syntax graph facts and reports import diagnostics, fix plans, and graph edges against the specific import source ranges.
@@ -17,8 +33,6 @@
 - @ctate
 - @PeterXMR
 - @h4ckf0r0day
-
-<!-- release:end -->
 
 ## 0.1.2
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -2466,7 +2466,7 @@ assert.equal(depGraphBody.package.resolver.deterministic, true);
 assert.match(depGraphBody.package.lockfile.path, /\.zero\/package-locks\/[0-9a-f]+\.lock\.json/);
 assert(depGraphBody.package.dependencies.some((item) => item.name === "dep-lib" && item.status === "path-resolved" && item.targetCompatible === true));
 assert(depGraphBody.package.dependencies.some((item) => item.name === "remote-tools" && item.status === "registry-reference" && item.version === "1.2.3"));
-assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.1.3");
+assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.1.4");
 assert.equal(depGraphBody.packageCache.cacheKeyInputs.packageVersion, "0.1.0");
 assert.match(depGraphBody.packageCache.cacheKeyInputs.dependencyGraphHash, /^[0-9a-f]{16}$/);
 const depDoc = await execFileAsync(zero, ["doc", "--json", "conformance/packages/dep-app"]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-docs",
   "private": true,
-  "version": "0.1.3",
+  "version": "0.1.4",
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zero Language",
   "description": "Syntax highlighting for the Zero programming language.",
   "publisher": "zero-lang",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "categories": [

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -23,7 +23,7 @@
 #endif
 #include <unistd.h>
 
-#define ZERO_VERSION "0.1.3"
+#define ZERO_VERSION "0.1.4"
 
 #include "embedded_runtime_sources.inc"
 #include "embedded_skills.inc"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-lang-workspace",
   "description": "Workspace for the Zero language docs, native compiler, examples, and editor tooling.",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.1.3",

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -194,11 +194,11 @@ function assertReleaseTargetContract(report, expected) {
 
 const generatedCBytesBeforeReadOnlyCommands = json(["size", "--json", "examples/memory-package"]).body.generatedCBytes;
 
-assert.equal(zero(["--version"]).stdout, "zero 0.1.3\n");
+assert.equal(zero(["--version"]).stdout, "zero 0.1.4\n");
 
 const version = json(["--version", "--json"]).body;
 assert.equal(version.schemaVersion, 1);
-assert.equal(version.version, "0.1.3");
+assert.equal(version.version, "0.1.4");
 assert.equal(version.backend, "zero-c");
 assert.equal(typeof version.host, "string");
 assert(version.targets.includes("darwin-arm64"));
@@ -1317,7 +1317,7 @@ assert.equal(depDoc.package.name, "dep-app");
 assert.equal(depDoc.publicationGate.requiresExamplesForPublicApi, true);
 const depBuild = json(["build", "--json", "--target", "linux-musl-x64", "conformance/packages/dep-app", "--out", join(outDir, "dep-app")]).body;
 assert.equal(depBuild.packageCache.invalidationReasons.includes("dependency graph changed"), true);
-assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.1.3" && item.packageVersion === "0.1.0"), true);
+assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.1.4" && item.packageVersion === "0.1.0"), true);
 const depDevTrace = json(["dev", "--json", "--trace", "--target", "linux-musl-x64", "conformance/packages/dep-app"]).body;
 assert.equal(depDevTrace.trace.requested, true);
 assert.equal(depDevTrace.partialDiagnostics.stable, true);

--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -62,8 +62,8 @@ async function collectSkillMdFiles(dir: string): Promise<string[]> {
 
 describe("native zero CLI", () => {
   it("prints a terse plain version", async () => {
-    assert.equal((await runZero(["--version"])).stdout, "zero 0.1.3\n");
-    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.1.3\n");
+    assert.equal((await runZero(["--version"])).stdout, "zero 0.1.4\n");
+    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.1.4\n");
   });
 
   it("checks directly and rejects removed legacy build flags", async () => {


### PR DESCRIPTION
- Bump workspace, docs, editor, and native compiler release versions to 0.1.4.
- Move changelog release markers to the 0.1.4 entry with contributor attribution.
- Update version-pinned command, conformance, and CLI test expectations.