### PR TITLE
ci: rely on Vercel for docs build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,9 +57,6 @@ jobs:
       - name: Docs tests
         run: pnpm run docs:test
 
-      - name: Docs production build
-        run: pnpm run docs:build
-
       - name: Extension tests
         run: pnpm run extension:test
 


### PR DESCRIPTION
- Remove the duplicate docs production build from GitHub CI.
- Keep docs tests in CI while Vercel handles preview and deployment builds.