### PR TITLE
Expand direct backend target parity

### DIFF
--- a/benchmarks/rosetta/reverse-a-string.0
+++ b/benchmarks/rosetta/reverse-a-string.0
@@ -6,5 +6,6 @@ pub fn main Void world World !
     let from - (std.mem.len source) (+ i 1)
     set out[i] source[from]
     set i + i 1
-  if && (&& (== out[0] 114) (== out[1] 101)) (&& (&& (== out[2] 119) (== out[3] 97)) (&& (== out[4] 114) (== out[5] 100)))
+  let actual Span<u8> out
+  if std.mem.eqlBytes actual "reward"[0..6]
     check world.out.write "reverse string ok\n"

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -175,6 +175,21 @@ async function assertElfAarch64Object(path, exportedName) {
   assert(bytes.includes(Buffer.concat([Buffer.from(exportedName), Buffer.from([0])])));
 }
 
+function hasAarch64Instruction(bytes, expected) {
+  for (let offset = 0; offset + 4 <= bytes.length; offset++) {
+    if (bytes.readUInt32LE(offset) === expected) return true;
+  }
+  return false;
+}
+
+function hasAarch64CondBranch(bytes, cond) {
+  for (let offset = 0; offset + 4 <= bytes.length; offset++) {
+    const instruction = bytes.readUInt32LE(offset);
+    if ((instruction & 0xff000010) === 0x54000000 && (instruction & 0xf) === cond) return true;
+  }
+  return false;
+}
+
 async function assertElf64Executable(path) {
   const bytes = await readFile(path);
   assert.equal(bytes[0], 0x7f);
@@ -997,6 +1012,35 @@ await execFileAsync(zero, [
   arm64PrivateHelperObj,
 ]);
 await assertElfAarch64Object(arm64PrivateHelperObj, "main");
+
+const arm64CompareSource = `${outDir}/aarch64-typed-compare.0`;
+const arm64CompareObj = `${outDir}/aarch64-typed-compare.o`;
+await writeFile(arm64CompareSource, `export c fn main u32
+  let large u32 4294967295
+  if > large 0_u32
+    ret 7
+  ret 3
+
+export c fn wide_guard u32
+  let wide u64 4294967296
+  if != wide 0_u64
+    ret 9
+  ret 4
+`);
+await execFileAsync(zero, [
+  "build",
+  "--json",
+  "--emit",
+  "obj",
+  "--target",
+  "linux-arm64",
+  arm64CompareSource,
+  "--out",
+  arm64CompareObj,
+]);
+const arm64CompareBytes = await readFile(arm64CompareObj);
+assert(hasAarch64CondBranch(arm64CompareBytes, 9));
+assert(hasAarch64Instruction(arm64CompareBytes, 0xeb09011f));
 
 const memoryPackageMachOReadiness = await execFileAsync(zero, [
   "check",

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -999,6 +999,50 @@ for (const key of ["code", "path", "line", "column", "length", "expected", "actu
 assert.equal(directCallArm64ObjBuildDiag.backendBlocker.backend, "zero-elf-aarch64");
 assert.equal(directCallArm64ObjBuildDiag.backendBlocker.stage, "buildability");
 
+let arm64NestedIndexExpr = "values[idx]";
+for (let i = 0; i < 32; i++) arm64NestedIndexExpr = `(+ 0_u32 ${arm64NestedIndexExpr})`;
+const arm64NestedIndexFixture = `${outDir}/aarch64-nested-index-scratch-blocked.0`;
+await writeFile(arm64NestedIndexFixture, `export c fn main u32
+  let values [1]u32 [7]
+  let idx u32 0_u32
+  ret ${arm64NestedIndexExpr}
+`);
+async function assertArm64NestedScratchBlocked(fixture, expectedMessage, outPrefix) {
+  for (const blocked of [["linux-arm64", "zero-elf-aarch64", "linux.o"], ["darwin-arm64", "zero-macho64", "macho.o"], ["win32-arm64.exe", "zero-coff-aarch64", "coff.obj"]]) {
+    const readiness = await execFileAsync(zero, ["check", "--json", "--emit", "obj", "--target", blocked[0], fixture]);
+    const readinessBody = JSON.parse(readiness.stdout);
+    assert.equal(readinessBody.ok, true);
+    assert.equal(readinessBody.targetReadiness.ok, false);
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].code, "BLD004");
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].backendBlocker.backend, blocked[1]);
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].backendBlocker.stage, "buildability");
+    assert.match(readinessBody.targetReadiness.diagnostics[0].message, expectedMessage);
+    const build = await execFileAsync(zero, ["build", "--json", "--emit", "obj", "--target", blocked[0], fixture, "--out", `${outDir}/${outPrefix}-${blocked[2]}`]).catch((error) => error);
+    assert.notEqual(build.code, 0);
+    assert.equal(JSON.parse(build.stdout).diagnostics[0].backendBlocker.stage, "buildability");
+  }
+}
+await assertArm64NestedScratchBlocked(arm64NestedIndexFixture, /indexed load exceeds scratch register spill capacity/, "aarch64-nested-index");
+let arm64NestedLenExpr = "((std.mem.len text[start..end]) as u32)";
+for (let i = 0; i < 32; i++) arm64NestedLenExpr = `(+ 0_u32 ${arm64NestedLenExpr})`;
+const arm64NestedLenFixture = `${outDir}/aarch64-nested-len-scratch-blocked.0`;
+await writeFile(arm64NestedLenFixture, `export c fn main u32
+  let text String "abcdef"
+  let start usize 1
+  let end usize 4
+  ret ${arm64NestedLenExpr}
+`);
+await assertArm64NestedScratchBlocked(arm64NestedLenFixture, /byte-view length exceeds scratch register spill capacity/, "aarch64-nested-len");
+let arm64NestedEndLenExpr = "((std.mem.len text[1..(+ end 0_usize)]) as u32)";
+for (let i = 0; i < 32; i++) arm64NestedEndLenExpr = `(+ 0_u32 ${arm64NestedEndLenExpr})`;
+const arm64NestedEndLenFixture = `${outDir}/aarch64-nested-end-len-scratch-blocked.0`;
+await writeFile(arm64NestedEndLenFixture, `export c fn main u32
+  let text String "abcdef"
+  let end usize 4
+  ret ${arm64NestedEndLenExpr}
+`);
+await assertArm64NestedScratchBlocked(arm64NestedEndLenFixture, /byte-view length exceeds scratch register spill capacity/, "aarch64-nested-end-len");
+
 const arm64PrivateHelperObj = `${outDir}/aarch64-private-helper-ignored.o`;
 await execFileAsync(zero, [
   "build",

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1010,11 +1010,27 @@ const memoryPackageMachOReadiness = await execFileAsync(zero, [
 const memoryPackageMachOReadinessBody = JSON.parse(memoryPackageMachOReadiness.stdout);
 assert.equal(memoryPackageMachOReadinessBody.ok, true);
 assert.equal(memoryPackageMachOReadinessBody.diagnostics.length, 0);
-assert.equal(memoryPackageMachOReadinessBody.targetReadiness.ok, false);
-assert.equal(memoryPackageMachOReadinessBody.targetReadiness.buildable, false);
-assert.equal(memoryPackageMachOReadinessBody.targetReadiness.diagnostics[0].code, "BLD004");
-assert.equal(memoryPackageMachOReadinessBody.targetReadiness.diagnostics[0].backendBlocker.backend, "zero-macho64");
-assert.equal(memoryPackageMachOReadinessBody.targetReadiness.diagnostics[0].backendBlocker.stage, "buildability");
+assert.equal(memoryPackageMachOReadinessBody.targetReadiness.ok, true);
+assert.equal(memoryPackageMachOReadinessBody.targetReadiness.buildable, true);
+assert.equal(memoryPackageMachOReadinessBody.targetReadiness.backend, "zero-macho64");
+assert.equal(memoryPackageMachOReadinessBody.targetReadiness.diagnostics.length, 0);
+const memoryPackageMachOObj = `${outDir}/memory-package-macho.o`;
+const memoryPackageMachOBuild = await execFileAsync(zero, [
+  "build",
+  "--json",
+  "--emit",
+  "obj",
+  "--target",
+  "darwin-arm64",
+  "examples/memory-package",
+  "--out",
+  memoryPackageMachOObj,
+]);
+const memoryPackageMachOBuildBody = JSON.parse(memoryPackageMachOBuild.stdout);
+assert.equal(memoryPackageMachOBuildBody.compiler, "zero-macho64");
+assert.equal(memoryPackageMachOBuildBody.generatedCBytes, 0);
+assert.equal(memoryPackageMachOBuildBody.objectBackend.objectEmission.path, "direct-macho64-object");
+await assertMachOArm64Object(memoryPackageMachOObj, "main");
 
 async function assertAgentSurfaceOwnedDropUnsupported(target, emit, outName, expectedPattern, expectedObjectFormat, expectedBackend, options = {}) {
   const extraArgs = options.extraArgs ?? [];

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1052,6 +1052,16 @@ await writeFile(arm64NestedEndLenFixture, `export c fn main u32
   ret ${arm64NestedEndLenExpr}
 `);
 await assertArm64NestedScratchBlocked(arm64NestedEndLenFixture, /byte-view length exceeds scratch register spill capacity/, "aarch64-nested-end-len");
+let arm64NestedDynamicEqlExpr = "(std.mem.eqlBytes text[(+ start (+ 0_usize 0_usize))..end] text[(+ start (+ 0_usize 0_usize))..end])";
+for (let i = 0; i < 29; i++) arm64NestedDynamicEqlExpr = `(== true ${arm64NestedDynamicEqlExpr})`;
+const arm64NestedDynamicEqlFixture = `${outDir}/aarch64-nested-dynamic-eql-scratch-blocked.0`;
+await writeFile(arm64NestedDynamicEqlFixture, `export c fn main Bool
+  let text String "abcdef"
+  let start usize 1
+  let end usize 4
+  ret ${arm64NestedDynamicEqlExpr}
+`);
+await assertArm64NestedScratchBlocked(arm64NestedDynamicEqlFixture, /byte-view equality exceeds scratch register spill capacity/, "aarch64-nested-dynamic-eql");
 
 const arm64PrivateHelperObj = `${outDir}/aarch64-private-helper-ignored.o`;
 await execFileAsync(zero, [

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1033,6 +1033,16 @@ await writeFile(arm64NestedLenFixture, `export c fn main u32
   ret ${arm64NestedLenExpr}
 `);
 await assertArm64NestedScratchBlocked(arm64NestedLenFixture, /byte-view length exceeds scratch register spill capacity/, "aarch64-nested-len");
+let arm64NestedDynamicStartLenExpr = "((std.mem.len text[(+ start 0_usize)..end]) as u32)";
+for (let i = 0; i < 31; i++) arm64NestedDynamicStartLenExpr = `(+ 0_u32 ${arm64NestedDynamicStartLenExpr})`;
+const arm64NestedDynamicStartLenFixture = `${outDir}/aarch64-nested-dynamic-start-len-scratch-blocked.0`;
+await writeFile(arm64NestedDynamicStartLenFixture, `export c fn main u32
+  let text String "abcdef"
+  let start usize 1
+  let end usize 4
+  ret ${arm64NestedDynamicStartLenExpr}
+`);
+await assertArm64NestedScratchBlocked(arm64NestedDynamicStartLenFixture, /expression nesting exceeds scratch register spill capacity/, "aarch64-nested-dynamic-start-len");
 let arm64NestedEndLenExpr = "((std.mem.len text[1..(+ end 0_usize)]) as u32)";
 for (let i = 0; i < 32; i++) arm64NestedEndLenExpr = `(+ 0_u32 ${arm64NestedEndLenExpr})`;
 const arm64NestedEndLenFixture = `${outDir}/aarch64-nested-end-len-scratch-blocked.0`;

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -1063,6 +1063,44 @@ await writeFile(arm64NestedDynamicEqlFixture, `export c fn main Bool
 `);
 await assertArm64NestedScratchBlocked(arm64NestedDynamicEqlFixture, /byte-view equality exceeds scratch register spill capacity/, "aarch64-nested-dynamic-eql");
 
+let arm64WorldWriteSliceStart = "(+ start 0_usize)";
+for (let i = 0; i < 31; i++) arm64WorldWriteSliceStart = `(+ 0_usize ${arm64WorldWriteSliceStart})`;
+const arm64WorldWriteFixture = `${outDir}/aarch64-world-write-dynamic-slice-scratch-blocked.0`;
+await writeFile(arm64WorldWriteFixture, `pub fn main Void world World !
+  let text String "abcdef"
+  let start usize 1
+  check world.out.write text[${arm64WorldWriteSliceStart}..6]
+`);
+async function assertArm64WorldWriteScratchBlocked(fixture, expectedMessage, outPrefix) {
+  for (const blocked of [["linux-musl-arm64", "zero-elf-aarch64-exe", "linux"], ["win32-arm64.exe", "zero-coff-aarch64-exe", "coff.exe"]]) {
+    const readiness = await execFileAsync(zero, ["check", "--json", "--emit", "exe", "--target", blocked[0], fixture]);
+    const readinessBody = JSON.parse(readiness.stdout);
+    assert.equal(readinessBody.ok, true);
+    assert.equal(readinessBody.targetReadiness.ok, false);
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].code, "BLD004");
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].backendBlocker.backend, blocked[1]);
+    assert.equal(readinessBody.targetReadiness.diagnostics[0].backendBlocker.stage, "buildability");
+    assert.match(readinessBody.targetReadiness.diagnostics[0].message, expectedMessage);
+    const build = await execFileAsync(zero, ["build", "--json", "--emit", "exe", "--target", blocked[0], fixture, "--out", `${outDir}/${outPrefix}-${blocked[2]}`]).catch((error) => error);
+    assert.notEqual(build.code, 0);
+    const buildDiag = JSON.parse(build.stdout).diagnostics[0];
+    assert.equal(buildDiag.backendBlocker.backend, blocked[1]);
+    assert.equal(buildDiag.backendBlocker.stage, "buildability");
+    assert.match(buildDiag.message, expectedMessage);
+  }
+}
+await assertArm64WorldWriteScratchBlocked(arm64WorldWriteFixture, /expression nesting exceeds scratch register spill capacity/, "aarch64-world-write-dynamic-slice");
+
+let arm64WorldWriteSliceEnd = "(+ end 0_usize)";
+for (let i = 0; i < 32; i++) arm64WorldWriteSliceEnd = `(+ 0_usize ${arm64WorldWriteSliceEnd})`;
+const arm64WorldWriteEndFixture = `${outDir}/aarch64-world-write-dynamic-end-scratch-blocked.0`;
+await writeFile(arm64WorldWriteEndFixture, `pub fn main Void world World !
+  let text String "abcdef"
+  let end usize 6
+  check world.out.write text[1..${arm64WorldWriteSliceEnd}]
+`);
+await assertArm64WorldWriteScratchBlocked(arm64WorldWriteEndFixture, /expression nesting exceeds scratch register spill capacity/, "aarch64-world-write-dynamic-end");
+
 const arm64PrivateHelperObj = `${outDir}/aarch64-private-helper-ignored.o`;
 await execFileAsync(zero, [
   "build",

--- a/docs/articles/language-reference.md
+++ b/docs/articles/language-reference.md
@@ -777,6 +777,7 @@ Executable targets are named after the supported artifact family:
 - `linux-arm64`
 - `linux-musl-arm64`
 - `linux-musl-x64`
+- `linux-x64`
 - `win32-arm64.exe`
 - `win32-x64.exe`
 

--- a/docs/src/tests/docs.test.mjs
+++ b/docs/src/tests/docs.test.mjs
@@ -27,6 +27,16 @@ function loadDocsRegistry() {
 }
 
 const docs = loadDocsRegistry();
+const publicTargets = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64",
+  "linux-musl-arm64",
+  "linux-musl-x64",
+  "linux-x64",
+  "win32-arm64.exe",
+  "win32-x64.exe",
+];
 
 describe("docs registry", () => {
   it("declares module pages with source files", async () => {
@@ -137,6 +147,12 @@ describe("docs registry", () => {
     for (const compileTimeTerm of ["compileTime", "target.pointerWidth", "fieldType", "hasEnumCase", "MET001", "integer, `Bool`, and enum static values", "runtime registries", "raw token-string builders"]) {
       assert.match(languageReference, new RegExp(compileTimeTerm));
     }
+    const buildingFromSource = await readDoc("building-from-source");
+    for (const target of publicTargets) {
+      const targetPattern = new RegExp(target.replace(".", "\\."));
+      assert.match(languageReference, targetPattern);
+      assert.match(buildingFromSource, targetPattern);
+    }
     const memModule = await readDoc("module-mem");
     for (const memTerm of ["NullAlloc", "FixedBufAlloc", "PageAlloc", "GeneralAlloc", "memoryBudgets", "allocatorFacts", "allocationInstrumentation", "collectionFacts", "heapBytes: 0", "hiddenHeapAllocation: false"]) {
       assert.match(memModule, new RegExp(memTerm));
@@ -175,7 +191,7 @@ describe("docs registry", () => {
     const learnZeroCleanup = await readDoc("learn-zero");
     assert.match(learnZeroCleanup, /canonical non-raising `fn drop Void self mutref<Self>`/);
     assert.doesNotMatch(learnZeroCleanup, /More advanced ownership and `?\.drop\(\)`? behavior is still implementation work/);
-    assert.match(await readDoc("building-from-source"), /Building From Source/);
+    assert.match(buildingFromSource, /Building From Source/);
     for (const demoTerm of ["--release tiny", "fixed-capacity", "vtables", "generic registries", "hello-linux-musl", "hello-win32", "target report", "artifact size"]) {
       assert.match(examples, new RegExp(demoTerm, "i"));
     }

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -794,7 +794,8 @@ typedef enum {
   Z_DIRECT_BACKEND_ELF_AARCH64,
   Z_DIRECT_BACKEND_MACHO64,
   Z_DIRECT_BACKEND_MACHO_X64,
-  Z_DIRECT_BACKEND_COFF_X64
+  Z_DIRECT_BACKEND_COFF_X64,
+  Z_DIRECT_BACKEND_COFF_AARCH64
 } ZDirectBackend;
 
 typedef struct {
@@ -913,6 +914,8 @@ bool z_emit_elf64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *dia
 bool z_emit_elf64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_elf_aarch64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
+size_t z_elf_aarch64_stack_bytes_from_ir(const IrProgram *program);
+size_t z_elf_aarch64_max_frame_bytes_from_ir(const IrProgram *program);
 size_t z_macho64_stack_bytes_from_ir(const IrProgram *program);
 size_t z_macho64_max_frame_bytes_from_ir(const IrProgram *program);
 bool z_emit_macho64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
@@ -921,6 +924,8 @@ bool z_emit_macho_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag 
 bool z_emit_macho_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_coff_x64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_coff_x64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
+bool z_emit_coff_aarch64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
+bool z_emit_coff_aarch64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_direct_object_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag);
 bool z_emit_direct_executable_from_ir(ZDirectBackend backend, const IrProgram *program, ZBuf *out, ZDiag *diag);
 

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -69,14 +69,14 @@ static bool a64_const_u32_value(const IrValue *value, unsigned *out) {
   return true;
 }
 
-static unsigned a64_cond_for_compare(IrCompareOp op) {
+static unsigned a64_cond_for_compare(IrCompareOp op, bool uns) {
   switch (op) {
     case IR_CMP_EQ: return 0;
     case IR_CMP_NE: return 1;
-    case IR_CMP_LT: return 11;
-    case IR_CMP_LE: return 13;
-    case IR_CMP_GT: return 12;
-    case IR_CMP_GE: return 10;
+    case IR_CMP_LT: return uns ? 3 : 11;
+    case IR_CMP_LE: return uns ? 9 : 13;
+    case IR_CMP_GT: return uns ? 8 : 12;
+    case IR_CMP_GE: return uns ? 2 : 10;
   }
   return 0;
 }
@@ -329,9 +329,12 @@ static bool a64_emit_compare_to_reg_at(ZBuf *text, const IrFunction *fun, const 
   if (!a64_emit_store_scratch(text, 8, value->left->type, scratch_slot, value->left, diag)) return false;
   if (!a64_emit_value_to_reg_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
   if (!a64_emit_load_scratch(text, 8, value->left->type, scratch_slot, value->left, diag)) return false;
-  z_aarch64_emit_cmp_w(text, 8, 9);
+  bool wide = a64_type_is_scalar64(value->left->type);
+  bool uns = a64_type_is_unsigned(value->left->type);
+  if (wide) z_aarch64_emit_cmp_x(text, 8, 9);
+  else z_aarch64_emit_cmp_w(text, 8, 9);
   z_aarch64_emit_movz_w(text, reg, 0);
-  size_t false_patch = z_aarch64_emit_b_cond_placeholder(text, a64_invert_cond(a64_cond_for_compare(value->compare_op)));
+  size_t false_patch = z_aarch64_emit_b_cond_placeholder(text, a64_invert_cond(a64_cond_for_compare(value->compare_op, uns)));
   z_aarch64_emit_movz_w(text, reg, 1);
   z_aarch64_patch_cond19(text, false_patch, text->len);
   return true;

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -492,6 +492,10 @@ static void a64_emit_epilogue(ZBuf *text, unsigned frame_size) {
   z_aarch64_emit_ret(text);
 }
 
+static void a64_emit_void_result(ZBuf *text, const IrFunction *fun) {
+  if (fun && fun->return_type == IR_TYPE_VOID) z_aarch64_emit_movz_w(text, 0, 0);
+}
+
 static bool a64_emit_instrs(ZBuf *text, const IrFunction *fun, const IrInstr *instrs, size_t len, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag);
 
 static bool a64_emit_local_set(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
@@ -561,6 +565,7 @@ static bool a64_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *ins
   if (instr->kind == IR_INSTR_EXPR) return !instr->value || a64_emit_value_to_reg_at(text, fun, instr->value, 0, frame_size, 0, ctx, diag);
   if (instr->kind == IR_INSTR_RETURN) {
     if (instr->value && !a64_emit_value_to_reg_at(text, fun, instr->value, 0, frame_size, 0, ctx, diag)) return false;
+    a64_emit_void_result(text, fun);
     a64_emit_epilogue(text, frame_size);
     return true;
   }
@@ -618,7 +623,10 @@ static bool a64_emit_function_text(ZBuf *text, const IrFunction *fun, ZAArch64Di
   z_aarch64_emit_mov_x29_sp(text);
   if (frame_size > 0) z_aarch64_emit_sub_sp_imm(text, frame_size);
   if (!a64_emit_instrs(text, fun, fun->instrs, fun->instr_len, frame_size, ctx, diag)) return false;
-  if (fun->instr_len == 0 || fun->instrs[fun->instr_len - 1].kind != IR_INSTR_RETURN) a64_emit_epilogue(text, frame_size);
+  if (fun->instr_len == 0 || fun->instrs[fun->instr_len - 1].kind != IR_INSTR_RETURN) {
+    a64_emit_void_result(text, fun);
+    a64_emit_epilogue(text, frame_size);
+  }
   return true;
 }
 

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -522,21 +522,25 @@ static bool a64_emit_index_store(ZBuf *text, const IrFunction *fun, const IrInst
   }
   if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) {
     if (!a64_emit_value_to_reg_at(text, fun, instr->value, 10, frame_size, 0, ctx, diag)) return false;
-    if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 0, ctx, diag)) return false;
+    if (!a64_emit_store_scratch(text, 10, instr->value ? instr->value->type : local->element_type, 0, instr->value, diag)) return false;
+    if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 1, ctx, diag)) return false;
     z_aarch64_emit_movz_w(text, 9, local->array_len);
     a64_emit_u32_bounds_check(text, 8, 9);
     z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, instr->array_index, 0, frame_size));
     z_aarch64_emit_add_x_reg_lsl(text, 9, 9, 8, 2);
+    if (!a64_emit_load_scratch(text, 10, instr->value ? instr->value->type : local->element_type, 0, instr->value, diag)) return false;
     z_aarch64_emit_store_w_imm(text, 10, 9, 0);
     return true;
   }
   if (!local->is_array || (local->element_type != IR_TYPE_U8 && local->element_type != IR_TYPE_BOOL)) return a64_diag(diag, "direct AArch64 indexed store requires [N]u8, [N]Bool, or integer arrays", instr->line, instr->column, "unsupported array local");
   if (!a64_emit_value_to_reg_at(text, fun, instr->value, 10, frame_size, 0, ctx, diag)) return false;
-  if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 0, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 10, instr->value ? instr->value->type : local->element_type, 0, instr->value, diag)) return false;
+  if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 1, ctx, diag)) return false;
   z_aarch64_emit_movz_w(text, 9, local->array_len);
   a64_emit_u32_bounds_check(text, 8, 9);
   z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, instr->array_index, 0, frame_size));
   z_aarch64_emit_add_x_reg(text, 9, 9, 8);
+  if (!a64_emit_load_scratch(text, 10, instr->value ? instr->value->type : local->element_type, 0, instr->value, diag)) return false;
   z_aarch64_emit_store_b_imm(text, 10, 9, 0);
   return true;
 }

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -1,0 +1,674 @@
+#include "zero.h"
+#include "aarch64_direct.h"
+#include "aarch64_emit.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+enum {
+  A64_DIRECT_SCRATCH_SLOT_COUNT = 32u,
+  A64_DIRECT_SCRATCH_SLOT_BYTES = 8u
+};
+
+static bool a64_diag(ZDiag *diag, const char *message, int line, int column, const char *actual) {
+  if (diag) {
+    diag->code = 4004;
+    diag->line = line > 0 ? line : 1;
+    diag->column = column > 0 ? column : 1;
+    diag->length = 1;
+    snprintf(diag->message, sizeof(diag->message), "%s", message);
+    snprintf(diag->expected, sizeof(diag->expected), "direct AArch64 backend subset");
+    snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "unsupported construct");
+    snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to AArch64 supported direct-backend constructs");
+  }
+  return false;
+}
+
+static bool a64_return_literal(const IrFunction *fun, uint32_t *out, ZDiag *diag) {
+  if (!fun) return a64_diag(diag, "direct AArch64 backend requires a function", 1, 1, "missing function");
+  if (fun->param_count != 0) {
+    return a64_diag(diag, "direct AArch64 backend supports exported functions without parameters", fun->line, fun->column, fun->name);
+  }
+  if (fun->return_type != IR_TYPE_VOID && fun->return_type != IR_TYPE_U8 && fun->return_type != IR_TYPE_I32 && fun->return_type != IR_TYPE_U32 && fun->return_type != IR_TYPE_USIZE) {
+    return a64_diag(diag, "direct AArch64 backend supports primitive 32-bit-or-smaller integer returns", fun->line, fun->column, fun->name);
+  }
+  *out = 0;
+  if (fun->return_type == IR_TYPE_VOID) {
+    if (fun->instr_len == 0) return true;
+    if (fun->instr_len == 1 && fun->instrs[0].kind == IR_INSTR_RETURN && !fun->instrs[0].value) return true;
+    return false;
+  }
+  if (fun->instr_len == 1 && fun->instrs[0].kind == IR_INSTR_RETURN && fun->instrs[0].value &&
+      fun->instrs[0].value->kind == IR_VALUE_INT && fun->instrs[0].value->int_value <= 65535) {
+    *out = (uint32_t)fun->instrs[0].value->int_value;
+    return true;
+  }
+  return false;
+}
+
+static bool a64_type_is_scalar32(IrTypeKind type) {
+  return type == IR_TYPE_BOOL || type == IR_TYPE_U8 || type == IR_TYPE_U16 || type == IR_TYPE_I32 || type == IR_TYPE_U32 || type == IR_TYPE_USIZE;
+}
+
+static bool a64_type_is_scalar64(IrTypeKind type) {
+  return type == IR_TYPE_I64 || type == IR_TYPE_U64;
+}
+
+static bool a64_type_is_scalar(IrTypeKind type) {
+  return a64_type_is_scalar32(type) || a64_type_is_scalar64(type);
+}
+
+static bool a64_type_is_unsigned(IrTypeKind type) {
+  return type == IR_TYPE_U8 || type == IR_TYPE_U16 || type == IR_TYPE_USIZE || type == IR_TYPE_U32 || type == IR_TYPE_U64;
+}
+
+static bool a64_const_u32_value(const IrValue *value, unsigned *out) {
+  if (!value || value->kind != IR_VALUE_INT || value->int_value > UINT32_MAX) return false;
+  if (out) *out = (unsigned)value->int_value;
+  return true;
+}
+
+static unsigned a64_cond_for_compare(IrCompareOp op) {
+  switch (op) {
+    case IR_CMP_EQ: return 0;
+    case IR_CMP_NE: return 1;
+    case IR_CMP_LT: return 11;
+    case IR_CMP_LE: return 13;
+    case IR_CMP_GT: return 12;
+    case IR_CMP_GE: return 10;
+  }
+  return 0;
+}
+
+static unsigned a64_invert_cond(unsigned cond) {
+  return cond ^ 1u;
+}
+
+static unsigned a64_slot_offset(unsigned local_index) {
+  return local_index * 8u;
+}
+
+static unsigned a64_local_slot_offset(const IrFunction *fun, unsigned local_index, unsigned slot_offset, unsigned frame_size) {
+  if (fun && local_index < fun->local_len && fun->locals[local_index].frame_offset > 0 && frame_size >= fun->locals[local_index].frame_offset) {
+    return frame_size - fun->locals[local_index].frame_offset + slot_offset;
+  }
+  return A64_DIRECT_SCRATCH_SLOT_COUNT * A64_DIRECT_SCRATCH_SLOT_BYTES + a64_slot_offset(local_index) + slot_offset;
+}
+
+static void a64_emit_load_local_w(ZBuf *text, const IrFunction *fun, unsigned reg, unsigned local_index, unsigned slot_offset, unsigned frame_size) {
+  z_aarch64_emit_load_w_sp(text, reg, a64_local_slot_offset(fun, local_index, slot_offset, frame_size));
+}
+
+static void a64_emit_load_local_x(ZBuf *text, const IrFunction *fun, unsigned reg, unsigned local_index, unsigned slot_offset, unsigned frame_size) {
+  z_aarch64_emit_load_x_sp(text, reg, a64_local_slot_offset(fun, local_index, slot_offset, frame_size));
+}
+
+static void a64_emit_store_local_w(ZBuf *text, const IrFunction *fun, unsigned reg, unsigned local_index, unsigned slot_offset, unsigned frame_size) {
+  z_aarch64_emit_store_w_sp(text, reg, a64_local_slot_offset(fun, local_index, slot_offset, frame_size));
+}
+
+static void a64_emit_store_local_x(ZBuf *text, const IrFunction *fun, unsigned reg, unsigned local_index, unsigned slot_offset, unsigned frame_size) {
+  z_aarch64_emit_store_x_sp(text, reg, a64_local_slot_offset(fun, local_index, slot_offset, frame_size));
+}
+
+static bool a64_scratch_slot(unsigned slot, unsigned *offset, const IrValue *value, ZDiag *diag) {
+  if (slot >= A64_DIRECT_SCRATCH_SLOT_COUNT) {
+    return a64_diag(diag, "direct AArch64 expression nesting exceeds scratch register spill capacity", value ? value->line : 1, value ? value->column : 1, "expression too deep");
+  }
+  *offset = slot * A64_DIRECT_SCRATCH_SLOT_BYTES;
+  return true;
+}
+
+static bool a64_emit_store_scratch(ZBuf *text, unsigned reg, IrTypeKind type, unsigned slot, const IrValue *value, ZDiag *diag) {
+  unsigned offset = 0;
+  if (!a64_scratch_slot(slot, &offset, value, diag)) return false;
+  if (a64_type_is_scalar64(type)) z_aarch64_emit_store_x_sp(text, reg, offset);
+  else z_aarch64_emit_store_w_sp(text, reg, offset);
+  return true;
+}
+
+static bool a64_emit_load_scratch(ZBuf *text, unsigned reg, IrTypeKind type, unsigned slot, const IrValue *value, ZDiag *diag) {
+  unsigned offset = 0;
+  if (!a64_scratch_slot(slot, &offset, value, diag)) return false;
+  if (a64_type_is_scalar64(type)) z_aarch64_emit_load_x_sp(text, reg, offset);
+  else z_aarch64_emit_load_w_sp(text, reg, offset);
+  return true;
+}
+
+static void a64_emit_u32_bounds_check(ZBuf *text, unsigned index_reg, unsigned len_reg) {
+  z_aarch64_emit_cmp_w(text, index_reg, len_reg);
+  size_t ok_patch = z_aarch64_emit_b_cond_placeholder(text, 3);
+  z_aarch64_emit_brk(text);
+  z_aarch64_patch_cond19(text, ok_patch, text->len);
+}
+
+static void a64_emit_cast_normalize_reg(ZBuf *text, unsigned reg, IrTypeKind source, IrTypeKind target) {
+  switch (target) {
+    case IR_TYPE_BOOL:
+    case IR_TYPE_U8:
+      z_aarch64_emit_uxtb_w(text, reg, reg);
+      return;
+    case IR_TYPE_U16:
+      z_aarch64_emit_uxth_w(text, reg, reg);
+      return;
+    case IR_TYPE_I32:
+    case IR_TYPE_U32:
+    case IR_TYPE_USIZE:
+      z_aarch64_emit_mov_w(text, reg, reg);
+      return;
+    case IR_TYPE_I64:
+    case IR_TYPE_U64:
+      if (source == IR_TYPE_I32) z_aarch64_emit_sxtw_x(text, reg, reg);
+      else if (!a64_type_is_scalar64(source)) z_aarch64_emit_mov_w(text, reg, reg);
+      return;
+    default:
+      return;
+  }
+}
+
+static void a64_emit_binary_reg(ZBuf *text, IrBinaryOp op, unsigned dst, unsigned lhs, unsigned rhs, bool wide) {
+  if (op == IR_BIN_ADD) {
+    if (wide) z_aarch64_emit_add_x_reg(text, dst, lhs, rhs);
+    else z_aarch64_emit_add_w_reg(text, dst, lhs, rhs);
+  } else if (op == IR_BIN_SUB) {
+    if (wide) z_aarch64_emit_sub_x_reg(text, dst, lhs, rhs);
+    else z_aarch64_emit_sub_w_reg(text, dst, lhs, rhs);
+  } else if (op == IR_BIN_MUL) {
+    if (wide) z_aarch64_emit_mul_x_reg(text, dst, lhs, rhs);
+    else z_aarch64_emit_mul_w_reg(text, dst, lhs, rhs);
+  }
+}
+
+static bool a64_record_data_patch(ZAArch64DirectContext *ctx, size_t patch_offset, unsigned data_offset, ZDiag *diag, const IrValue *value) {
+  if (!ctx || !ctx->record_data_patch) return a64_diag(diag, "direct AArch64 readonly data patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  return ctx->record_data_patch(ctx->patch_user, patch_offset, data_offset, value, diag);
+}
+
+static bool a64_emit_rodata_ptr_literal(ZBuf *text, unsigned reg, unsigned data_offset, ZAArch64DirectContext *ctx, const IrValue *value, ZDiag *diag) {
+  while (((text->len + 8) % 8) != 0) z_aarch64_emit_nop(text);
+  z_aarch64_emit_ldr_x_literal8(text, reg);
+  z_aarch64_emit_b_offset_words(text, 3);
+  size_t patch_offset = text->len;
+  z_aarch64_append_u64(text, 0);
+  return a64_record_data_patch(ctx, patch_offset, data_offset, diag, value);
+}
+
+static bool a64_emit_byte_view_ptr_at(ZBuf *text, const IrFunction *fun, const IrValue *view, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag);
+static bool a64_emit_byte_view_len_at(ZBuf *text, const IrFunction *fun, const IrValue *view, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag);
+static bool a64_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag);
+
+static bool a64_emit_byte_view_len_at(ZBuf *text, const IrFunction *fun, const IrValue *view, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!view) return a64_diag(diag, "direct AArch64 byte view is missing", 1, 1, "missing byte view");
+  if (view->kind == IR_VALUE_STRING_LITERAL || view->kind == IR_VALUE_ARRAY_BYTE_VIEW) {
+    if (view->data_len > 65535) return a64_diag(diag, "direct AArch64 byte-view length is too large for this backend", view->line, view->column, "large byte view");
+    z_aarch64_emit_movz_w(text, reg, view->data_len);
+    return true;
+  }
+  if (view->kind == IR_VALUE_LOCAL && view->local_index < fun->local_len && fun->locals[view->local_index].type == IR_TYPE_BYTE_VIEW) {
+    a64_emit_load_local_w(text, fun, reg, view->local_index, 8, frame_size);
+    return true;
+  }
+  if (view->kind == IR_VALUE_BYTE_SLICE) {
+    unsigned start = 0;
+    unsigned end = 0;
+    if ((!view->index || a64_const_u32_value(view->index, &start)) &&
+        a64_const_u32_value(view->right, &end) && end >= start && end - start <= 65535) {
+      z_aarch64_emit_movz_w(text, reg, end - start);
+      return true;
+    }
+    if ((!view->index || a64_const_u32_value(view->index, &start)) && view->right) {
+      if (!a64_emit_value_to_reg_at(text, fun, view->right, reg, frame_size, scratch_slot, ctx, diag)) return false;
+      if (start > 0) z_aarch64_emit_sub_w_imm(text, reg, reg, start);
+      return true;
+    }
+    if (view->index && view->right) {
+      unsigned tmp = reg == 8 ? 9 : 8;
+      if (!a64_emit_value_to_reg_at(text, fun, view->right, reg, frame_size, scratch_slot, ctx, diag)) return false;
+      if (!a64_emit_store_scratch(text, reg, view->right ? view->right->type : IR_TYPE_U32, scratch_slot, view->right, diag)) return false;
+      if (!a64_emit_value_to_reg_at(text, fun, view->index, tmp, frame_size, scratch_slot + 1, ctx, diag)) return false;
+      if (!a64_emit_load_scratch(text, reg, view->right ? view->right->type : IR_TYPE_U32, scratch_slot, view->right, diag)) return false;
+      a64_emit_binary_reg(text, IR_BIN_SUB, reg, reg, tmp, false);
+      return true;
+    }
+  }
+  return a64_diag(diag, "direct AArch64 byte-view length currently requires a literal, constant slice, or byte-view local", view->line, view->column, "unsupported byte view length");
+}
+
+static bool a64_emit_byte_view_ptr_at(ZBuf *text, const IrFunction *fun, const IrValue *view, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!view) return a64_diag(diag, "direct AArch64 byte view is missing", 1, 1, "missing byte view");
+  if (view->kind == IR_VALUE_LOCAL && view->local_index < fun->local_len && fun->locals[view->local_index].type == IR_TYPE_BYTE_VIEW) {
+    a64_emit_load_local_x(text, fun, reg, view->local_index, 0, frame_size);
+    return true;
+  }
+  if (view->kind == IR_VALUE_ARRAY_BYTE_VIEW && view->array_index < fun->local_len) {
+    const IrLocal *local = &fun->locals[view->array_index];
+    if (!local->is_array || local->element_type != IR_TYPE_U8) return a64_diag(diag, "direct AArch64 byte-view array requires [N]u8", view->line, view->column, "unsupported array view");
+    z_aarch64_emit_add_x_sp_imm(text, reg, a64_local_slot_offset(fun, view->array_index, 0, frame_size));
+    return true;
+  }
+  if (view->kind == IR_VALUE_STRING_LITERAL) return a64_emit_rodata_ptr_literal(text, reg, view->data_offset, ctx, view, diag);
+  if (view->kind == IR_VALUE_BYTE_SLICE) {
+    unsigned start = 0;
+    if (!a64_emit_byte_view_ptr_at(text, fun, view->left, reg, frame_size, scratch_slot, ctx, diag)) return false;
+    if (!view->index) return true;
+    if (a64_const_u32_value(view->index, &start)) {
+      if (start > 4095) return a64_diag(diag, "direct AArch64 byte slice constant start is too large", view->line, view->column, "unsupported byte slice");
+      if (start > 0) z_aarch64_emit_add_x_imm(text, reg, reg, start);
+      return true;
+    }
+    unsigned tmp = reg == 8 ? 9 : 8;
+    if (!a64_emit_store_scratch(text, reg, IR_TYPE_U64, scratch_slot, view, diag)) return false;
+    if (!a64_emit_value_to_reg_at(text, fun, view->index, tmp, frame_size, scratch_slot + 1, ctx, diag)) return false;
+    if (!a64_emit_load_scratch(text, reg, IR_TYPE_U64, scratch_slot, view, diag)) return false;
+    z_aarch64_emit_add_x_reg(text, reg, reg, tmp);
+    return true;
+  }
+  return a64_diag(diag, "direct AArch64 value is not a supported byte view", view->line, view->column, "unsupported byte view");
+}
+
+static bool a64_emit_cast_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!a64_emit_value_to_reg_at(text, fun, value->left, reg, frame_size, scratch_slot, ctx, diag)) return false;
+  a64_emit_cast_normalize_reg(text, reg, value->left ? value->left->type : IR_TYPE_UNSUPPORTED, value->type);
+  return true;
+}
+
+static bool a64_emit_binary_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (value->binary_op == IR_BIN_AND) {
+    if (!a64_emit_value_to_reg_at(text, fun, value->left, reg, frame_size, scratch_slot, ctx, diag)) return false;
+    size_t left_false = z_aarch64_emit_cbz_w_placeholder(text, reg);
+    if (!a64_emit_value_to_reg_at(text, fun, value->right, reg, frame_size, scratch_slot, ctx, diag)) return false;
+    size_t right_false = z_aarch64_emit_cbz_w_placeholder(text, reg);
+    z_aarch64_emit_movz_w(text, reg, 1);
+    size_t end_patch = z_aarch64_emit_b_placeholder(text);
+    z_aarch64_patch_cond19(text, left_false, text->len);
+    z_aarch64_patch_cond19(text, right_false, text->len);
+    z_aarch64_emit_movz_w(text, reg, 0);
+    z_aarch64_patch_branch26(text, end_patch, text->len);
+    return true;
+  }
+  if (value->binary_op == IR_BIN_OR) {
+    if (!a64_emit_value_to_reg_at(text, fun, value->left, reg, frame_size, scratch_slot, ctx, diag)) return false;
+    size_t eval_right = z_aarch64_emit_cbz_w_placeholder(text, reg);
+    z_aarch64_emit_movz_w(text, reg, 1);
+    size_t left_true_end = z_aarch64_emit_b_placeholder(text);
+    z_aarch64_patch_cond19(text, eval_right, text->len);
+    if (!a64_emit_value_to_reg_at(text, fun, value->right, reg, frame_size, scratch_slot, ctx, diag)) return false;
+    size_t right_false = z_aarch64_emit_cbz_w_placeholder(text, reg);
+    z_aarch64_emit_movz_w(text, reg, 1);
+    size_t right_true_end = z_aarch64_emit_b_placeholder(text);
+    z_aarch64_patch_cond19(text, right_false, text->len);
+    z_aarch64_emit_movz_w(text, reg, 0);
+    z_aarch64_patch_branch26(text, left_true_end, text->len);
+    z_aarch64_patch_branch26(text, right_true_end, text->len);
+    return true;
+  }
+  if (value->binary_op != IR_BIN_ADD && value->binary_op != IR_BIN_SUB && value->binary_op != IR_BIN_MUL &&
+      value->binary_op != IR_BIN_DIV && value->binary_op != IR_BIN_MOD) {
+    return a64_diag(diag, "direct AArch64 binary operator is unsupported", value->line, value->column, "unsupported operator");
+  }
+  if (!a64_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, value->left ? value->left->type : IR_TYPE_I32, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_value_to_reg_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, value->left ? value->left->type : IR_TYPE_I32, scratch_slot, value->left, diag)) return false;
+  bool wide = a64_type_is_scalar64(value->type);
+  if (value->binary_op == IR_BIN_DIV) {
+    z_aarch64_emit_div_reg(text, reg, 8, 9, a64_type_is_unsigned(value->type), wide);
+  } else if (value->binary_op == IR_BIN_MOD) {
+    z_aarch64_emit_div_reg(text, 10, 8, 9, a64_type_is_unsigned(value->type), wide);
+    z_aarch64_emit_msub_reg(text, reg, 10, 9, 8, wide);
+  } else {
+    a64_emit_binary_reg(text, value->binary_op, reg, 8, 9, wide);
+  }
+  return true;
+}
+
+static bool a64_emit_compare_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return a64_diag(diag, "direct AArch64 comparison requires two operands", value->line, value->column, "invalid comparison");
+  if (!a64_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, value->left->type, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_value_to_reg_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, value->left->type, scratch_slot, value->left, diag)) return false;
+  z_aarch64_emit_cmp_w(text, 8, 9);
+  z_aarch64_emit_movz_w(text, reg, 0);
+  size_t false_patch = z_aarch64_emit_b_cond_placeholder(text, a64_invert_cond(a64_cond_for_compare(value->compare_op)));
+  z_aarch64_emit_movz_w(text, reg, 1);
+  z_aarch64_patch_cond19(text, false_patch, text->len);
+  return true;
+}
+
+static bool a64_emit_byte_copy_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return a64_diag(diag, "direct AArch64 byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, value->left, 10, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 10, IR_TYPE_U32, scratch_slot + 1, value->left, diag)) return false;
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 12, IR_TYPE_U64, scratch_slot + 2, value->right, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, value->right, 13, frame_size, scratch_slot + 3, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 10, IR_TYPE_U32, scratch_slot + 1, value->left, diag)) return false;
+  if (!a64_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_load_scratch(text, 12, IR_TYPE_U64, scratch_slot + 2, value->right, diag)) return false;
+  z_aarch64_emit_byte_copy_min_loop(text, reg);
+  return true;
+}
+
+static bool a64_emit_byte_fill_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return a64_diag(diag, "direct AArch64 byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
+  if (!a64_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, IR_TYPE_U8, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->right, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->right, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, value->right, 10, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, IR_TYPE_U8, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->right, diag)) return false;
+  z_aarch64_emit_byte_fill_loop(text, reg);
+  return true;
+}
+
+static bool a64_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return a64_diag(diag, "direct AArch64 byte-view equality requires two byte views", value->line, value->column, "missing byte view");
+  if (!a64_emit_byte_view_len_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
+  z_aarch64_emit_cmp_w(text, 8, 9);
+  size_t same_len = z_aarch64_emit_b_cond_placeholder(text, 0);
+  z_aarch64_emit_movz_w(text, reg, 0);
+  size_t end_patch = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_cond19(text, same_len, text->len);
+  z_aarch64_emit_mov_w(text, 10, 8);
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  z_aarch64_emit_byte_eq_loop(text, reg);
+  z_aarch64_patch_branch26(text, end_patch, text->len);
+  return true;
+}
+
+static bool a64_emit_byte_view_index_load_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->index || !a64_emit_value_to_reg_at(text, fun, value->index, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, value->left, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+  a64_emit_u32_bounds_check(text, 8, 9);
+  if (!a64_emit_byte_view_ptr_at(text, fun, value->left, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!a64_emit_load_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+  z_aarch64_emit_add_x_reg(text, 9, 9, 8);
+  z_aarch64_emit_load_b_imm(text, reg, 9, 0);
+  return true;
+}
+
+static bool a64_emit_index_load_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (value->array_index >= fun->local_len) return a64_diag(diag, "direct AArch64 indexed load array is out of range", value->line, value->column, "invalid array local");
+  const IrLocal *local = &fun->locals[value->array_index];
+  unsigned const_index = 0;
+  if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE) &&
+      a64_const_u32_value(value->index, &const_index) && const_index < local->array_len) {
+    a64_emit_load_local_w(text, fun, reg, value->array_index, const_index * 4u, frame_size);
+    return true;
+  }
+  if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) {
+    if (!value->index || !a64_emit_value_to_reg_at(text, fun, value->index, 8, frame_size, scratch_slot, ctx, diag)) return false;
+    if (!a64_emit_store_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+    z_aarch64_emit_movz_w(text, 9, local->array_len);
+    a64_emit_u32_bounds_check(text, 8, 9);
+    if (!a64_emit_load_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+    z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, value->array_index, 0, frame_size));
+    z_aarch64_emit_add_x_reg_lsl(text, 9, 9, 8, 2);
+    z_aarch64_emit_load_w_imm(text, reg, 9, 0);
+    return true;
+  }
+  if (!local->is_array || (local->element_type != IR_TYPE_U8 && local->element_type != IR_TYPE_BOOL)) return a64_diag(diag, "direct AArch64 indexed load requires [N]u8, [N]Bool, or integer arrays", value->line, value->column, "unsupported array local");
+  if (!value->index || !a64_emit_value_to_reg_at(text, fun, value->index, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!a64_emit_store_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+  z_aarch64_emit_movz_w(text, 9, local->array_len);
+  a64_emit_u32_bounds_check(text, 8, 9);
+  if (!a64_emit_load_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
+  z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, value->array_index, 0, frame_size));
+  z_aarch64_emit_add_x_reg(text, 9, 9, 8);
+  z_aarch64_emit_load_b_imm(text, reg, 9, 0);
+  return true;
+}
+
+static bool a64_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value) return a64_diag(diag, "direct AArch64 expression is missing", 1, 1, "missing expression");
+  switch (value->kind) {
+    case IR_VALUE_BOOL:
+    case IR_VALUE_INT:
+      if (a64_type_is_scalar64(value->type)) z_aarch64_emit_movz_x(text, reg, (uint64_t)value->int_value);
+      else z_aarch64_emit_movz_w(text, reg, (uint32_t)value->int_value);
+      return true;
+    case IR_VALUE_LOCAL:
+      if (value->local_index >= fun->local_len) return a64_diag(diag, "direct AArch64 local index is out of range", value->line, value->column, "invalid local");
+      if (fun->locals[value->local_index].is_array) return a64_diag(diag, "direct AArch64 fixed array local cannot be used as a scalar", value->line, value->column, "array local");
+      if (fun->locals[value->local_index].type == IR_TYPE_BYTE_VIEW) return a64_diag(diag, "direct AArch64 byte-view local cannot be used as a scalar", value->line, value->column, "byte-view local");
+      if (a64_type_is_scalar64(fun->locals[value->local_index].type)) a64_emit_load_local_x(text, fun, reg, value->local_index, 0, frame_size);
+      else a64_emit_load_local_w(text, fun, reg, value->local_index, 0, frame_size);
+      return true;
+    case IR_VALUE_CAST: return a64_emit_cast_value_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BINARY: return a64_emit_binary_value_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_COMPARE: return a64_emit_compare_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_LEN: return a64_emit_byte_view_len_at(text, fun, value->left, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_COPY: return a64_emit_byte_copy_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_FILL: return a64_emit_byte_fill_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_EQ: return a64_emit_byte_view_eq_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return a64_emit_byte_view_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_INDEX_LOAD: return a64_emit_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    default:
+      return a64_diag(diag, "direct AArch64 value kind is unsupported", value->line, value->column, "unsupported value");
+  }
+}
+
+static size_t a64_function_frame_bytes(const IrFunction *fun) {
+  uint32_t ignored = 0;
+  if (a64_return_literal(fun, &ignored, NULL)) return 0;
+  unsigned base = (unsigned)(fun ? (fun->frame_bytes ? fun->frame_bytes : fun->local_len * 8) : 0);
+  return z_aarch64_align(base + A64_DIRECT_SCRATCH_SLOT_COUNT * A64_DIRECT_SCRATCH_SLOT_BYTES, 16);
+}
+
+size_t z_aarch64_direct_stack_bytes_from_ir(const IrProgram *program) {
+  size_t total = 0;
+  for (size_t i = 0; program && i < program->function_len; i++) total += a64_function_frame_bytes(&program->functions[i]);
+  return total;
+}
+
+size_t z_aarch64_direct_max_frame_bytes_from_ir(const IrProgram *program) {
+  size_t max_frame = 0;
+  for (size_t i = 0; program && i < program->function_len; i++) {
+    size_t frame = a64_function_frame_bytes(&program->functions[i]);
+    if (frame > max_frame) max_frame = frame;
+  }
+  return max_frame;
+}
+
+static void a64_emit_epilogue(ZBuf *text, unsigned frame_size) {
+  if (frame_size > 0) z_aarch64_emit_add_sp_imm(text, frame_size);
+  z_aarch64_emit_ldp_x29_x30_sp_post16(text);
+  z_aarch64_emit_ret(text);
+}
+
+static bool a64_emit_instrs(ZBuf *text, const IrFunction *fun, const IrInstr *instrs, size_t len, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag);
+
+static bool a64_emit_local_set(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (instr->local_index >= fun->local_len) return a64_diag(diag, "direct AArch64 local store is out of range", instr->line, instr->column, "invalid local");
+  const IrLocal *local = &fun->locals[instr->local_index];
+  if (local->type == IR_TYPE_BYTE_VIEW) {
+    if (!a64_emit_byte_view_ptr_at(text, fun, instr->value, 8, frame_size, 0, ctx, diag)) return false;
+    a64_emit_store_local_x(text, fun, 8, instr->local_index, 0, frame_size);
+    if (!a64_emit_byte_view_len_at(text, fun, instr->value, 8, frame_size, 0, ctx, diag)) return false;
+    a64_emit_store_local_w(text, fun, 8, instr->local_index, 8, frame_size);
+    return true;
+  }
+  if (!a64_emit_value_to_reg_at(text, fun, instr->value, 8, frame_size, 0, ctx, diag)) return false;
+  if (a64_type_is_scalar64(local->type)) a64_emit_store_local_x(text, fun, 8, instr->local_index, 0, frame_size);
+  else a64_emit_store_local_w(text, fun, 8, instr->local_index, 0, frame_size);
+  return true;
+}
+
+static bool a64_emit_index_store(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (instr->array_index >= fun->local_len) return a64_diag(diag, "direct AArch64 indexed store array is out of range", instr->line, instr->column, "invalid array local");
+  const IrLocal *local = &fun->locals[instr->array_index];
+  unsigned const_index = 0;
+  if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE) &&
+      a64_const_u32_value(instr->index, &const_index) && const_index < local->array_len) {
+    if (!a64_emit_value_to_reg_at(text, fun, instr->value, 10, frame_size, 0, ctx, diag)) return false;
+    a64_emit_store_local_w(text, fun, 10, instr->array_index, const_index * 4u, frame_size);
+    return true;
+  }
+  if (local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) {
+    if (!a64_emit_value_to_reg_at(text, fun, instr->value, 10, frame_size, 0, ctx, diag)) return false;
+    if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 0, ctx, diag)) return false;
+    z_aarch64_emit_movz_w(text, 9, local->array_len);
+    a64_emit_u32_bounds_check(text, 8, 9);
+    z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, instr->array_index, 0, frame_size));
+    z_aarch64_emit_add_x_reg_lsl(text, 9, 9, 8, 2);
+    z_aarch64_emit_store_w_imm(text, 10, 9, 0);
+    return true;
+  }
+  if (!local->is_array || (local->element_type != IR_TYPE_U8 && local->element_type != IR_TYPE_BOOL)) return a64_diag(diag, "direct AArch64 indexed store requires [N]u8, [N]Bool, or integer arrays", instr->line, instr->column, "unsupported array local");
+  if (!a64_emit_value_to_reg_at(text, fun, instr->value, 10, frame_size, 0, ctx, diag)) return false;
+  if (!instr->index || !a64_emit_value_to_reg_at(text, fun, instr->index, 8, frame_size, 0, ctx, diag)) return false;
+  z_aarch64_emit_movz_w(text, 9, local->array_len);
+  a64_emit_u32_bounds_check(text, 8, 9);
+  z_aarch64_emit_add_x_sp_imm(text, 9, a64_local_slot_offset(fun, instr->array_index, 0, frame_size));
+  z_aarch64_emit_add_x_reg(text, 9, 9, 8);
+  z_aarch64_emit_store_b_imm(text, 10, 9, 0);
+  return true;
+}
+
+static bool a64_emit_world_write(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!instr || !instr->value) return a64_diag(diag, "direct AArch64 World write requires bytes", instr ? instr->line : 1, instr ? instr->column : 1, "missing byte view");
+  if (!ctx || !ctx->emit_world_write) return a64_diag(diag, "direct AArch64 World write requires an executable target runtime", instr->line, instr->column, "unsupported instruction");
+  if (!a64_emit_byte_view_ptr_at(text, fun, instr->value, 1, frame_size, 0, ctx, diag)) return false;
+  if (!a64_emit_byte_view_len_at(text, fun, instr->value, 2, frame_size, 0, ctx, diag)) return false;
+  z_aarch64_emit_movz_w(text, 0, instr->field_offset == 2 ? 2u : 1u);
+  return ctx->emit_world_write(text, instr, ctx, diag);
+}
+
+static bool a64_emit_instr(ZBuf *text, const IrFunction *fun, const IrInstr *instr, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (instr->kind == IR_INSTR_LOCAL_SET) return a64_emit_local_set(text, fun, instr, frame_size, ctx, diag);
+  if (instr->kind == IR_INSTR_INDEX_STORE) return a64_emit_index_store(text, fun, instr, frame_size, ctx, diag);
+  if (instr->kind == IR_INSTR_WORLD_WRITE) return a64_emit_world_write(text, fun, instr, frame_size, ctx, diag);
+  if (instr->kind == IR_INSTR_EXPR) return !instr->value || a64_emit_value_to_reg_at(text, fun, instr->value, 0, frame_size, 0, ctx, diag);
+  if (instr->kind == IR_INSTR_RETURN) {
+    if (instr->value && !a64_emit_value_to_reg_at(text, fun, instr->value, 0, frame_size, 0, ctx, diag)) return false;
+    a64_emit_epilogue(text, frame_size);
+    return true;
+  }
+  if (instr->kind == IR_INSTR_IF) {
+    if (!a64_emit_value_to_reg_at(text, fun, instr->value, 0, frame_size, 0, ctx, diag)) return false;
+    size_t false_patch = z_aarch64_emit_cbz_w_placeholder(text, 0);
+    if (!a64_emit_instrs(text, fun, instr->then_instrs, instr->then_len, frame_size, ctx, diag)) return false;
+    if (instr->else_len > 0) {
+      size_t end_patch = z_aarch64_emit_b_placeholder(text);
+      z_aarch64_patch_cond19(text, false_patch, text->len);
+      if (!a64_emit_instrs(text, fun, instr->else_instrs, instr->else_len, frame_size, ctx, diag)) return false;
+      z_aarch64_patch_branch26(text, end_patch, text->len);
+    } else {
+      z_aarch64_patch_cond19(text, false_patch, text->len);
+    }
+    return true;
+  }
+  return a64_diag(diag, "direct AArch64 instruction kind is unsupported", instr->line, instr->column, "unsupported instruction");
+}
+
+static bool a64_emit_instrs(ZBuf *text, const IrFunction *fun, const IrInstr *instrs, size_t len, unsigned frame_size, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  for (size_t i = 0; i < len; i++) {
+    if (!a64_emit_instr(text, fun, &instrs[i], frame_size, ctx, diag)) return false;
+  }
+  return true;
+}
+
+static bool a64_validate_function(const IrFunction *fun, ZDiag *diag) {
+  if (!fun) return a64_diag(diag, "direct AArch64 backend requires a function", 1, 1, "missing function");
+  if (fun->param_count != 0) return a64_diag(diag, "direct AArch64 backend supports functions without parameters", fun->line, fun->column, fun->name);
+  if (fun->return_type != IR_TYPE_VOID && !a64_type_is_scalar32(fun->return_type)) {
+    return a64_diag(diag, "direct AArch64 backend supports only Void and 32-bit-or-smaller integer returns", fun->line, fun->column, fun->name);
+  }
+  for (size_t i = 0; i < fun->local_len; i++) {
+    const IrLocal *local = &fun->locals[i];
+    if (local->type == IR_TYPE_BYTE_VIEW) continue;
+    if (local->is_array && (local->element_type == IR_TYPE_U8 || local->element_type == IR_TYPE_BOOL ||
+                            local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE)) continue;
+    if (local->is_array || !a64_type_is_scalar(local->type)) {
+      return a64_diag(diag, "direct AArch64 backend supports only primitive scalar locals and fixed byte/integer arrays", local->line, local->column, local->name);
+    }
+  }
+  return true;
+}
+
+static bool a64_emit_function_text(ZBuf *text, const IrFunction *fun, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  uint32_t literal = 0;
+  if (a64_return_literal(fun, &literal, NULL)) {
+    z_aarch64_emit_literal_return(text, literal);
+    return true;
+  }
+  if (!a64_validate_function(fun, diag)) return false;
+  unsigned frame_size = (unsigned)a64_function_frame_bytes(fun);
+  z_aarch64_emit_stp_x29_x30_sp_pre16(text);
+  z_aarch64_emit_mov_x29_sp(text);
+  if (frame_size > 0) z_aarch64_emit_sub_sp_imm(text, frame_size);
+  if (!a64_emit_instrs(text, fun, fun->instrs, fun->instr_len, frame_size, ctx, diag)) return false;
+  if (fun->instr_len == 0 || fun->instrs[fun->instr_len - 1].kind != IR_INSTR_RETURN) a64_emit_epilogue(text, frame_size);
+  return true;
+}
+
+static const IrFunction *a64_find_main(const IrProgram *ir, unsigned *out_index, ZDiag *diag) {
+  const IrFunction *fun = NULL;
+  unsigned index = 0;
+  for (size_t i = 0; ir && i < ir->function_len; i++) {
+    if (ir->functions[i].is_exported && strcmp(ir->functions[i].name, "main") == 0) {
+      if (fun) {
+        a64_diag(diag, "direct AArch64 executable backend requires exactly one exported main function", ir->functions[i].line, ir->functions[i].column, ir->functions[i].name);
+        return NULL;
+      }
+      fun = &ir->functions[i];
+      index = (unsigned)i;
+    }
+  }
+  if (!fun) {
+    a64_diag(diag, "direct AArch64 executable backend requires an exported main function", 1, 1, "missing main");
+    return NULL;
+  }
+  if (out_index) *out_index = index;
+  return fun;
+}
+
+static unsigned a64_rodata_base_offset(const IrProgram *ir) {
+  if (!ir || ir->data_segment_len == 0) return 0;
+  unsigned base = ir->data_segments[0].offset;
+  for (size_t i = 1; i < ir->data_segment_len; i++) {
+    if (ir->data_segments[i].offset < base) base = ir->data_segments[i].offset;
+  }
+  return base;
+}
+
+static void a64_append_rodata(ZBuf *rodata, const IrProgram *ir, unsigned base_offset) {
+  for (size_t i = 0; ir && i < ir->data_segment_len; i++) {
+    const IrDataSegment *segment = &ir->data_segments[i];
+    while (rodata->len < segment->offset - base_offset) zbuf_append_char(rodata, 0);
+    for (size_t j = 0; j < segment->len; j++) zbuf_append_char(rodata, (char)segment->bytes[j]);
+  }
+}
+
+bool z_aarch64_direct_emit_function_text(ZBuf *text, const IrFunction *fun, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  return a64_emit_function_text(text, fun, ctx, diag);
+}
+
+bool z_aarch64_direct_validate_function(const IrFunction *fun, ZDiag *diag) {
+  return a64_validate_function(fun, diag);
+}
+
+const IrFunction *z_aarch64_direct_find_main(const IrProgram *program, unsigned *out_index, ZDiag *diag) {
+  return a64_find_main(program, out_index, diag);
+}
+
+unsigned z_aarch64_direct_rodata_base_offset(const IrProgram *program) {
+  return a64_rodata_base_offset(program);
+}
+
+void z_aarch64_direct_append_rodata(ZBuf *rodata, const IrProgram *program, unsigned base_offset) {
+  a64_append_rodata(rodata, program, base_offset);
+}

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -380,11 +380,11 @@ static bool a64_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun, c
   z_aarch64_emit_movz_w(text, reg, 0);
   size_t end_patch = z_aarch64_emit_b_placeholder(text);
   z_aarch64_patch_cond19(text, same_len, text->len);
-  z_aarch64_emit_mov_w(text, 10, 8);
   if (!a64_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
   if (!a64_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
   if (!a64_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
   if (!a64_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  if (!a64_emit_load_scratch(text, 10, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
   z_aarch64_emit_byte_eq_loop(text, reg);
   z_aarch64_patch_branch26(text, end_patch, text->len);
   return true;

--- a/native/zero-c/src/aarch64_direct.h
+++ b/native/zero-c/src/aarch64_direct.h
@@ -1,0 +1,29 @@
+#ifndef ZERO_C_AARCH64_DIRECT_H
+#define ZERO_C_AARCH64_DIRECT_H
+
+#include "zero.h"
+
+typedef struct ZAArch64DirectContext ZAArch64DirectContext;
+
+typedef bool (*ZAArch64DirectDataPatchFn)(void *user, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag);
+typedef bool (*ZAArch64DirectWorldWriteFn)(ZBuf *text, const IrInstr *instr, ZAArch64DirectContext *ctx, ZDiag *diag);
+
+struct ZAArch64DirectContext {
+  const IrProgram *program;
+  size_t *function_offsets;
+  size_t function_count;
+  unsigned rodata_base_offset;
+  void *patch_user;
+  ZAArch64DirectDataPatchFn record_data_patch;
+  ZAArch64DirectWorldWriteFn emit_world_write;
+};
+
+bool z_aarch64_direct_emit_function_text(ZBuf *text, const IrFunction *fun, ZAArch64DirectContext *ctx, ZDiag *diag);
+bool z_aarch64_direct_validate_function(const IrFunction *fun, ZDiag *diag);
+const IrFunction *z_aarch64_direct_find_main(const IrProgram *program, unsigned *out_index, ZDiag *diag);
+unsigned z_aarch64_direct_rodata_base_offset(const IrProgram *program);
+void z_aarch64_direct_append_rodata(ZBuf *rodata, const IrProgram *program, unsigned base_offset);
+size_t z_aarch64_direct_stack_bytes_from_ir(const IrProgram *program);
+size_t z_aarch64_direct_max_frame_bytes_from_ir(const IrProgram *program);
+
+#endif

--- a/native/zero-c/src/aarch64_emit.c
+++ b/native/zero-c/src/aarch64_emit.c
@@ -45,6 +45,10 @@ void z_aarch64_emit_ret(ZBuf *text) {
   z_aarch64_append_u32(text, 0xd65f03c0u);
 }
 
+void z_aarch64_emit_blr_x(ZBuf *text, unsigned reg) {
+  z_aarch64_append_u32(text, 0xd63f0000u | ((reg & 31u) << 5));
+}
+
 void z_aarch64_emit_nop(ZBuf *text) {
   z_aarch64_append_u32(text, 0xd503201fu);
 }
@@ -251,6 +255,63 @@ void z_aarch64_emit_ldr_x_literal8(ZBuf *text, unsigned reg) {
 
 void z_aarch64_emit_b_offset_words(ZBuf *text, int32_t words) {
   z_aarch64_append_u32(text, 0x14000000u | ((uint32_t)words & 0x03ffffffu));
+}
+
+void z_aarch64_emit_byte_copy_min_loop(ZBuf *text, unsigned result_reg) {
+  z_aarch64_emit_mov_w(text, 14, 13);
+  z_aarch64_emit_cmp_w(text, 13, 10);
+  size_t keep_dst_len = z_aarch64_emit_b_cond_placeholder(text, 9);
+  z_aarch64_emit_mov_w(text, 14, 10);
+  z_aarch64_patch_cond19(text, keep_dst_len, text->len);
+  z_aarch64_emit_movz_w(text, 9, 0);
+  size_t loop = text->len;
+  z_aarch64_emit_cmp_w(text, 9, 14);
+  size_t done = z_aarch64_emit_b_cond_placeholder(text, 2);
+  z_aarch64_emit_add_x_reg(text, 15, 11, 9);
+  z_aarch64_emit_load_b_imm(text, 15, 15, 0);
+  z_aarch64_emit_add_x_reg(text, 13, 12, 9);
+  z_aarch64_emit_store_b_imm(text, 15, 13, 0);
+  z_aarch64_emit_add_w_imm(text, 9, 9, 1);
+  size_t back = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_branch26(text, back, loop);
+  z_aarch64_patch_cond19(text, done, text->len);
+  z_aarch64_emit_mov_w(text, result_reg, 14);
+}
+
+void z_aarch64_emit_byte_fill_loop(ZBuf *text, unsigned result_reg) {
+  z_aarch64_emit_movz_w(text, 9, 0);
+  size_t loop = text->len;
+  z_aarch64_emit_cmp_w(text, 9, 10);
+  size_t done = z_aarch64_emit_b_cond_placeholder(text, 2);
+  z_aarch64_emit_add_x_reg(text, 12, 11, 9);
+  z_aarch64_emit_store_b_imm(text, 8, 12, 0);
+  z_aarch64_emit_add_w_imm(text, 9, 9, 1);
+  size_t back = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_branch26(text, back, loop);
+  z_aarch64_patch_cond19(text, done, text->len);
+  z_aarch64_emit_mov_w(text, result_reg, 10);
+}
+
+void z_aarch64_emit_byte_eq_loop(ZBuf *text, unsigned result_reg) {
+  z_aarch64_emit_movz_w(text, 9, 0);
+  size_t loop = text->len;
+  z_aarch64_emit_cmp_w(text, 9, 10);
+  size_t equal = z_aarch64_emit_b_cond_placeholder(text, 2);
+  z_aarch64_emit_add_x_reg(text, 13, 11, 9);
+  z_aarch64_emit_load_b_imm(text, 13, 13, 0);
+  z_aarch64_emit_add_x_reg(text, 14, 12, 9);
+  z_aarch64_emit_load_b_imm(text, 14, 14, 0);
+  z_aarch64_emit_cmp_w(text, 13, 14);
+  size_t mismatch = z_aarch64_emit_b_cond_placeholder(text, 1);
+  z_aarch64_emit_add_w_imm(text, 9, 9, 1);
+  size_t back = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_branch26(text, back, loop);
+  z_aarch64_patch_cond19(text, mismatch, text->len);
+  z_aarch64_emit_movz_w(text, result_reg, 0);
+  size_t after_false = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_cond19(text, equal, text->len);
+  z_aarch64_emit_movz_w(text, result_reg, 1);
+  z_aarch64_patch_branch26(text, after_false, text->len);
 }
 
 size_t z_aarch64_emit_bl_placeholder(ZBuf *text) {

--- a/native/zero-c/src/aarch64_emit.h
+++ b/native/zero-c/src/aarch64_emit.h
@@ -15,6 +15,7 @@ void z_aarch64_patch_u32(ZBuf *buf, size_t offset, uint32_t value);
 void z_aarch64_patch_u64(ZBuf *buf, size_t offset, uint64_t value);
 
 void z_aarch64_emit_ret(ZBuf *text);
+void z_aarch64_emit_blr_x(ZBuf *text, unsigned reg);
 void z_aarch64_emit_nop(ZBuf *text);
 void z_aarch64_emit_brk(ZBuf *text);
 void z_aarch64_emit_svc(ZBuf *text, unsigned imm16);
@@ -63,6 +64,9 @@ void z_aarch64_emit_cmp_x(ZBuf *text, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_adrp_add_placeholder(ZBuf *text, unsigned reg);
 void z_aarch64_emit_ldr_x_literal8(ZBuf *text, unsigned reg);
 void z_aarch64_emit_b_offset_words(ZBuf *text, int32_t words);
+void z_aarch64_emit_byte_copy_min_loop(ZBuf *text, unsigned result_reg);
+void z_aarch64_emit_byte_fill_loop(ZBuf *text, unsigned result_reg);
+void z_aarch64_emit_byte_eq_loop(ZBuf *text, unsigned result_reg);
 
 size_t z_aarch64_emit_bl_placeholder(ZBuf *text);
 size_t z_aarch64_emit_b_placeholder(ZBuf *text);

--- a/native/zero-c/src/buildability.c
+++ b/native/zero-c/src/buildability.c
@@ -129,10 +129,12 @@ static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, c
       if (instr->value && !build_check_value(ctx, fun, instr->value, true, 0, diag)) return false;
       return true;
     case IR_INSTR_INDEX_STORE:
-    case IR_INSTR_FIELD_STORE:
+    case IR_INSTR_FIELD_STORE: {
       if (instr->value && !build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
-      if (instr->index && !build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
+      unsigned index_scratch_slot = instr->kind == IR_INSTR_INDEX_STORE && z_build_backend_is_aarch64_direct(ctx->backend) ? 1 : 0;
+      if (instr->index && !build_check_value(ctx, fun, instr->index, false, index_scratch_slot, diag)) return false;
       return true;
+    }
     case IR_INSTR_WORLD_WRITE:
       if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64 && instr->value && !z_build_check_coff_byte_view(ctx, fun, instr->value, diag)) return false;
       if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 && instr->value && !z_build_check_macho_x64_byte_view(ctx, fun, instr->value, diag)) return false;

--- a/native/zero-c/src/buildability.c
+++ b/native/zero-c/src/buildability.c
@@ -1,16 +1,28 @@
 #include "buildability_internal.h"
 
-#include <stdio.h>
 #include <string.h>
 
 static bool build_value_supported(const ZBuildability *ctx, const IrValue *value, bool local_set_value) {
   if (!ctx || !value) return false;
-  if (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64) return true;
+  if (z_build_backend_is_aarch64_direct(ctx->backend)) {
+    switch (value->kind) {
+      case IR_VALUE_INT: case IR_VALUE_BOOL: case IR_VALUE_LOCAL: case IR_VALUE_CAST: case IR_VALUE_BINARY: case IR_VALUE_COMPARE:
+      case IR_VALUE_STRING_LITERAL: case IR_VALUE_ARRAY_BYTE_VIEW: case IR_VALUE_BYTE_SLICE: case IR_VALUE_BYTE_VIEW_LEN:
+      case IR_VALUE_BYTE_VIEW_INDEX_LOAD: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL: case IR_VALUE_BYTE_VIEW_EQ:
+      case IR_VALUE_INDEX_LOAD:
+        (void)local_set_value;
+        return true;
+      default:
+        (void)local_set_value;
+        return false;
+    }
+  }
   if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64) {
     switch (value->kind) {
       case IR_VALUE_INT: case IR_VALUE_BOOL: case IR_VALUE_LOCAL: case IR_VALUE_CAST: case IR_VALUE_BINARY: case IR_VALUE_COMPARE: case IR_VALUE_CALL:
       case IR_VALUE_STRING_LITERAL: case IR_VALUE_ARRAY_BYTE_VIEW: case IR_VALUE_BYTE_SLICE: case IR_VALUE_BYTE_VIEW_LEN:
-      case IR_VALUE_BYTE_VIEW_INDEX_LOAD: case IR_VALUE_INDEX_LOAD: case IR_VALUE_FIELD_LOAD: case IR_VALUE_CHECK:
+      case IR_VALUE_BYTE_VIEW_INDEX_LOAD: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL: case IR_VALUE_BYTE_VIEW_EQ:
+      case IR_VALUE_INDEX_LOAD: case IR_VALUE_FIELD_LOAD: case IR_VALUE_CHECK:
         return true;
       default:
         (void)local_set_value;
@@ -41,8 +53,14 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
     case IR_VALUE_FS_CLOSE_FILE: case IR_VALUE_FS_EXISTS: case IR_VALUE_FS_REMOVE: case IR_VALUE_FS_RENAME:
     case IR_VALUE_FS_FILE_LEN: case IR_VALUE_FS_MAKE_DIR: case IR_VALUE_FS_REMOVE_DIR: case IR_VALUE_FS_IS_DIR:
     case IR_VALUE_FS_DIR_ENTRY_COUNT: case IR_VALUE_FS_TEMP_NAME: case IR_VALUE_FS_ATOMIC_WRITE:
-    case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_VIEW_EQ: case IR_VALUE_CRC32_BYTES:
+    case IR_VALUE_CRC32_BYTES:
       return ctx->backend == Z_DIRECT_BACKEND_ELF64;
+    case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL:
+      return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 ||
+             ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 || ctx->backend == Z_DIRECT_BACKEND_COFF_X64;
+    case IR_VALUE_BYTE_VIEW_EQ:
+      return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 ||
+             ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 || ctx->backend == Z_DIRECT_BACKEND_COFF_X64;
     case IR_VALUE_CHECK: return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 || ctx->backend == Z_DIRECT_BACKEND_MACHO_X64;
     case IR_VALUE_RESCUE: return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64;
     case IR_VALUE_MAYBE_VALUE:
@@ -53,8 +71,6 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
     case IR_VALUE_HTTP_RESPONSE_BODY_OFFSET: case IR_VALUE_HTTP_HEADER_VALUE: case IR_VALUE_HTTP_HEADER_FOUND:
     case IR_VALUE_HTTP_HEADER_OFFSET: case IR_VALUE_HTTP_HEADER_LEN:
       return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64;
-    case IR_VALUE_BYTE_FILL:
-      return false;
   }
   return false;
 }
@@ -65,81 +81,16 @@ static bool build_check_value(const ZBuildability *ctx, const IrFunction *fun, c
     return z_build_diag(ctx, diag, "direct backend buildability does not support this MIR value", value->line, value->column, z_build_value_kind_name(value->kind));
   }
   bool skip_left = false;
-  if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64) {
-    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_coff_byte_view_len(ctx, fun, value->left, diag)) return false;
-    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
-    if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
-    skip_left = value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD || value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT;
-  }
-  if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64) {
-    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_x64_byte_view_len(ctx, fun, value->left, diag)) return false;
-    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
-    skip_left = value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD;
-  }
-  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64) {
-    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_byte_view_len(ctx, fun, value->left, diag)) return false;
-    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-    if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-    if ((value->kind == IR_VALUE_JSON_PARSE_BYTES || value->kind == IR_VALUE_JSON_VALIDATE_BYTES || value->kind == IR_VALUE_JSON_STREAM_TOKENS_BYTES) &&
-        !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-    if (value->kind == IR_VALUE_HTTP_FETCH) {
-      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
-    }
-    if ((value->kind == IR_VALUE_HTTP_RESPONSE_LEN || value->kind == IR_VALUE_HTTP_RESPONSE_HEADERS_LEN || value->kind == IR_VALUE_HTTP_RESPONSE_BODY_OFFSET) &&
-        !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-    if (value->kind == IR_VALUE_HTTP_HEADER_VALUE) {
-      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
-      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
-    }
-  }
-  if (value->kind == IR_VALUE_BINARY) {
-    bool supported = true;
-    if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64) supported = value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB || value->binary_op == IR_BIN_MUL;
-    if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64) supported = value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB || value->binary_op == IR_BIN_MUL || value->binary_op == IR_BIN_DIV || value->binary_op == IR_BIN_MOD || value->binary_op == IR_BIN_AND || value->binary_op == IR_BIN_OR;
-    if (ctx->backend == Z_DIRECT_BACKEND_MACHO64) supported = value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB || value->binary_op == IR_BIN_MUL || value->binary_op == IR_BIN_DIV || value->binary_op == IR_BIN_MOD || value->binary_op == IR_BIN_AND || value->binary_op == IR_BIN_OR;
-    if (!supported) return z_build_diag(ctx, diag, "direct backend buildability does not support this binary operator", value->line, value->column, "unsupported operator");
-    if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->binary_op != IR_BIN_AND && value->binary_op != IR_BIN_OR &&
-        macho_scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
-      return z_build_diag(ctx, diag, "direct AArch64 Mach-O expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
-    }
-  }
-  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->kind == IR_VALUE_COMPARE && macho_scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
-    return z_build_diag(ctx, diag, "direct AArch64 Mach-O expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
-  }
-  if (value->kind == IR_VALUE_CALL) {
-    size_t max_args = ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ? 4 : (ctx->backend == Z_DIRECT_BACKEND_MACHO64 ? 8 : 6);
-    size_t abi_slots = 0;
-    for (size_t i = 0; i < value->arg_len; i++) abi_slots += value->args[i] && value->args[i]->type == IR_TYPE_BYTE_VIEW ? 2u : 1u;
-    if (ctx->backend != Z_DIRECT_BACKEND_ELF_AARCH64 && abi_slots > max_args) {
-      char actual[80];
-      snprintf(actual, sizeof(actual), "%zu ABI argument slot(s)", abi_slots);
-      return z_build_diag(ctx, diag, "direct backend buildability found a call with too many arguments", value->line, value->column, actual);
-    }
-    if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && macho_scratch_slot + abi_slots >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
-      return z_build_diag(ctx, diag, "direct AArch64 Mach-O call argument nesting exceeds scratch spill capacity", value->line, value->column, "too many nested call arguments");
-    }
-  }
+  unsigned right_slot = macho_scratch_slot;
+  if (!z_build_check_target_value(ctx, fun, value, macho_scratch_slot, &skip_left, &right_slot, diag)) return false;
   if (value->kind == IR_VALUE_LOCAL && fun && value->local_index < fun->local_len && fun->locals[value->local_index].is_array) {
     return z_build_diag(ctx, diag, "direct backend buildability cannot use fixed array locals as scalar values", value->line, value->column, "array local");
-  }
-  unsigned right_slot = macho_scratch_slot;
-  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 &&
-      ((value->kind == IR_VALUE_BINARY && value->binary_op != IR_BIN_AND && value->binary_op != IR_BIN_OR) ||
-       value->kind == IR_VALUE_COMPARE)) {
-    right_slot = macho_scratch_slot + 1;
   }
   if (value->index && !build_check_value(ctx, fun, value->index, false, macho_scratch_slot, diag)) return false;
   if (value->left && !skip_left && !build_check_value(ctx, fun, value->left, false, macho_scratch_slot, diag)) return false;
   if (value->right && !build_check_value(ctx, fun, value->right, false, right_slot, diag)) return false;
-  size_t arg_abi_slots = 0;
-  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->kind == IR_VALUE_CALL) {
-    for (size_t i = 0; i < value->arg_len; i++) arg_abi_slots += value->args[i] && value->args[i]->type == IR_TYPE_BYTE_VIEW ? 2u : 1u;
-  }
+  unsigned arg_slot = z_build_target_call_arg_slot(ctx, value, macho_scratch_slot);
   for (size_t i = 0; i < value->arg_len; i++) {
-    unsigned arg_slot = ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->kind == IR_VALUE_CALL
-                      ? macho_scratch_slot + (unsigned)arg_abi_slots
-                      : macho_scratch_slot;
     if (!build_check_value(ctx, fun, value->args[i], false, arg_slot, diag)) return false;
   }
   return true;
@@ -149,7 +100,18 @@ static bool build_check_instrs(const ZBuildability *ctx, const IrFunction *fun, 
 
 static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, const IrInstr *instr, ZDiag *diag) {
   if (!ctx || !instr) return z_build_diag(ctx, diag, "direct backend buildability found a missing instruction", 1, 1, "missing instruction");
-  if (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64) return true;
+  if (z_build_backend_is_aarch64_direct(ctx->backend) && instr->kind == IR_INSTR_WORLD_WRITE) {
+    if (!ctx->executable) {
+      return z_build_diag(ctx, diag, "direct AArch64 object buildability does not support World write instructions", instr->line, instr->column, "IR_INSTR_WORLD_WRITE");
+    }
+    if (instr->value && !z_build_check_aarch64_byte_view(ctx, fun, instr->value, diag)) return false;
+    if (instr->index && !build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
+    return true;
+  }
+  if (z_build_backend_is_aarch64_direct(ctx->backend) &&
+      (instr->kind == IR_INSTR_FIELD_STORE || instr->kind == IR_INSTR_WHILE || instr->kind == IR_INSTR_RAISE)) {
+    return z_build_diag(ctx, diag, "direct AArch64 buildability does not support this instruction yet", instr->line, instr->column, "unsupported instruction");
+  }
   switch (instr->kind) {
     case IR_INSTR_LOCAL_SET:
       if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64 && fun && instr->local_index < fun->local_len && fun->locals[instr->local_index].type == IR_TYPE_BYTE_VIEW) {
@@ -160,6 +122,9 @@ static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, c
       }
       if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && fun && instr->local_index < fun->local_len && fun->locals[instr->local_index].type == IR_TYPE_BYTE_VIEW) {
         if (instr->value && !z_build_check_macho_byte_view(ctx, fun, instr->value, diag)) return false;
+      }
+      if (z_build_backend_is_aarch64_direct(ctx->backend) && fun && instr->local_index < fun->local_len && fun->locals[instr->local_index].type == IR_TYPE_BYTE_VIEW) {
+        if (instr->value && !z_build_check_aarch64_byte_view(ctx, fun, instr->value, diag)) return false;
       }
       if (instr->value && !build_check_value(ctx, fun, instr->value, true, 0, diag)) return false;
       return true;
@@ -204,12 +169,10 @@ static bool build_check_function_shape(const ZBuildability *ctx, const IrFunctio
   size_t abi_slots = 0;
   for (size_t i = 0; i < fun->param_count; i++) abi_slots += fun->locals[i].type == IR_TYPE_BYTE_VIEW ? 2 : 1;
   size_t max_slots = ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ? 4 : (ctx->backend == Z_DIRECT_BACKEND_MACHO64 ? 8 : 6);
-  if (ctx->backend != Z_DIRECT_BACKEND_ELF_AARCH64 && abi_slots > max_slots) {
+  if (!z_build_backend_is_aarch64_direct(ctx->backend) && abi_slots > max_slots) {
     return z_build_diag(ctx, diag, "direct backend object buildability has too many ABI argument slots", fun->line, fun->column, fun->name);
   }
-  if (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64) {
-    return z_build_check_aarch64_literal_shape(ctx, fun, diag);
-  }
+  if (z_build_backend_is_aarch64_direct(ctx->backend)) return z_build_check_aarch64_function_shape(ctx, fun, diag);
   bool wide_scalars = ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 || ctx->backend == Z_DIRECT_BACKEND_MACHO_X64;
   bool return_ok = wide_scalars ? (fun->return_type == IR_TYPE_VOID || z_build_is_elf_scalar(fun->return_type))
                                 : (fun->return_type == IR_TYPE_VOID || z_build_is_scalar32(fun->return_type));
@@ -253,21 +216,24 @@ static const IrFunction *build_find_main(const ZBuildability *ctx, const IrProgr
 static bool build_check_executable_shape(const ZBuildability *ctx, const IrProgram *ir, ZDiag *diag) {
   const IrFunction *main_fun = build_find_main(ctx, ir, diag);
   if (!main_fun) return false;
-  if (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64) return true;
   if (main_fun->param_count != 0) {
     const char *message = ctx->backend == Z_DIRECT_BACKEND_ELF64 ? "direct ELF64 executable main must not take parameters" :
+                          (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64 ? "direct AArch64 ELF executable main must not take parameters" :
+                          (ctx->backend == Z_DIRECT_BACKEND_COFF_AARCH64 ? "direct COFF AArch64 executable main must not take parameters" :
                           (ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ? "direct COFF x64 executable main must not take parameters" :
                            (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 ? "direct x86_64 Mach-O executable main must not take parameters" :
-                            "direct AArch64 Mach-O executable main must not take parameters"));
+                            "direct AArch64 Mach-O executable main must not take parameters"))));
     return z_build_diag(ctx, diag, message, main_fun->line, main_fun->column, main_fun->name);
   }
   bool return_ok = ctx->backend == Z_DIRECT_BACKEND_ELF64 ? z_build_is_scalar32(main_fun->return_type)
                                                          : (main_fun->return_type == IR_TYPE_VOID || z_build_is_scalar32(main_fun->return_type));
   if (!return_ok) {
     const char *message = ctx->backend == Z_DIRECT_BACKEND_ELF64 ? "direct ELF64 executable main must return a 32-bit-or-smaller scalar" :
+                          (ctx->backend == Z_DIRECT_BACKEND_ELF_AARCH64 ? "direct AArch64 ELF executable main must return Void or a 32-bit-or-smaller scalar" :
+                          (ctx->backend == Z_DIRECT_BACKEND_COFF_AARCH64 ? "direct COFF AArch64 executable main must return Void or a 32-bit-or-smaller scalar" :
                           (ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ? "direct COFF x64 executable main must return Void or a 32-bit-or-smaller scalar" :
                            (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 ? "direct x86_64 Mach-O executable main must return Void or a 32-bit-or-smaller scalar" :
-                            "direct AArch64 Mach-O executable main must return Void or a 32-bit-or-smaller scalar"));
+                            "direct AArch64 Mach-O executable main must return Void or a 32-bit-or-smaller scalar"))));
     return z_build_diag(ctx, diag, message, main_fun->line, main_fun->column, z_build_type_name(main_fun->return_type));
   }
   return true;
@@ -283,11 +249,11 @@ bool z_direct_buildability_check(const IrProgram *ir, const ZTargetInfo *target,
   bool has_export = false;
   for (size_t i = 0; i < ir->function_len; i++) {
     if (ir->functions[i].is_exported) has_export = true;
-    if (ctx.backend == Z_DIRECT_BACKEND_ELF_AARCH64 && !ir->functions[i].is_exported) continue;
+    if (z_build_backend_is_aarch64_direct(ctx.backend) && !ir->functions[i].is_exported) continue;
     if (!build_check_function_shape(&ctx, &ir->functions[i], diag)) return false;
     if (!build_check_instrs(&ctx, &ir->functions[i], ir->functions[i].instrs, ir->functions[i].instr_len, diag)) return false;
   }
   if (!has_export) return z_build_diag(&ctx, diag, "direct backend buildability requires at least one exported function", 1, 1, "no exported function");
-  if (strcmp(ctx.emit_kind, "exe") == 0 && !build_check_executable_shape(&ctx, ir, diag)) return false;
+  if (ctx.executable && !build_check_executable_shape(&ctx, ir, diag)) return false;
   return true;
 }

--- a/native/zero-c/src/buildability.c
+++ b/native/zero-c/src/buildability.c
@@ -75,23 +75,23 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
   return false;
 }
 
-static bool build_check_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, bool local_set_value, unsigned macho_scratch_slot, ZDiag *diag) {
+bool z_build_check_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, bool local_set_value, unsigned scratch_slot, ZDiag *diag) {
   if (!value) return z_build_diag(ctx, diag, "direct backend buildability found a missing expression", 1, 1, "missing expression");
   if (!build_value_supported(ctx, value, local_set_value)) {
     return z_build_diag(ctx, diag, "direct backend buildability does not support this MIR value", value->line, value->column, z_build_value_kind_name(value->kind));
   }
   bool skip_left = false;
-  unsigned right_slot = macho_scratch_slot;
-  if (!z_build_check_target_value(ctx, fun, value, macho_scratch_slot, &skip_left, &right_slot, diag)) return false;
+  unsigned right_slot = scratch_slot;
+  if (!z_build_check_target_value(ctx, fun, value, scratch_slot, &skip_left, &right_slot, diag)) return false;
   if (value->kind == IR_VALUE_LOCAL && fun && value->local_index < fun->local_len && fun->locals[value->local_index].is_array) {
     return z_build_diag(ctx, diag, "direct backend buildability cannot use fixed array locals as scalar values", value->line, value->column, "array local");
   }
-  if (value->index && !build_check_value(ctx, fun, value->index, false, macho_scratch_slot, diag)) return false;
-  if (value->left && !skip_left && !build_check_value(ctx, fun, value->left, false, macho_scratch_slot, diag)) return false;
-  if (value->right && !build_check_value(ctx, fun, value->right, false, right_slot, diag)) return false;
-  unsigned arg_slot = z_build_target_call_arg_slot(ctx, value, macho_scratch_slot);
+  if (value->index && !z_build_check_value(ctx, fun, value->index, false, scratch_slot, diag)) return false;
+  if (value->left && !skip_left && !z_build_check_value(ctx, fun, value->left, false, scratch_slot, diag)) return false;
+  if (value->right && !z_build_check_value(ctx, fun, value->right, false, right_slot, diag)) return false;
+  unsigned arg_slot = z_build_target_call_arg_slot(ctx, value, scratch_slot);
   for (size_t i = 0; i < value->arg_len; i++) {
-    if (!build_check_value(ctx, fun, value->args[i], false, arg_slot, diag)) return false;
+    if (!z_build_check_value(ctx, fun, value->args[i], false, arg_slot, diag)) return false;
   }
   return true;
 }
@@ -105,7 +105,7 @@ static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, c
       return z_build_diag(ctx, diag, "direct AArch64 object buildability does not support World write instructions", instr->line, instr->column, "IR_INSTR_WORLD_WRITE");
     }
     if (instr->value && !z_build_check_aarch64_byte_view(ctx, fun, instr->value, diag)) return false;
-    if (instr->index && !build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
+    if (instr->index && !z_build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
     return true;
   }
   if (z_build_backend_is_aarch64_direct(ctx->backend) &&
@@ -126,30 +126,30 @@ static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, c
       if (z_build_backend_is_aarch64_direct(ctx->backend) && fun && instr->local_index < fun->local_len && fun->locals[instr->local_index].type == IR_TYPE_BYTE_VIEW) {
         if (instr->value && !z_build_check_aarch64_byte_view(ctx, fun, instr->value, diag)) return false;
       }
-      if (instr->value && !build_check_value(ctx, fun, instr->value, true, 0, diag)) return false;
+      if (instr->value && !z_build_check_value(ctx, fun, instr->value, true, 0, diag)) return false;
       return true;
     case IR_INSTR_INDEX_STORE:
     case IR_INSTR_FIELD_STORE: {
-      if (instr->value && !build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
+      if (instr->value && !z_build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
       unsigned index_scratch_slot = instr->kind == IR_INSTR_INDEX_STORE && z_build_backend_is_aarch64_direct(ctx->backend) ? 1 : 0;
-      if (instr->index && !build_check_value(ctx, fun, instr->index, false, index_scratch_slot, diag)) return false;
+      if (instr->index && !z_build_check_value(ctx, fun, instr->index, false, index_scratch_slot, diag)) return false;
       return true;
     }
     case IR_INSTR_WORLD_WRITE:
       if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64 && instr->value && !z_build_check_coff_byte_view(ctx, fun, instr->value, diag)) return false;
       if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 && instr->value && !z_build_check_macho_x64_byte_view(ctx, fun, instr->value, diag)) return false;
       if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && instr->value && !z_build_check_macho_byte_view(ctx, fun, instr->value, diag)) return false;
-      if (ctx->backend != Z_DIRECT_BACKEND_COFF_X64 && instr->value && !build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
-      if (instr->index && !build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
+      if (ctx->backend != Z_DIRECT_BACKEND_COFF_X64 && instr->value && !z_build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
+      if (instr->index && !z_build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
       return true;
     case IR_INSTR_EXPR:
     case IR_INSTR_RETURN:
-      if (instr->value && !build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
-      if (instr->index && !build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
+      if (instr->value && !z_build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
+      if (instr->index && !z_build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
       return true;
     case IR_INSTR_IF:
     case IR_INSTR_WHILE:
-      if (instr->value && !build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
+      if (instr->value && !z_build_check_value(ctx, fun, instr->value, false, 0, diag)) return false;
       if (!build_check_instrs(ctx, fun, instr->then_instrs, instr->then_len, diag)) return false;
       return build_check_instrs(ctx, fun, instr->else_instrs, instr->else_len, diag);
     case IR_INSTR_RAISE:

--- a/native/zero-c/src/buildability.c
+++ b/native/zero-c/src/buildability.c
@@ -104,7 +104,7 @@ static bool build_check_instr(const ZBuildability *ctx, const IrFunction *fun, c
     if (!ctx->executable) {
       return z_build_diag(ctx, diag, "direct AArch64 object buildability does not support World write instructions", instr->line, instr->column, "IR_INSTR_WORLD_WRITE");
     }
-    if (instr->value && !z_build_check_aarch64_byte_view(ctx, fun, instr->value, diag)) return false;
+    if (instr->value && !z_build_check_aarch64_world_write_byte_view(ctx, fun, instr->value, diag)) return false;
     if (instr->index && !z_build_check_value(ctx, fun, instr->index, false, 0, diag)) return false;
     return true;
   }

--- a/native/zero-c/src/buildability_context.c
+++ b/native/zero-c/src/buildability_context.c
@@ -138,10 +138,11 @@ bool z_build_diag(const ZBuildability *ctx, ZDiag *diag, const char *message, in
 static const char *build_expected_for_backend(ZDirectBackend backend, bool executable) {
   switch (backend) {
     case Z_DIRECT_BACKEND_ELF64: return executable ? "direct ELF64 executable buildability subset" : "direct ELF64 object buildability subset";
-    case Z_DIRECT_BACKEND_ELF_AARCH64: return executable ? "direct AArch64 ELF executable MVP subset" : "direct AArch64 ELF object MVP subset";
+    case Z_DIRECT_BACKEND_ELF_AARCH64: return executable ? "direct AArch64 ELF executable subset" : "direct AArch64 ELF object subset";
     case Z_DIRECT_BACKEND_MACHO64: return executable ? "direct AArch64 Mach-O executable buildability subset" : "direct AArch64 Mach-O object buildability subset";
     case Z_DIRECT_BACKEND_MACHO_X64: return executable ? "direct x86_64 Mach-O executable buildability subset" : "direct x86_64 Mach-O object buildability subset";
     case Z_DIRECT_BACKEND_COFF_X64: return executable ? "direct COFF x64 executable buildability subset" : "direct COFF x64 object buildability subset";
+    case Z_DIRECT_BACKEND_COFF_AARCH64: return executable ? "direct COFF AArch64 executable subset" : "direct COFF AArch64 object subset";
     default: return "direct backend buildability subset";
   }
 }
@@ -149,9 +150,11 @@ static const char *build_expected_for_backend(ZDirectBackend backend, bool execu
 static const char *build_help_for_backend(ZDirectBackend backend) {
   switch (backend) {
     case Z_DIRECT_BACKEND_ELF_AARCH64:
-      return "choose a supported direct target or restrict this program to exported functions returning small integer literals";
+      return "choose a supported direct target or reduce the program to AArch64 ELF supported direct-backend constructs";
     case Z_DIRECT_BACKEND_COFF_X64:
       return "reduce the program to primitive direct-backend constructs or choose a supported direct target";
+    case Z_DIRECT_BACKEND_COFF_AARCH64:
+      return "choose a supported direct target or reduce the program to AArch64 COFF supported direct-backend constructs";
     case Z_DIRECT_BACKEND_MACHO_X64:
       return "choose a supported direct target or reduce the program to x86_64 Mach-O supported direct-backend constructs";
     case Z_DIRECT_BACKEND_MACHO64:
@@ -166,6 +169,7 @@ bool z_build_select(const IrProgram *ir, const ZTargetInfo *target, const char *
   bool executable = emit_kind && strcmp(emit_kind, "exe") == 0;
   ctx->target = target;
   ctx->emit_kind = executable ? "exe" : "obj";
+  ctx->executable = executable;
   ctx->backend = executable ? z_direct_exe_backend(target) : z_direct_object_backend(target);
   ctx->backend_name = executable ? z_direct_backend_exe_emitter(ctx->backend) : z_direct_backend_object_emitter(ctx->backend);
   ctx->expected = build_expected_for_backend(ctx->backend, executable);

--- a/native/zero-c/src/buildability_internal.h
+++ b/native/zero-c/src/buildability_internal.h
@@ -10,10 +10,12 @@ typedef struct {
   const char *expected;
   const char *help;
   ZDirectBackend backend;
+  bool executable;
 } ZBuildability;
 
 enum {
-  BUILD_MACHO_SCRATCH_SLOT_COUNT = 32u
+  BUILD_MACHO_SCRATCH_SLOT_COUNT = 32u,
+  BUILD_AARCH64_SCRATCH_SLOT_COUNT = 32u
 };
 
 const char *z_build_type_name(IrTypeKind type);
@@ -22,12 +24,17 @@ bool z_build_is_elf_scalar(IrTypeKind type);
 bool z_build_is_scalar32(IrTypeKind type);
 bool z_build_diag(const ZBuildability *ctx, ZDiag *diag, const char *message, int line, int column, const char *actual);
 bool z_build_select(const IrProgram *ir, const ZTargetInfo *target, const char *emit_kind, ZBuildability *ctx, ZDiag *diag);
+bool z_build_backend_is_aarch64_direct(ZDirectBackend backend);
 bool z_build_check_coff_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_coff_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_macho_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_macho_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_macho_x64_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_macho_x64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
-bool z_build_check_aarch64_literal_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag);
+bool z_build_check_aarch64_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
+bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
+bool z_build_check_aarch64_function_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag);
+bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, unsigned *right_slot, ZDiag *diag);
+unsigned z_build_target_call_arg_slot(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot);
 
 #endif

--- a/native/zero-c/src/buildability_internal.h
+++ b/native/zero-c/src/buildability_internal.h
@@ -30,6 +30,7 @@ bool z_build_check_macho_x64_byte_view_len(const ZBuildability *ctx, const IrFun
 bool z_build_check_macho_x64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_aarch64_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
+bool z_build_check_aarch64_world_write_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_aarch64_function_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag);
 bool z_build_check_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, bool local_set_value, unsigned scratch_slot, ZDiag *diag);
 bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, unsigned *right_slot, ZDiag *diag);

--- a/native/zero-c/src/buildability_internal.h
+++ b/native/zero-c/src/buildability_internal.h
@@ -13,10 +13,7 @@ typedef struct {
   bool executable;
 } ZBuildability;
 
-enum {
-  BUILD_MACHO_SCRATCH_SLOT_COUNT = 32u,
-  BUILD_AARCH64_SCRATCH_SLOT_COUNT = 32u
-};
+enum { BUILD_MACHO_SCRATCH_SLOT_COUNT = 32u, BUILD_AARCH64_SCRATCH_SLOT_COUNT = 32u };
 
 const char *z_build_type_name(IrTypeKind type);
 const char *z_build_value_kind_name(IrValueKind kind);
@@ -34,6 +31,7 @@ bool z_build_check_macho_x64_byte_view(const ZBuildability *ctx, const IrFunctio
 bool z_build_check_aarch64_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag);
 bool z_build_check_aarch64_function_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag);
+bool z_build_check_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, bool local_set_value, unsigned scratch_slot, ZDiag *diag);
 bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, unsigned *right_slot, ZDiag *diag);
 unsigned z_build_target_call_arg_slot(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot);
 

--- a/native/zero-c/src/buildability_targets.c
+++ b/native/zero-c/src/buildability_targets.c
@@ -135,7 +135,7 @@ bool z_build_check_macho_byte_view_len(const ZBuildability *ctx, const IrFunctio
   if (!view) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte view is missing", 1, 1, "missing byte view");
   if (view->kind == IR_VALUE_STRING_LITERAL || view->kind == IR_VALUE_ARRAY_BYTE_VIEW) {
     if (view->data_len > 65535u) {
-      return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view length is too large for the current MVP", view->line, view->column, "large byte view");
+      return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view length is too large for the this backend", view->line, view->column, "large byte view");
     }
     return true;
   }
@@ -160,27 +160,4 @@ bool z_build_check_macho_byte_view_len(const ZBuildability *ctx, const IrFunctio
 
 bool z_build_check_macho_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
   return build_check_macho_byte_view_ptr(ctx, fun, view, diag) && z_build_check_macho_byte_view_len(ctx, fun, view, diag);
-}
-
-static bool build_aarch64_return_type_ok(IrTypeKind type) {
-  return type == IR_TYPE_VOID || type == IR_TYPE_U8 || type == IR_TYPE_I32 || type == IR_TYPE_U32 || type == IR_TYPE_USIZE;
-}
-
-bool z_build_check_aarch64_literal_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag) {
-  if (fun->param_count != 0) {
-    return z_build_diag(ctx, diag, "direct AArch64 ELF buildability currently supports functions without parameters", fun->line, fun->column, fun->name);
-  }
-  if (!build_aarch64_return_type_ok(fun->return_type)) {
-    return z_build_diag(ctx, diag, "direct AArch64 ELF buildability currently supports primitive 32-bit-or-smaller integer returns", fun->line, fun->column, z_build_type_name(fun->return_type));
-  }
-  if (fun->return_type == IR_TYPE_VOID) {
-    if (fun->instr_len == 0) return true;
-    if (fun->instr_len == 1 && fun->instrs[0].kind == IR_INSTR_RETURN && !fun->instrs[0].value) return true;
-    return z_build_diag(ctx, diag, "direct AArch64 ELF buildability currently supports only empty Void functions or small integer literal returns", fun->line, fun->column, fun->name);
-  }
-  if (fun->instr_len != 1 || fun->instrs[0].kind != IR_INSTR_RETURN || !fun->instrs[0].value ||
-      fun->instrs[0].value->kind != IR_VALUE_INT || fun->instrs[0].value->int_value > 65535) {
-    return z_build_diag(ctx, diag, "direct AArch64 ELF buildability currently requires a small integer literal return", fun->line, fun->column, fun->name);
-  }
-  return true;
 }

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -3,17 +3,31 @@
 #include <stdint.h>
 #include <stdio.h>
 
-enum {
-  BUILD_AARCH64_IMM12_MAX = 4095u
-};
+enum { BUILD_AARCH64_IMM12_MAX = 4095u };
 
-bool z_build_backend_is_aarch64_direct(ZDirectBackend backend) {
-  return backend == Z_DIRECT_BACKEND_ELF_AARCH64 || backend == Z_DIRECT_BACKEND_COFF_AARCH64;
-}
+bool z_build_backend_is_aarch64_direct(ZDirectBackend backend) { return backend == Z_DIRECT_BACKEND_ELF_AARCH64 || backend == Z_DIRECT_BACKEND_COFF_AARCH64; }
 
 static bool build_const_u32_value(const IrValue *value, unsigned *out) {
   if (!value || value->kind != IR_VALUE_INT || value->int_value > UINT32_MAX) return false;
   if (out) *out = (unsigned)value->int_value;
+  return true;
+}
+
+static bool build_aarch64_index_load_uses_scratch(const IrFunction *fun, const IrValue *value) {
+  if (!fun || value->kind != IR_VALUE_INDEX_LOAD || value->array_index >= fun->local_len) return true;
+  const IrLocal *local = &fun->locals[value->array_index];
+  unsigned const_index = 0;
+  return !(local->is_array && (local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 || local->element_type == IR_TYPE_USIZE) &&
+           build_const_u32_value(value->index, &const_index) && const_index < local->array_len);
+}
+
+static bool build_check_aarch64_byte_view_len_spill(const ZBuildability *ctx, const IrValue *view, unsigned scratch_slot, unsigned slot_count, const char *message, ZDiag *diag) {
+  if (!view || view->kind != IR_VALUE_BYTE_SLICE) return true;
+  unsigned start = 0, end = 0;
+  bool const_start = !view->index || build_const_u32_value(view->index, &start);
+  bool const_end = build_const_u32_value(view->right, &end);
+  if (const_start && const_end && end >= start && end - start <= 65535u) return true;
+  if ((const_start && view->right) || (view->index && view->right)) return scratch_slot < slot_count || z_build_diag(ctx, diag, message, view->line, view->column, "expression too deep");
   return true;
 }
 
@@ -98,7 +112,11 @@ static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunct
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
   }
+  if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view length exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_aarch64_byte_view_len(ctx, fun, value->left, diag)) return false;
+  if (value->kind == IR_VALUE_INDEX_LOAD && build_aarch64_index_load_uses_scratch(fun, value) && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
   return true;
@@ -205,7 +223,11 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
       if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
     }
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view length exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_byte_view_len(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_INDEX_LOAD && build_aarch64_index_load_uses_scratch(fun, value) && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_JSON_PARSE_BYTES || value->kind == IR_VALUE_JSON_VALIDATE_BYTES || value->kind == IR_VALUE_JSON_STREAM_TOKENS_BYTES) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -1,0 +1,261 @@
+#include "buildability_internal.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+enum {
+  BUILD_AARCH64_IMM12_MAX = 4095u
+};
+
+bool z_build_backend_is_aarch64_direct(ZDirectBackend backend) {
+  return backend == Z_DIRECT_BACKEND_ELF_AARCH64 || backend == Z_DIRECT_BACKEND_COFF_AARCH64;
+}
+
+static bool build_const_u32_value(const IrValue *value, unsigned *out) {
+  if (!value || value->kind != IR_VALUE_INT || value->int_value > UINT32_MAX) return false;
+  if (out) *out = (unsigned)value->int_value;
+  return true;
+}
+
+static size_t build_value_abi_slots(const IrValue *value) {
+  size_t slots = 0;
+  for (size_t i = 0; value && i < value->arg_len; i++) {
+    slots += value->args[i] && value->args[i]->type == IR_TYPE_BYTE_VIEW ? 2u : 1u;
+  }
+  return slots;
+}
+
+static bool build_aarch64_byte_view_ptr(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
+  if (!view) return z_build_diag(ctx, diag, "direct AArch64 byte view is missing", 1, 1, "missing byte view");
+  if (view->kind == IR_VALUE_LOCAL && fun && view->local_index < fun->local_len && fun->locals[view->local_index].type == IR_TYPE_BYTE_VIEW) return true;
+  if (view->kind == IR_VALUE_ARRAY_BYTE_VIEW && fun && view->array_index < fun->local_len) {
+    const IrLocal *local = &fun->locals[view->array_index];
+    if (!local->is_array || local->element_type != IR_TYPE_U8) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte-view array requires [N]u8", view->line, view->column, "unsupported array view");
+    }
+    return true;
+  }
+  if (view->kind == IR_VALUE_STRING_LITERAL) return true;
+  if (view->kind == IR_VALUE_BYTE_SLICE) {
+    unsigned start = 0;
+    if (!build_aarch64_byte_view_ptr(ctx, fun, view->left, diag)) return false;
+    if (build_const_u32_value(view->index, &start) && start > BUILD_AARCH64_IMM12_MAX) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte slice constant start is too large", view->line, view->column, "unsupported byte slice");
+    }
+    return true;
+  }
+  return z_build_diag(ctx, diag, "direct AArch64 value is not a supported byte view", view->line, view->column, "unsupported byte view");
+}
+
+bool z_build_check_aarch64_byte_view_len(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
+  if (!view) return z_build_diag(ctx, diag, "direct AArch64 byte view is missing", 1, 1, "missing byte view");
+  if (view->kind == IR_VALUE_STRING_LITERAL || view->kind == IR_VALUE_ARRAY_BYTE_VIEW) {
+    if (view->data_len > 65535u) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte-view length is too large for this backend", view->line, view->column, "large byte view");
+    }
+    return true;
+  }
+  if (view->kind == IR_VALUE_LOCAL && fun && view->local_index < fun->local_len && fun->locals[view->local_index].type == IR_TYPE_BYTE_VIEW) return true;
+  if (view->kind == IR_VALUE_BYTE_SLICE) {
+    unsigned start = 0;
+    unsigned end = 0;
+    bool const_start = !view->index || build_const_u32_value(view->index, &start);
+    bool const_end = build_const_u32_value(view->right, &end);
+    if (const_start && const_end && end >= start && end - start <= 65535u) return true;
+    if (const_start && view->right) {
+      if (start > BUILD_AARCH64_IMM12_MAX) {
+        return z_build_diag(ctx, diag, "direct AArch64 byte slice constant start is too large", view->line, view->column, "unsupported byte view length");
+      }
+      return true;
+    }
+    if (view->index && view->right) return true;
+  }
+  return z_build_diag(ctx, diag, "direct AArch64 byte-view length currently requires a literal, constant slice, or byte-view local", view->line, view->column, "unsupported byte view length");
+}
+
+bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
+  return build_aarch64_byte_view_ptr(ctx, fun, view, diag) && z_build_check_aarch64_byte_view_len(ctx, fun, view, diag);
+}
+
+static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, ZDiag *diag) {
+  if (value->kind == IR_VALUE_BYTE_COPY) {
+    if (scratch_slot + 3 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte copy exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    }
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+  }
+  if (value->kind == IR_VALUE_BYTE_FILL) {
+    if (scratch_slot + 2 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte fill exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    }
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+  }
+  if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
+    if (scratch_slot + 3 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+      return z_build_diag(ctx, diag, "direct AArch64 byte-view equality exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    }
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+  }
+  if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_aarch64_byte_view_len(ctx, fun, value->left, diag)) return false;
+  if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
+  if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
+  return true;
+}
+
+static bool build_check_binary_operator(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot, unsigned *right_slot, ZDiag *diag) {
+  if (value->kind != IR_VALUE_BINARY) return true;
+  bool supported = true;
+  if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64) {
+    supported = value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB || value->binary_op == IR_BIN_MUL;
+  }
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 || z_build_backend_is_aarch64_direct(ctx->backend)) {
+    supported = value->binary_op == IR_BIN_ADD || value->binary_op == IR_BIN_SUB || value->binary_op == IR_BIN_MUL ||
+                value->binary_op == IR_BIN_DIV || value->binary_op == IR_BIN_MOD ||
+                value->binary_op == IR_BIN_AND || value->binary_op == IR_BIN_OR;
+  }
+  if (!supported) return z_build_diag(ctx, diag, "direct backend buildability does not support this binary operator", value->line, value->column, "unsupported operator");
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->binary_op != IR_BIN_AND && value->binary_op != IR_BIN_OR && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
+    return z_build_diag(ctx, diag, "direct AArch64 Mach-O expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  }
+  if (z_build_backend_is_aarch64_direct(ctx->backend) && value->binary_op != IR_BIN_AND && value->binary_op != IR_BIN_OR && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+    return z_build_diag(ctx, diag, "direct AArch64 expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  }
+  if ((ctx->backend == Z_DIRECT_BACKEND_MACHO64 || z_build_backend_is_aarch64_direct(ctx->backend)) &&
+      value->binary_op != IR_BIN_AND && value->binary_op != IR_BIN_OR) {
+    *right_slot = scratch_slot + 1;
+  }
+  return true;
+}
+
+static bool build_check_compare(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot, unsigned *right_slot, ZDiag *diag) {
+  if (value->kind != IR_VALUE_COMPARE) return true;
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
+    return z_build_diag(ctx, diag, "direct AArch64 Mach-O expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  }
+  if (z_build_backend_is_aarch64_direct(ctx->backend) && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+    return z_build_diag(ctx, diag, "direct AArch64 expression nesting exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+  }
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 || z_build_backend_is_aarch64_direct(ctx->backend)) *right_slot = scratch_slot + 1;
+  return true;
+}
+
+static bool build_check_call_shape(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot, ZDiag *diag) {
+  if (value->kind != IR_VALUE_CALL) return true;
+  size_t max_args = ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ? 4 : (ctx->backend == Z_DIRECT_BACKEND_MACHO64 ? 8 : 6);
+  size_t abi_slots = build_value_abi_slots(value);
+  if (!z_build_backend_is_aarch64_direct(ctx->backend) && abi_slots > max_args) {
+    char actual[80];
+    snprintf(actual, sizeof(actual), "%zu ABI argument slot(s)", abi_slots);
+    return z_build_diag(ctx, diag, "direct backend buildability found a call with too many arguments", value->line, value->column, actual);
+  }
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64 && scratch_slot + abi_slots >= BUILD_MACHO_SCRATCH_SLOT_COUNT) {
+    return z_build_diag(ctx, diag, "direct AArch64 Mach-O call argument nesting exceeds scratch spill capacity", value->line, value->column, "too many nested call arguments");
+  }
+  return true;
+}
+
+bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, unsigned *right_slot, ZDiag *diag) {
+  if (skip_left) *skip_left = false;
+  if (right_slot) *right_slot = scratch_slot;
+  if (!ctx || !value) return true;
+  if (ctx->backend == Z_DIRECT_BACKEND_COFF_X64) {
+    if (value->kind == IR_VALUE_BYTE_COPY) {
+      if (!z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_coff_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_FILL && !z_build_check_coff_byte_view(ctx, fun, value->right, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
+      if (!z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_coff_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_coff_byte_view_len(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
+    if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD ||
+        value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) *skip_left = true;
+  }
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO_X64) {
+    if (value->kind == IR_VALUE_BYTE_COPY) {
+      if (!z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_x64_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_FILL && !z_build_check_macho_x64_byte_view(ctx, fun, value->right, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
+      if (!z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_x64_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_x64_byte_view_len(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
+  }
+  if (ctx->backend == Z_DIRECT_BACKEND_MACHO64) {
+    if (value->kind == IR_VALUE_BYTE_COPY) {
+      if (scratch_slot + 3 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_FILL) {
+      if (scratch_slot + 2 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte fill exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
+      if (scratch_slot + 3 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_byte_view_len(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+    if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+    if ((value->kind == IR_VALUE_JSON_PARSE_BYTES || value->kind == IR_VALUE_JSON_VALIDATE_BYTES || value->kind == IR_VALUE_JSON_STREAM_TOKENS_BYTES) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_HTTP_FETCH) {
+      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+    if ((value->kind == IR_VALUE_HTTP_RESPONSE_LEN || value->kind == IR_VALUE_HTTP_RESPONSE_HEADERS_LEN || value->kind == IR_VALUE_HTTP_RESPONSE_BODY_OFFSET) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_HTTP_HEADER_VALUE) {
+      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+    }
+  }
+  if (z_build_backend_is_aarch64_direct(ctx->backend) && !build_aarch64_byte_operation(ctx, fun, value, scratch_slot, skip_left, diag)) return false;
+  return build_check_binary_operator(ctx, value, scratch_slot, right_slot, diag) &&
+         build_check_compare(ctx, value, scratch_slot, right_slot, diag) &&
+         build_check_call_shape(ctx, value, scratch_slot, diag);
+}
+
+unsigned z_build_target_call_arg_slot(const ZBuildability *ctx, const IrValue *value, unsigned scratch_slot) {
+  if (ctx && value && ctx->backend == Z_DIRECT_BACKEND_MACHO64 && value->kind == IR_VALUE_CALL) {
+    return scratch_slot + (unsigned)build_value_abi_slots(value);
+  }
+  return scratch_slot;
+}
+
+bool z_build_check_aarch64_function_shape(const ZBuildability *ctx, const IrFunction *fun, ZDiag *diag) {
+  if (fun->param_count != 0) {
+    return z_build_diag(ctx, diag, "direct AArch64 buildability currently supports functions without parameters", fun->line, fun->column, fun->name);
+  }
+  if (fun->return_type != IR_TYPE_VOID && !z_build_is_scalar32(fun->return_type)) {
+    return z_build_diag(ctx, diag, "direct AArch64 buildability currently supports Void or 32-bit-or-smaller integer returns", fun->line, fun->column, z_build_type_name(fun->return_type));
+  }
+  size_t frame_bytes = (fun->frame_bytes ? fun->frame_bytes : fun->local_len * 8u) + BUILD_AARCH64_SCRATCH_SLOT_COUNT * 8u;
+  if (frame_bytes > 4095u) {
+    return z_build_diag(ctx, diag, "direct AArch64 stack frame exceeds current immediate-offset support", fun->line, fun->column, fun->name);
+  }
+  for (size_t i = 0; i < fun->local_len; i++) {
+    const IrLocal *local = &fun->locals[i];
+    if (local->type == IR_TYPE_BYTE_VIEW) continue;
+    if (local->is_array) {
+      bool array_ok = local->element_type == IR_TYPE_U8 || local->element_type == IR_TYPE_BOOL ||
+                      local->element_type == IR_TYPE_U32 || local->element_type == IR_TYPE_I32 ||
+                      local->element_type == IR_TYPE_USIZE;
+      if (!array_ok) return z_build_diag(ctx, diag, "direct AArch64 object buildability does not support this fixed-array local", local->line, local->column, z_build_type_name(local->element_type));
+      continue;
+    }
+    if (!z_build_is_elf_scalar(local->type)) {
+      return z_build_diag(ctx, diag, "direct AArch64 object buildability does not support this local type", local->line, local->column, z_build_type_name(local->type));
+    }
+  }
+  return true;
+}

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -100,8 +100,12 @@ bool z_build_check_aarch64_byte_view_len(const ZBuildability *ctx, const IrFunct
   return z_build_diag(ctx, diag, "direct AArch64 byte-view length currently requires a literal, constant slice, or byte-view local", view->line, view->column, "unsupported byte view length");
 }
 
-bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
-  return build_aarch64_byte_view_ptr(ctx, fun, view, diag) && z_build_check_aarch64_byte_view_len(ctx, fun, view, diag);
+bool z_build_check_aarch64_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) { return build_aarch64_byte_view_ptr(ctx, fun, view, diag) && z_build_check_aarch64_byte_view_len(ctx, fun, view, diag); }
+
+bool z_build_check_aarch64_world_write_byte_view(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, ZDiag *diag) {
+  if (!z_build_check_aarch64_byte_view(ctx, fun, view, diag)) return false;
+  if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, view, 0, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 World write exceeds scratch register spill capacity", diag)) return false;
+  return build_check_aarch64_byte_view_len_spill(ctx, fun, view, 0, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 World write exceeds scratch register spill capacity", diag);
 }
 
 static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunction *fun, const IrValue *value, unsigned scratch_slot, bool *skip_left, ZDiag *diag) {

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -33,6 +33,17 @@ static bool build_check_aarch64_byte_view_len_spill(const ZBuildability *ctx, co
   return true;
 }
 
+static bool build_check_aarch64_byte_view_ptr_spill(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, unsigned scratch_slot, unsigned slot_count, const char *message, ZDiag *diag) {
+  if (!view || view->kind != IR_VALUE_BYTE_SLICE) return true;
+  if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, view->left, scratch_slot, slot_count, message, diag)) return false;
+  unsigned start = 0;
+  if (view->index && !build_const_u32_value(view->index, &start)) {
+    if (scratch_slot >= slot_count) return z_build_diag(ctx, diag, message, view->line, view->column, "expression too deep");
+    if (!z_build_check_value(ctx, fun, view->index, false, scratch_slot + 1, diag)) return false;
+  }
+  return true;
+}
+
 static size_t build_value_abi_slots(const IrValue *value) {
   size_t slots = 0;
   for (size_t i = 0; value && i < value->arg_len; i++) {
@@ -100,12 +111,18 @@ static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunct
     }
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte copy exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte copy exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte copy exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 3, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte copy exceeds scratch register spill capacity", diag)) return false;
   }
   if (value->kind == IR_VALUE_BYTE_FILL) {
     if (scratch_slot + 2 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
       return z_build_diag(ctx, diag, "direct AArch64 byte fill exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
     }
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte fill exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte fill exceeds scratch register spill capacity", diag)) return false;
   }
   if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
     if (scratch_slot + 3 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
@@ -113,6 +130,10 @@ static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunct
     }
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view equality exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view equality exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view equality exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view equality exceeds scratch register spill capacity", diag)) return false;
   }
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view length exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_aarch64_byte_view_len(ctx, fun, value->left, diag)) return false;
@@ -215,15 +236,25 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
       if (scratch_slot + 3 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
       if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 3, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte copy exceeds scratch register spill capacity", diag)) return false;
     }
     if (value->kind == IR_VALUE_BYTE_FILL) {
       if (scratch_slot + 2 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte fill exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
       if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte fill exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte fill exceeds scratch register spill capacity", diag)) return false;
     }
     if (value->kind == IR_VALUE_BYTE_VIEW_EQ) {
       if (scratch_slot + 3 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
       if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->right, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->right, scratch_slot + 2, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view equality exceeds scratch register spill capacity", diag)) return false;
     }
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view length exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_byte_view_len(ctx, fun, value->left, diag)) return false;

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -1,8 +1,6 @@
 #include "buildability_internal.h"
-
 #include <stdint.h>
 #include <stdio.h>
-
 enum { BUILD_AARCH64_IMM12_MAX = 4095u };
 
 bool z_build_backend_is_aarch64_direct(ZDirectBackend backend) { return backend == Z_DIRECT_BACKEND_ELF_AARCH64 || backend == Z_DIRECT_BACKEND_COFF_AARCH64; }
@@ -21,13 +19,17 @@ static bool build_aarch64_index_load_uses_scratch(const IrFunction *fun, const I
            build_const_u32_value(value->index, &const_index) && const_index < local->array_len);
 }
 
-static bool build_check_aarch64_byte_view_len_spill(const ZBuildability *ctx, const IrValue *view, unsigned scratch_slot, unsigned slot_count, const char *message, ZDiag *diag) {
+static bool build_check_aarch64_byte_view_len_spill(const ZBuildability *ctx, const IrFunction *fun, const IrValue *view, unsigned scratch_slot, unsigned slot_count, const char *message, ZDiag *diag) {
   if (!view || view->kind != IR_VALUE_BYTE_SLICE) return true;
   unsigned start = 0, end = 0;
   bool const_start = !view->index || build_const_u32_value(view->index, &start);
   bool const_end = build_const_u32_value(view->right, &end);
   if (const_start && const_end && end >= start && end - start <= 65535u) return true;
-  if ((const_start && view->right) || (view->index && view->right)) return scratch_slot < slot_count || z_build_diag(ctx, diag, message, view->line, view->column, "expression too deep");
+  if ((const_start && view->right) || (view->index && view->right)) {
+    if (scratch_slot >= slot_count) return z_build_diag(ctx, diag, message, view->line, view->column, "expression too deep");
+    if (!z_build_check_value(ctx, fun, view->right, false, scratch_slot, diag)) return false;
+    return const_start || z_build_check_value(ctx, fun, view->index, false, scratch_slot + 1, diag);
+  }
   return true;
 }
 
@@ -112,11 +114,11 @@ static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunct
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
     if (!z_build_check_aarch64_byte_view(ctx, fun, value->right, diag)) return false;
   }
-  if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view length exceeds scratch register spill capacity", diag)) return false;
+  if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view length exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_aarch64_byte_view_len(ctx, fun, value->left, diag)) return false;
   if (value->kind == IR_VALUE_INDEX_LOAD && build_aarch64_index_load_uses_scratch(fun, value) && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
-  if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
+  if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
   return true;
@@ -223,11 +225,11 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
       if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_macho_byte_view(ctx, fun, value->right, diag)) return false;
     }
-    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view length exceeds scratch register spill capacity", diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view length exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_byte_view_len(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_INDEX_LOAD && build_aarch64_index_load_uses_scratch(fun, value) && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
-    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
+    if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_JSON_PARSE_BYTES || value->kind == IR_VALUE_JSON_VALIDATE_BYTES || value->kind == IR_VALUE_JSON_STREAM_TOKENS_BYTES) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;

--- a/native/zero-c/src/coff_format.c
+++ b/native/zero-c/src/coff_format.c
@@ -59,10 +59,14 @@ void z_coff_patch_u64(ZBuf *buf, size_t offset, uint64_t value) {
   for (unsigned i = 0; i < 8; i++) buf->data[offset + i] = (char)((value >> (i * 8)) & 0xffu);
 }
 
-void z_coff_append_reloc_amd64(ZBuf *buf, uint32_t offset, uint32_t symbol_index, uint16_t type) {
+void z_coff_append_reloc(ZBuf *buf, uint32_t offset, uint32_t symbol_index, uint16_t type) {
   z_coff_append_u32(buf, offset);
   z_coff_append_u32(buf, symbol_index);
   z_coff_append_u16(buf, type);
+}
+
+void z_coff_append_reloc_amd64(ZBuf *buf, uint32_t offset, uint32_t symbol_index, uint16_t type) {
+  z_coff_append_reloc(buf, offset, symbol_index, type);
 }
 
 static void coff_append_name(ZBuf *buf, const char *name) {
@@ -309,7 +313,8 @@ void z_coff_write_pe64_executable(ZBuf *out, const ZCoffExecutableImage *image) 
     const ZCoffImportPatch *patch = &image->import_patches[i];
     if (patch->import_index >= Z_COFF_IMPORT_COUNT) continue;
     uint64_t target = image_base + rdata_rva + imports.iat_offsets[patch->import_index];
-    coff_patch_rel32_to_va(text, patch->patch_offset, image_base + text_rva, target);
+    if (image && image->machine == Z_COFF_MACHINE_ARM64) z_coff_patch_u64(text, patch->patch_offset, target);
+    else coff_patch_rel32_to_va(text, patch->patch_offset, image_base + text_rva, target);
   }
 
   zbuf_init(out);

--- a/native/zero-c/src/coff_format.h
+++ b/native/zero-c/src/coff_format.h
@@ -6,12 +6,14 @@
 #include <stdint.h>
 
 typedef enum {
+  Z_COFF_MACHINE_ARM64 = 0xaa64,
   Z_COFF_MACHINE_AMD64 = 0x8664
 } ZCoffMachine;
 
 enum {
   Z_COFF_RELOC_AMD64_ADDR64 = 0x0001,
-  Z_COFF_RELOC_AMD64_REL32 = 0x0004
+  Z_COFF_RELOC_AMD64_REL32 = 0x0004,
+  Z_COFF_RELOC_ARM64_ADDR64 = 0x000e
 };
 
 enum {
@@ -78,6 +80,7 @@ void z_coff_append_zeros(ZBuf *buf, size_t len);
 void z_coff_pad_to(ZBuf *buf, size_t offset);
 void z_coff_patch_u32(ZBuf *buf, size_t offset, uint32_t value);
 void z_coff_patch_u64(ZBuf *buf, size_t offset, uint64_t value);
+void z_coff_append_reloc(ZBuf *buf, uint32_t offset, uint32_t symbol_index, uint16_t type);
 void z_coff_append_reloc_amd64(ZBuf *buf, uint32_t offset, uint32_t symbol_index, uint16_t type);
 void z_coff_write_object(ZBuf *out, const ZCoffObjectImage *image);
 void z_coff_write_pe64_executable(ZBuf *out, const ZCoffExecutableImage *image);

--- a/native/zero-c/src/direct_emit.c
+++ b/native/zero-c/src/direct_emit.c
@@ -7,6 +7,7 @@ bool z_emit_direct_object_from_ir(ZDirectBackend backend, const IrProgram *progr
     case Z_DIRECT_BACKEND_MACHO64: return z_emit_macho64_object_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_MACHO_X64: return z_emit_macho_x64_object_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_COFF_X64: return z_emit_coff_x64_object_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_COFF_AARCH64: return z_emit_coff_aarch64_object_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_NONE: return false;
   }
   return false;
@@ -19,6 +20,7 @@ bool z_emit_direct_executable_from_ir(ZDirectBackend backend, const IrProgram *p
     case Z_DIRECT_BACKEND_MACHO64: return z_emit_macho64_exe_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_MACHO_X64: return z_emit_macho_x64_exe_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_COFF_X64: return z_emit_coff_x64_exe_from_ir(program, out, diag);
+    case Z_DIRECT_BACKEND_COFF_AARCH64: return z_emit_coff_aarch64_exe_from_ir(program, out, diag);
     case Z_DIRECT_BACKEND_NONE: return false;
   }
   return false;

--- a/native/zero-c/src/direct_metrics.c
+++ b/native/zero-c/src/direct_metrics.c
@@ -1,10 +1,17 @@
 #include "zero.h"
+#include "aarch64_direct.h"
 
 size_t z_direct_target_stack_bytes(const ZTargetInfo *target, const IrProgram *program) {
   if (!program) return 0;
   if (z_direct_object_backend(target) == Z_DIRECT_BACKEND_MACHO64 ||
       z_direct_exe_backend(target) == Z_DIRECT_BACKEND_MACHO64) {
     return z_macho64_stack_bytes_from_ir(program);
+  }
+  if (z_direct_object_backend(target) == Z_DIRECT_BACKEND_ELF_AARCH64 ||
+      z_direct_exe_backend(target) == Z_DIRECT_BACKEND_ELF_AARCH64 ||
+      z_direct_object_backend(target) == Z_DIRECT_BACKEND_COFF_AARCH64 ||
+      z_direct_exe_backend(target) == Z_DIRECT_BACKEND_COFF_AARCH64) {
+    return z_aarch64_direct_stack_bytes_from_ir(program);
   }
   return program->direct_stack_bytes;
 }
@@ -14,6 +21,12 @@ size_t z_direct_target_max_frame_bytes(const ZTargetInfo *target, const IrProgra
   if (z_direct_object_backend(target) == Z_DIRECT_BACKEND_MACHO64 ||
       z_direct_exe_backend(target) == Z_DIRECT_BACKEND_MACHO64) {
     return z_macho64_max_frame_bytes_from_ir(program);
+  }
+  if (z_direct_object_backend(target) == Z_DIRECT_BACKEND_ELF_AARCH64 ||
+      z_direct_exe_backend(target) == Z_DIRECT_BACKEND_ELF_AARCH64 ||
+      z_direct_object_backend(target) == Z_DIRECT_BACKEND_COFF_AARCH64 ||
+      z_direct_exe_backend(target) == Z_DIRECT_BACKEND_COFF_AARCH64) {
+    return z_aarch64_direct_max_frame_bytes_from_ir(program);
   }
   return program->direct_max_frame_bytes;
 }

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -335,6 +335,7 @@ static bool coff_emit_byte_view_index_load_value(ZBuf *text, const IrFunction *f
 
 static bool coff_emit_byte_copy_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
   if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
+  z_x64_emit_push_reg64(text, 7); z_x64_emit_push_reg64(text, 6);
   if (!coff_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
   z_x64_emit_push_rax(text);
   if (!coff_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
@@ -346,20 +347,21 @@ static bool coff_emit_byte_copy_value(ZBuf *text, const IrFunction *fun, const I
   z_x64_emit_pop_reg64(text, 1);
   z_x64_emit_pop_reg64(text, 6);
   z_x64_emit_byte_copy_min_loop(text);
+  z_x64_emit_pop_reg64(text, 6); z_x64_emit_pop_reg64(text, 7);
   return true;
 }
 
 static bool coff_emit_byte_fill_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
   if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
   if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
-  z_x64_emit_push_rax(text);
+  z_x64_emit_push_rax(text); z_x64_emit_push_reg64(text, 7);
   if (!coff_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
   z_x64_emit_push_rax(text);
   if (!coff_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
   z_x64_emit_mov_rdx_from_rax(text);
-  z_x64_emit_pop_reg64(text, 7);
-  z_x64_emit_pop_reg64(text, 9);
-  z_x64_emit_byte_fill_loop(text);
+  z_x64_emit_pop_reg64(text, 7); z_x64_emit_pop_reg64(text, 11);
+  z_x64_emit_pop_reg64(text, 9); z_x64_emit_push_reg64(text, 11);
+  z_x64_emit_byte_fill_loop(text); z_x64_emit_pop_reg64(text, 7);
   return true;
 }
 

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -333,6 +333,57 @@ static bool coff_emit_byte_view_index_load_value(ZBuf *text, const IrFunction *f
   return true;
 }
 
+static bool coff_emit_byte_copy_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
+  if (!coff_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_pop_reg64(text, 7);
+  z_x64_emit_pop_reg64(text, 1);
+  z_x64_emit_pop_reg64(text, 6);
+  z_x64_emit_byte_copy_min_loop(text);
+  return true;
+}
+
+static bool coff_emit_byte_fill_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
+  if (!coff_emit_value(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_mov_rdx_from_rax(text);
+  z_x64_emit_pop_reg64(text, 7);
+  z_x64_emit_pop_reg64(text, 9);
+  z_x64_emit_byte_fill_loop(text);
+  return true;
+}
+
+static bool coff_emit_byte_view_eq_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return coff_diag_at(diag, "direct COFF byte-view equality requires two byte views", value->line, value->column, "missing byte view");
+  if (!coff_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!coff_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_pop_reg64(text, 1);
+  z_x64_emit_cmp_reg_reg(text, 1, 0, false);
+  size_t same_len = z_x64_emit_jcc32_placeholder(text, 0x84);
+  z_x64_emit_mov_eax_u32(text, 0);
+  size_t end = z_x64_emit_jmp32_placeholder(text, 0xe9);
+  z_x64_patch_rel32(text, same_len, text->len);
+  z_x64_emit_mov_reg_from_rax(text, 10, true);
+  if (!coff_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_mov_reg_from_rax(text, 8, true);
+  if (!coff_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_mov_r9_from_rax(text);
+  z_x64_emit_byte_eq_loop(text);
+  z_x64_patch_rel32(text, end, text->len);
+  return true;
+}
+
 static bool coff_emit_index_load_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return coff_diag_at(diag, "direct COFF indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -395,6 +446,9 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
       coff_emit_load_local_slot_eax(text, fun, value->local_index, 0);
       return true;
     case IR_VALUE_BYTE_VIEW_LEN: return coff_emit_byte_view_len(text, fun, value->left, ctx, diag);
+    case IR_VALUE_BYTE_COPY: return coff_emit_byte_copy_value(text, fun, value, ctx, diag);
+    case IR_VALUE_BYTE_FILL: return coff_emit_byte_fill_value(text, fun, value, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_EQ: return coff_emit_byte_view_eq_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return coff_emit_byte_view_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_INDEX_LOAD: return coff_emit_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_FIELD_LOAD: return coff_emit_field_load_value(text, fun, value, diag);

--- a/native/zero-c/src/emit_coff_aarch64.c
+++ b/native/zero-c/src/emit_coff_aarch64.c
@@ -119,6 +119,7 @@ static size_t coff_a64_emit_exe_world_write(ZBuf *text, ZCoffImportPatch *import
   z_aarch64_emit_store_x_sp(text, 1, 0);
   z_aarch64_emit_store_x_sp(text, 2, 8);
   z_aarch64_emit_store_w_sp(text, 31, 16);
+  z_aarch64_emit_store_x_sp(text, 30, 40);
   z_aarch64_emit_movz_w(text, 8, 2);
   z_aarch64_emit_cmp_w(text, 0, 8);
   z_aarch64_emit_movz_w(text, 0, 0xfffffff5u);
@@ -136,6 +137,7 @@ static size_t coff_a64_emit_exe_world_write(ZBuf *text, ZCoffImportPatch *import
   z_aarch64_emit_brk(text);
   z_aarch64_patch_cond19(text, ok_patch, text->len);
   z_aarch64_emit_movz_w(text, 0, 0);
+  z_aarch64_emit_load_x_sp(text, 30, 40);
   z_aarch64_emit_add_sp_imm(text, 48);
   z_aarch64_emit_ret(text);
   return offset;

--- a/native/zero-c/src/emit_coff_aarch64.c
+++ b/native/zero-c/src/emit_coff_aarch64.c
@@ -1,0 +1,324 @@
+#include "zero.h"
+#include "aarch64_direct.h"
+#include "aarch64_emit.h"
+#include "coff_format.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+typedef struct {
+  ZCoffImageDataPatch *items;
+  size_t len;
+  size_t cap;
+} CoffA64DataPatches;
+
+typedef struct {
+  size_t *items;
+  size_t len;
+  size_t cap;
+} CoffA64BranchPatches;
+
+typedef struct {
+  CoffA64DataPatches data;
+  CoffA64BranchPatches world_write;
+} CoffA64EmitState;
+
+static bool coff_a64_diag(ZDiag *diag, const char *message, int line, int column, const char *actual) {
+  if (diag) {
+    diag->code = 4004;
+    diag->line = line > 0 ? line : 1;
+    diag->column = column > 0 ? column : 1;
+    diag->length = 1;
+    snprintf(diag->message, sizeof(diag->message), "%s", message);
+    snprintf(diag->expected, sizeof(diag->expected), "direct COFF AArch64 object subset");
+    snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "unsupported construct");
+    snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to AArch64 COFF supported direct-backend constructs");
+  }
+  return false;
+}
+
+static bool coff_a64_record_data_patch(void *user, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag) {
+  CoffA64EmitState *state = user;
+  CoffA64DataPatches *patches = state ? &state->data : NULL;
+  if (!patches) return coff_a64_diag(diag, "direct COFF AArch64 readonly data patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  if (patches->len == patches->cap) {
+    patches->cap = z_grow_capacity(patches->cap, patches->len + 1, 8);
+    patches->items = z_checked_reallocarray(patches->items, patches->cap, sizeof(ZCoffImageDataPatch));
+  }
+  if (!patches->items) return coff_a64_diag(diag, "direct COFF AArch64 backend ran out of memory", value ? value->line : 1, value ? value->column : 1, "allocation failed");
+  patches->items[patches->len++] = (ZCoffImageDataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
+  return true;
+}
+
+static void coff_a64_data_patches_free(CoffA64DataPatches *patches) {
+  if (!patches) return;
+  free(patches->items);
+}
+
+static bool coff_a64_record_branch_patch(CoffA64BranchPatches *patches, size_t patch_offset, const IrInstr *instr, ZDiag *diag) {
+  if (!patches) return coff_a64_diag(diag, "direct COFF AArch64 branch patch requires an emit context", instr ? instr->line : 1, instr ? instr->column : 1, "missing context");
+  if (patches->len == patches->cap) {
+    patches->cap = z_grow_capacity(patches->cap, patches->len + 1, 8);
+    patches->items = z_checked_reallocarray(patches->items, patches->cap, sizeof(size_t));
+  }
+  if (!patches->items) return coff_a64_diag(diag, "direct COFF AArch64 backend ran out of memory", instr ? instr->line : 1, instr ? instr->column : 1, "allocation failed");
+  patches->items[patches->len++] = patch_offset;
+  return true;
+}
+
+static void coff_a64_emit_state_free(CoffA64EmitState *state) {
+  if (!state) return;
+  coff_a64_data_patches_free(&state->data);
+  free(state->world_write.items);
+}
+
+static void coff_a64_append_object_rodata_relocations(ZBuf *text, ZBuf *relocs, const CoffA64DataPatches *patches, unsigned rodata_base_offset) {
+  for (size_t i = 0; patches && i < patches->len; i++) {
+    const ZCoffImageDataPatch *patch = &patches->items[i];
+    z_coff_patch_u64(text, patch->patch_offset, patch->data_offset - rodata_base_offset);
+    z_coff_append_reloc(relocs, (uint32_t)patch->patch_offset, 1u, Z_COFF_RELOC_ARM64_ADDR64);
+  }
+}
+
+static size_t coff_a64_emit_import_call(ZBuf *text, ZCoffImportPatch *patches, size_t *patch_len, unsigned import_index) {
+  while (((text->len + 8) % 8) != 0) z_aarch64_emit_nop(text);
+  z_aarch64_emit_ldr_x_literal8(text, 16);
+  z_aarch64_emit_b_offset_words(text, 3);
+  size_t patch = text->len;
+  z_aarch64_append_u64(text, 0);
+  z_aarch64_emit_load_x_imm(text, 16, 16, 0);
+  z_aarch64_emit_blr_x(text, 16);
+  if (patches && patch_len && *patch_len < 8) {
+    patches[*patch_len] = (ZCoffImportPatch){.patch_offset = patch, .import_index = import_index};
+    *patch_len += 1;
+  }
+  return patch;
+}
+
+static size_t coff_a64_emit_exe_start_stub(ZBuf *text, ZCoffImportPatch *import_patches, size_t *import_patch_len) {
+  z_aarch64_emit_sub_sp_imm(text, 16);
+  size_t main_patch = z_aarch64_emit_bl_placeholder(text);
+  coff_a64_emit_import_call(text, import_patches, import_patch_len, Z_COFF_IMPORT_EXIT_PROCESS);
+  z_aarch64_emit_brk(text);
+  return main_patch;
+}
+
+static bool coff_a64_emit_world_write_call(ZBuf *text, const IrInstr *instr, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  CoffA64EmitState *state = ctx ? ctx->patch_user : NULL;
+  size_t patch = z_aarch64_emit_bl_placeholder(text);
+  if (!coff_a64_record_branch_patch(state ? &state->world_write : NULL, patch, instr, diag)) return false;
+  size_t ok_patch = z_aarch64_emit_cbz_w_placeholder(text, 0);
+  z_aarch64_emit_brk(text);
+  z_aarch64_patch_cond19(text, ok_patch, text->len);
+  return true;
+}
+
+static size_t coff_a64_emit_exe_world_write(ZBuf *text, ZCoffImportPatch *import_patches, size_t *import_patch_len) {
+  size_t offset = text->len;
+  z_aarch64_emit_sub_sp_imm(text, 48);
+  z_aarch64_emit_store_x_sp(text, 1, 0);
+  z_aarch64_emit_store_x_sp(text, 2, 8);
+  z_aarch64_emit_store_w_sp(text, 31, 16);
+  z_aarch64_emit_movz_w(text, 8, 2);
+  z_aarch64_emit_cmp_w(text, 0, 8);
+  z_aarch64_emit_movz_w(text, 0, 0xfffffff5u);
+  size_t stdout_patch = z_aarch64_emit_b_cond_placeholder(text, 1);
+  z_aarch64_emit_movz_w(text, 0, 0xfffffff4u);
+  z_aarch64_patch_cond19(text, stdout_patch, text->len);
+  coff_a64_emit_import_call(text, import_patches, import_patch_len, Z_COFF_IMPORT_GET_STD_HANDLE);
+  z_aarch64_emit_load_x_sp(text, 1, 0);
+  z_aarch64_emit_load_w_sp(text, 2, 8);
+  z_aarch64_emit_add_x_sp_imm(text, 3, 16);
+  z_aarch64_emit_movz_x(text, 4, 0);
+  coff_a64_emit_import_call(text, import_patches, import_patch_len, Z_COFF_IMPORT_WRITE_FILE);
+  z_aarch64_emit_cmp_w(text, 0, 31);
+  size_t ok_patch = z_aarch64_emit_b_cond_placeholder(text, 1);
+  z_aarch64_emit_brk(text);
+  z_aarch64_patch_cond19(text, ok_patch, text->len);
+  z_aarch64_emit_movz_w(text, 0, 0);
+  z_aarch64_emit_add_sp_imm(text, 48);
+  z_aarch64_emit_ret(text);
+  return offset;
+}
+
+bool z_emit_coff_aarch64_object_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
+  if (!program || !out) return coff_a64_diag(diag, "direct COFF AArch64 backend received no program", 1, 1, "missing MIR");
+  if (!program->mir_valid) {
+    bool ok = coff_a64_diag(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
+  if (program->function_len == 0) return coff_a64_diag(diag, "direct COFF AArch64 object backend requires at least one exported function", 1, 1, "empty program");
+
+  ZBuf text;
+  ZBuf rodata;
+  ZBuf relocs;
+  zbuf_init(&text);
+  zbuf_init(&rodata);
+  zbuf_init(&relocs);
+
+  bool has_rodata = program->readonly_data_bytes > 0 || program->data_segment_len > 0;
+  unsigned rodata_base_offset = z_aarch64_direct_rodata_base_offset(program);
+  if (has_rodata) z_aarch64_direct_append_rodata(&rodata, program, rodata_base_offset);
+
+  size_t *offsets = z_checked_calloc(program->function_len, sizeof(size_t));
+  ZCoffSymbol *symbols = z_checked_calloc(program->function_len, sizeof(ZCoffSymbol));
+  if (!offsets || !symbols) {
+    free(offsets);
+    free(symbols);
+    zbuf_free(&relocs);
+    zbuf_free(&rodata);
+    zbuf_free(&text);
+    return coff_a64_diag(diag, "out of memory while emitting COFF AArch64 object", 1, 1, "allocation failed");
+  }
+
+  CoffA64EmitState state = {0};
+  ZAArch64DirectContext ctx = {
+    .program = program,
+    .function_offsets = offsets,
+    .function_count = program->function_len,
+    .rodata_base_offset = rodata_base_offset,
+    .patch_user = &state,
+    .record_data_patch = coff_a64_record_data_patch
+  };
+
+  bool has_export = false;
+  size_t symbol_len = 0;
+  for (size_t i = 0; i < program->function_len; i++) {
+    if (!program->functions[i].is_exported) continue;
+    has_export = true;
+    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+    offsets[i] = text.len;
+    if (!z_aarch64_direct_emit_function_text(&text, &program->functions[i], &ctx, diag)) {
+      coff_a64_emit_state_free(&state);
+      free(offsets);
+      free(symbols);
+      zbuf_free(&relocs);
+      zbuf_free(&rodata);
+      zbuf_free(&text);
+      return false;
+    }
+    symbols[symbol_len++] = (ZCoffSymbol){
+      .name = program->functions[i].name ? program->functions[i].name : "zero_fn",
+      .value = (uint32_t)offsets[i],
+      .section_number = 1,
+      .type = 0x20,
+      .storage_class = Z_COFF_SYMBOL_EXTERNAL
+    };
+  }
+  if (!has_export) {
+    coff_a64_emit_state_free(&state);
+    free(offsets);
+    free(symbols);
+    zbuf_free(&relocs);
+    zbuf_free(&rodata);
+    zbuf_free(&text);
+    return coff_a64_diag(diag, "direct COFF AArch64 object backend requires at least one exported function", 1, 1, "no exported function");
+  }
+  if (has_rodata) coff_a64_append_object_rodata_relocations(&text, &relocs, &state.data, rodata_base_offset);
+
+  ZCoffObjectImage image = {
+    .machine = Z_COFF_MACHINE_ARM64,
+    .text = &text,
+    .rodata = has_rodata ? &rodata : NULL,
+    .text_relocs = &relocs,
+    .text_reloc_count = (uint16_t)state.data.len,
+    .symbols = symbols,
+    .symbol_len = symbol_len
+  };
+  z_coff_write_object(out, &image);
+
+  coff_a64_emit_state_free(&state);
+  free(offsets);
+  free(symbols);
+  zbuf_free(&relocs);
+  zbuf_free(&rodata);
+  zbuf_free(&text);
+  return true;
+}
+
+bool z_emit_coff_aarch64_exe_from_ir(const IrProgram *program, ZBuf *out, ZDiag *diag) {
+  if (!program || !out) return coff_a64_diag(diag, "direct COFF AArch64 executable backend received no program", 1, 1, "missing MIR");
+  if (!program->mir_valid) {
+    bool ok = coff_a64_diag(diag, program->mir_message[0] ? program->mir_message : "direct backend lowering failed", program->mir_line, program->mir_column, program->mir_actual);
+    z_diag_set_backend_blocker(diag, &program->backend_blocker);
+    return ok;
+  }
+
+  unsigned main_index = 0;
+  if (!z_aarch64_direct_find_main(program, &main_index, diag)) return false;
+
+  ZBuf text;
+  ZBuf rdata;
+  zbuf_init(&text);
+  zbuf_init(&rdata);
+
+  bool has_rodata = program->readonly_data_bytes > 0 || program->data_segment_len > 0;
+  unsigned rodata_base_offset = z_aarch64_direct_rodata_base_offset(program);
+  if (has_rodata) z_aarch64_direct_append_rodata(&rdata, program, rodata_base_offset);
+
+  size_t *offsets = z_checked_calloc(program->function_len, sizeof(size_t));
+  if (!offsets) {
+    zbuf_free(&rdata);
+    zbuf_free(&text);
+    return coff_a64_diag(diag, "out of memory while emitting COFF AArch64 executable", 1, 1, "allocation failed");
+  }
+
+  CoffA64EmitState state = {0};
+  ZAArch64DirectContext ctx = {
+    .program = program,
+    .function_offsets = offsets,
+    .function_count = program->function_len,
+    .rodata_base_offset = rodata_base_offset,
+    .patch_user = &state,
+    .record_data_patch = coff_a64_record_data_patch,
+    .emit_world_write = coff_a64_emit_world_write_call
+  };
+
+  ZCoffImportPatch import_patches[8];
+  size_t import_patch_len = 0;
+  size_t start_main_patch = coff_a64_emit_exe_start_stub(&text, import_patches, &import_patch_len);
+  z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+  for (size_t i = 0; i < program->function_len; i++) {
+    if (!program->functions[i].is_exported) continue;
+    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+    offsets[i] = text.len;
+    if (!z_aarch64_direct_emit_function_text(&text, &program->functions[i], &ctx, diag)) {
+      coff_a64_emit_state_free(&state);
+      free(offsets);
+      zbuf_free(&rdata);
+      zbuf_free(&text);
+      return false;
+    }
+  }
+  z_aarch64_patch_branch26(&text, start_main_patch, offsets[main_index]);
+  size_t world_write_offset = 0;
+  if (state.world_write.len > 0) {
+    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+    world_write_offset = coff_a64_emit_exe_world_write(&text, import_patches, &import_patch_len);
+    for (size_t i = 0; i < state.world_write.len; i++) {
+      z_aarch64_patch_branch26(&text, state.world_write.items[i], world_write_offset);
+    }
+  }
+
+  ZCoffExecutableImage image = {
+    .machine = Z_COFF_MACHINE_ARM64,
+    .image_base = 0x140000000ull,
+    .section_alignment = 0x1000,
+    .file_alignment = 0x200,
+    .text = &text,
+    .rdata = &rdata,
+    .rodata_base_offset = rodata_base_offset,
+    .rodata_patches = state.data.items,
+    .rodata_patch_len = state.data.len,
+    .import_patches = import_patches,
+    .import_patch_len = import_patch_len
+  };
+  z_coff_write_pe64_executable(out, &image);
+
+  coff_a64_emit_state_free(&state);
+  free(offsets);
+  zbuf_free(&rdata);
+  zbuf_free(&text);
+  return true;
+}

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -1152,22 +1152,20 @@ static bool elf_emit_byte_bulk_value(ZBuf *code, const IrFunction *fun, const Ir
       z_x64_emit_pop_reg64(code, 7);
       z_x64_emit_pop_reg64(code, 1);
       z_x64_emit_pop_reg64(code, 6);
-      z_x64_emit_cmp_rax_rcx(code, true);
-      size_t keep_dst_len = z_x64_emit_jcc32_placeholder(code, 0x86);
-      z_x64_emit_mov_rax_from_rcx(code);
-      z_x64_patch_rel32(code, keep_dst_len, code->len);
+      z_x64_emit_byte_copy_min_loop(code);
+      return true;
+    }
+    case IR_VALUE_BYTE_FILL: {
+      if (!value->left || !value->right) return elf_diag(diag, "direct ELF64 byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
+      if (!elf_emit_value(code, fun, value->left, ctx, diag)) return false;
+      z_x64_emit_push_rax(code);
+      if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
+      z_x64_emit_push_rax(code);
+      if (!elf_emit_byte_view_len(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_rdx_from_rax(code);
-      z_x64_emit_xor_r8d_r8d(code);
-      size_t loop = code->len;
-      z_x64_emit_cmp_reg_reg(code, 2, 8, true);
-      size_t done = z_x64_emit_jcc32_placeholder(code, 0x86);
-      z_x64_emit_load_reg8_base_index(code, 3, 6, 8);
-      z_x64_emit_store_base_index_reg8(code, 7, 8, 3);
-      z_x64_emit_inc_r8(code);
-      size_t back = z_x64_emit_jmp32_placeholder(code, 0xe9);
-      z_x64_patch_rel32(code, back, loop);
-      z_x64_patch_rel32(code, done, code->len);
-      z_x64_emit_mov_rax_from_rdx(code);
+      z_x64_emit_pop_reg64(code, 7);
+      z_x64_emit_pop_reg64(code, 9);
+      z_x64_emit_byte_fill_loop(code);
       return true;
     }
     case IR_VALUE_BYTE_VIEW_EQ: {
@@ -1186,22 +1184,7 @@ static bool elf_emit_byte_bulk_value(ZBuf *code, const IrFunction *fun, const Ir
       z_x64_emit_mov_reg_from_rax(code, 8, true);
       if (!elf_emit_byte_view_ptr(code, fun, value->right, ctx, diag)) return false;
       z_x64_emit_mov_r9_from_rax(code);
-      z_x64_emit_xor_ecx_ecx(code);
-      size_t loop = code->len;
-      z_x64_emit_cmp_reg_reg(code, 1, 10, true);
-      size_t equal = z_x64_emit_jcc32_placeholder(code, 0x83);
-      z_x64_emit_load_reg8_base_index(code, 0, 8, 1);
-      z_x64_emit_cmp_base_index_reg8(code, 9, 1, 0);
-      size_t mismatch = z_x64_emit_jcc32_placeholder(code, 0x85);
-      z_x64_emit_inc_rcx(code);
-      size_t back = z_x64_emit_jmp32_placeholder(code, 0xe9);
-      z_x64_patch_rel32(code, back, loop);
-      z_x64_patch_rel32(code, mismatch, code->len);
-      z_x64_emit_mov_eax_u32(code, 0);
-      size_t after_false = z_x64_emit_jmp32_placeholder(code, 0xe9);
-      z_x64_patch_rel32(code, equal, code->len);
-      z_x64_emit_mov_eax_u32(code, 1);
-      z_x64_patch_rel32(code, after_false, code->len);
+      z_x64_emit_byte_eq_loop(code);
       z_x64_patch_rel32(code, end, code->len);
       return true;
     }
@@ -1275,7 +1258,7 @@ static bool elf_emit_value(ZBuf *code, const IrFunction *fun, const IrValue *val
       return elf_emit_stateful_value(code, fun, value, ctx, diag);
     case IR_VALUE_INDEX_LOAD: case IR_VALUE_FIELD_LOAD: case IR_VALUE_BYTE_VIEW_LEN:
       return elf_emit_memory_access_value(code, fun, value, ctx, diag);
-    case IR_VALUE_CRC32_BYTES: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_VIEW_EQ:
+    case IR_VALUE_CRC32_BYTES: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL: case IR_VALUE_BYTE_VIEW_EQ:
       return elf_emit_byte_bulk_value(code, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD:
       return elf_emit_byte_index_value(code, fun, value, ctx, diag);

--- a/native/zero-c/src/emit_elf_aarch64.c
+++ b/native/zero-c/src/emit_elf_aarch64.c
@@ -1,10 +1,26 @@
 #include "zero.h"
+#include "aarch64_direct.h"
 #include "aarch64_emit.h"
 #include "elf_format.h"
 
+#include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+
+enum {
+  R_AARCH64_ABS64 = 257u
+};
+
+typedef struct {
+  size_t patch_offset;
+  unsigned data_offset;
+} A64ElfDataPatch;
+
+typedef struct {
+  A64ElfDataPatch *data_patches;
+  size_t data_patch_len;
+  size_t data_patch_cap;
+} A64ElfPatchContext;
 
 static bool a64_diag(ZDiag *diag, const char *message, int line, int column, const char *actual) {
   if (diag) {
@@ -13,54 +29,64 @@ static bool a64_diag(ZDiag *diag, const char *message, int line, int column, con
     diag->column = column > 0 ? column : 1;
     diag->length = 1;
     snprintf(diag->message, sizeof(diag->message), "%s", message);
-    snprintf(diag->expected, sizeof(diag->expected), "direct AArch64 ELF object MVP subset");
+    snprintf(diag->expected, sizeof(diag->expected), "direct AArch64 ELF backend subset");
     snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "unsupported construct");
-    snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to exported no-parameter functions returning small integer literals");
+    snprintf(diag->help, sizeof(diag->help), "choose a supported direct target or restrict this program to AArch64 ELF supported direct-backend constructs");
   }
   return false;
 }
 
-static bool a64_return_literal(const IrFunction *fun, uint32_t *out, ZDiag *diag) {
-  if (!fun) return a64_diag(diag, "direct AArch64 ELF object backend requires a function", 1, 1, "missing function");
-  if (fun->param_count != 0) {
-    return a64_diag(diag, "direct AArch64 ELF object backend currently supports exported functions without parameters", fun->line, fun->column, fun->name);
+static bool a64_elf_record_data_patch(void *user, size_t patch_offset, unsigned data_offset, const IrValue *value, ZDiag *diag) {
+  A64ElfPatchContext *ctx = user;
+  if (!ctx) return a64_diag(diag, "direct AArch64 ELF readonly data patch requires an emit context", value ? value->line : 1, value ? value->column : 1, "missing context");
+  if (ctx->data_patch_len + 1 > ctx->data_patch_cap) {
+    ctx->data_patch_cap = z_grow_capacity(ctx->data_patch_cap, ctx->data_patch_len + 1, 8);
+    ctx->data_patches = z_checked_reallocarray(ctx->data_patches, ctx->data_patch_cap, sizeof(A64ElfDataPatch));
   }
-  if (fun->return_type != IR_TYPE_VOID && fun->return_type != IR_TYPE_U8 && fun->return_type != IR_TYPE_I32 && fun->return_type != IR_TYPE_U32 && fun->return_type != IR_TYPE_USIZE) {
-    return a64_diag(diag, "direct AArch64 ELF object backend currently supports primitive 32-bit-or-smaller integer returns", fun->line, fun->column, fun->name);
-  }
-  *out = 0;
-  if (fun->return_type == IR_TYPE_VOID) {
-    if (fun->instr_len == 0) return true;
-    if (fun->instr_len == 1 && fun->instrs[0].kind == IR_INSTR_RETURN && !fun->instrs[0].value) return true;
-    return a64_diag(diag, "direct AArch64 ELF object backend currently supports only empty Void functions or small integer literal returns", fun->line, fun->column, fun->name);
-  }
-  if (fun->instr_len == 1 && fun->instrs[0].kind == IR_INSTR_RETURN && fun->instrs[0].value &&
-      fun->instrs[0].value->kind == IR_VALUE_INT && fun->instrs[0].value->int_value <= 65535) {
-    *out = (uint32_t)fun->instrs[0].value->int_value;
-    return true;
-  }
-  return a64_diag(diag, "direct AArch64 ELF object backend currently requires a small integer literal return", fun->line, fun->column, fun->name);
+  if (!ctx->data_patches) return a64_diag(diag, "direct AArch64 ELF backend ran out of memory", value ? value->line : 1, value ? value->column : 1, "allocation failed");
+  ctx->data_patches[ctx->data_patch_len++] = (A64ElfDataPatch){.patch_offset = patch_offset, .data_offset = data_offset};
+  return true;
 }
 
-static const IrFunction *a64_find_main(const IrProgram *ir, unsigned *out_index, ZDiag *diag) {
-  const IrFunction *fun = NULL;
-  unsigned index = 0;
-  for (size_t i = 0; ir && i < ir->function_len; i++) {
-    if (ir->functions[i].is_exported && strcmp(ir->functions[i].name, "main") == 0) {
-      if (fun) {
-        a64_diag(diag, "direct AArch64 ELF executable backend requires exactly one exported main function", ir->functions[i].line, ir->functions[i].column, ir->functions[i].name);
-        return NULL;
-      }
-      fun = &ir->functions[i];
-      index = (unsigned)i;
-    }
+static void a64_elf_patch_context_free(A64ElfPatchContext *ctx) {
+  if (!ctx) return;
+  free(ctx->data_patches);
+}
+
+static bool a64_elf_emit_world_write(ZBuf *text, const IrInstr *instr, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  (void)ctx;
+  z_aarch64_emit_movz_x(text, 8, 64); // Linux SYS_write(fd=x0, buf=x1, len=x2)
+  z_aarch64_emit_svc(text, 0);
+  z_aarch64_emit_cmp_x(text, 0, 31);
+  size_t ok_patch = z_aarch64_emit_b_cond_placeholder(text, 10);
+  z_aarch64_emit_brk(text);
+  z_aarch64_patch_cond19(text, ok_patch, text->len);
+  (void)instr;
+  (void)diag;
+  return true;
+}
+
+size_t z_elf_aarch64_stack_bytes_from_ir(const IrProgram *program) {
+  return z_aarch64_direct_stack_bytes_from_ir(program);
+}
+
+size_t z_elf_aarch64_max_frame_bytes_from_ir(const IrProgram *program) {
+  return z_aarch64_direct_max_frame_bytes_from_ir(program);
+}
+
+static void a64_patch_data_patches(ZBuf *text, const A64ElfPatchContext *patches, uint64_t rodata_addr, unsigned rodata_base_offset) {
+  for (size_t i = 0; patches && i < patches->data_patch_len; i++) {
+    const A64ElfDataPatch *patch = &patches->data_patches[i];
+    uint64_t addr = rodata_addr + (patch->data_offset - rodata_base_offset);
+    z_aarch64_patch_u64(text, patch->patch_offset, addr);
   }
-  if (!fun) {
-    a64_diag(diag, "direct AArch64 ELF executable backend requires an exported main function", 1, 1, "missing main");
-    return NULL;
+}
+
+static void a64_append_data_relocations(ZBuf *rela_text, const A64ElfPatchContext *patches, unsigned rodata_base_offset, uint32_t rodata_symbol) {
+  for (size_t i = 0; patches && i < patches->data_patch_len; i++) {
+    const A64ElfDataPatch *patch = &patches->data_patches[i];
+    z_elf_append_rela(rela_text, patch->patch_offset, rodata_symbol, R_AARCH64_ABS64, patch->data_offset - rodata_base_offset);
   }
-  if (out_index) *out_index = index;
-  return fun;
 }
 
 bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag) {
@@ -72,13 +98,24 @@ bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *di
   }
 
   ZBuf text;
+  ZBuf rodata;
+  ZBuf rela_text;
   ZBuf strtab;
   ZBuf symtab;
   zbuf_init(&text);
+  zbuf_init(&rodata);
+  zbuf_init(&rela_text);
   zbuf_init(&strtab);
   zbuf_init(&symtab);
   z_elf_append_u8(&strtab, 0);
   z_elf_append_zeros(&symtab, 24);
+
+  bool has_rodata = ir->readonly_data_bytes > 0 || ir->data_segment_len > 0;
+  unsigned rodata_base_offset = z_aarch64_direct_rodata_base_offset(ir);
+  if (has_rodata) {
+    z_aarch64_direct_append_rodata(&rodata, ir, rodata_base_offset);
+    z_elf_append_symbol(&symtab, 0, 0x03, 2, 0, 0);
+  }
 
   size_t *function_offsets = z_checked_calloc(ir->function_len, sizeof(size_t));
   size_t *function_sizes = z_checked_calloc(ir->function_len, sizeof(size_t));
@@ -88,43 +125,59 @@ bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *di
     free(function_sizes);
     free(symbol_names);
     zbuf_free(&text);
+    zbuf_free(&rodata);
+    zbuf_free(&rela_text);
     zbuf_free(&strtab);
     zbuf_free(&symtab);
     return a64_diag(diag, "direct AArch64 ELF object backend ran out of memory", 1, 1, "allocation failed");
   }
+  A64ElfPatchContext patch_ctx = {0};
+  ZAArch64DirectContext ctx = {
+    .program = ir,
+    .function_offsets = function_offsets,
+    .function_count = ir->function_len,
+    .rodata_base_offset = rodata_base_offset,
+    .patch_user = &patch_ctx,
+    .record_data_patch = a64_elf_record_data_patch
+  };
 
   bool has_export = false;
   for (size_t i = 0; i < ir->function_len; i++) {
     if (!ir->functions[i].is_exported) continue;
     has_export = true;
-    uint32_t literal = 0;
-    if (!a64_return_literal(&ir->functions[i], &literal, diag)) {
+    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+    function_offsets[i] = text.len;
+    if (!z_aarch64_direct_emit_function_text(&text, &ir->functions[i], &ctx, diag)) {
+      a64_elf_patch_context_free(&patch_ctx);
       free(function_offsets);
       free(function_sizes);
       free(symbol_names);
       zbuf_free(&text);
+      zbuf_free(&rodata);
+      zbuf_free(&rela_text);
       zbuf_free(&strtab);
       zbuf_free(&symtab);
       return false;
     }
-    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 4));
-    function_offsets[i] = text.len;
-    z_aarch64_emit_literal_return(&text, literal);
     function_sizes[i] = text.len - function_offsets[i];
     symbol_names[i] = (uint32_t)strtab.len;
     zbuf_append(&strtab, ir->functions[i].name ? ir->functions[i].name : "zero_fn");
     z_elf_append_u8(&strtab, 0);
   }
   if (!has_export) {
+    a64_elf_patch_context_free(&patch_ctx);
     free(function_offsets);
     free(function_sizes);
     free(symbol_names);
     zbuf_free(&text);
+    zbuf_free(&rodata);
+    zbuf_free(&rela_text);
     zbuf_free(&strtab);
     zbuf_free(&symtab);
     return a64_diag(diag, "direct AArch64 ELF object backend requires at least one exported function", 1, 1, "no exported function");
   }
 
+  if (has_rodata) a64_append_data_relocations(&rela_text, &patch_ctx, rodata_base_offset, 1);
   for (size_t i = 0; i < ir->function_len; i++) {
     if (function_sizes[i] > 0) z_elf_append_symbol(&symtab, symbol_names[i], ir->functions[i].is_exported ? 0x12 : 0x02, 1, function_offsets[i], function_sizes[i]);
   }
@@ -132,17 +185,23 @@ bool z_emit_elf_aarch64_object_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *di
   ZElfObjectImage image = {
     .machine = Z_ELF_MACHINE_AARCH64,
     .text = &text,
-    .text_align = 4,
+    .text_align = 16,
+    .rodata = has_rodata ? &rodata : NULL,
+    .rodata_align = 8,
+    .rela_text = rela_text.len > 0 ? &rela_text : NULL,
     .symtab = &symtab,
     .strtab = &strtab,
-    .local_symbol_count = 1
+    .local_symbol_count = has_rodata ? 2 : 1
   };
   z_elf_write_object64(out, &image);
 
+  a64_elf_patch_context_free(&patch_ctx);
   free(function_offsets);
   free(function_sizes);
   free(symbol_names);
   zbuf_free(&text);
+  zbuf_free(&rodata);
+  zbuf_free(&rela_text);
   zbuf_free(&strtab);
   zbuf_free(&symtab);
   return true;
@@ -156,10 +215,16 @@ bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag)
     return ok;
   }
   unsigned main_index = 0;
-  if (!a64_find_main(ir, &main_index, diag)) return false;
+  if (!z_aarch64_direct_find_main(ir, &main_index, diag)) return false;
 
   ZBuf text;
+  ZBuf rodata;
   zbuf_init(&text);
+  zbuf_init(&rodata);
+  bool has_rodata = ir->readonly_data_bytes > 0 || ir->data_segment_len > 0;
+  unsigned rodata_base_offset = z_aarch64_direct_rodata_base_offset(ir);
+  if (has_rodata) z_aarch64_direct_append_rodata(&rodata, ir, rodata_base_offset);
+
   size_t start_call_patch = z_aarch64_emit_bl_placeholder(&text);
   z_aarch64_emit_movz_x(&text, 8, 93);
   z_aarch64_emit_svc(&text, 0);
@@ -168,19 +233,30 @@ bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag)
   size_t *function_offsets = z_checked_calloc(ir->function_len, sizeof(size_t));
   if (!function_offsets) {
     zbuf_free(&text);
+    zbuf_free(&rodata);
     return a64_diag(diag, "direct AArch64 ELF executable backend ran out of memory", 1, 1, "allocation failed");
   }
+  A64ElfPatchContext patch_ctx = {0};
+  ZAArch64DirectContext ctx = {
+    .program = ir,
+    .function_offsets = function_offsets,
+    .function_count = ir->function_len,
+    .rodata_base_offset = rodata_base_offset,
+    .patch_user = &patch_ctx,
+    .record_data_patch = a64_elf_record_data_patch,
+    .emit_world_write = a64_elf_emit_world_write
+  };
   for (size_t i = 0; i < ir->function_len; i++) {
     if (!ir->functions[i].is_exported) continue;
-    uint32_t literal = 0;
-    if (!a64_return_literal(&ir->functions[i], &literal, diag)) {
+    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 16));
+    function_offsets[i] = text.len;
+    if (!z_aarch64_direct_emit_function_text(&text, &ir->functions[i], &ctx, diag)) {
+      a64_elf_patch_context_free(&patch_ctx);
       free(function_offsets);
       zbuf_free(&text);
+      zbuf_free(&rodata);
       return false;
     }
-    z_aarch64_pad_to(&text, z_aarch64_align(text.len, 4));
-    function_offsets[i] = text.len;
-    z_aarch64_emit_literal_return(&text, literal);
   }
   z_aarch64_patch_branch26(&text, start_call_patch, function_offsets[main_index]);
 
@@ -189,16 +265,23 @@ bool z_emit_elf_aarch64_exe_from_ir(const IrProgram *ir, ZBuf *out, ZDiag *diag)
   const size_t phdr_size = 56;
   const size_t text_offset = ehdr_size + phdr_size;
   const uint64_t entry_addr = base_addr + text_offset;
+  size_t rodata_offset = has_rodata ? z_elf_align(text_offset + text.len, 8) : 0;
+  uint64_t rodata_addr = has_rodata ? base_addr + rodata_offset : 0;
+  a64_patch_data_patches(&text, &patch_ctx, rodata_addr, rodata_base_offset);
   ZElfExecutableImage image = {
     .machine = Z_ELF_MACHINE_AARCH64,
     .base_addr = base_addr,
     .entry_addr = entry_addr,
     .text_offset = text_offset,
     .text = &text,
+    .rodata = has_rodata ? &rodata : NULL,
+    .rodata_offset = rodata_offset,
     .segment_align = 0x1000
   };
   z_elf_write_executable64(out, &image);
+  a64_elf_patch_context_free(&patch_ctx);
   free(function_offsets);
   zbuf_free(&text);
+  zbuf_free(&rodata);
   return true;
 }

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -547,6 +547,56 @@ static bool macho_emit_byte_view_index_load_to_reg_at(ZBuf *text, const IrFuncti
   return true;
 }
 
+static bool macho_emit_byte_copy_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return macho_diag_at(diag, "direct AArch64 Mach-O byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
+  if (!macho_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot, value->left, diag)) return false;
+  if (!macho_emit_byte_view_len_at(text, fun, value->left, 10, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 10, IR_TYPE_U32, scratch_slot + 1, value->left, diag)) return false;
+  if (!macho_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 12, IR_TYPE_U64, scratch_slot + 2, value->right, diag)) return false;
+  if (!macho_emit_byte_view_len_at(text, fun, value->right, 13, frame_size, scratch_slot + 3, ctx, diag)) return false;
+  if (!macho_emit_load_scratch(text, 10, IR_TYPE_U32, scratch_slot + 1, value->left, diag)) return false;
+  if (!macho_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot, value->left, diag)) return false;
+  if (!macho_emit_load_scratch(text, 12, IR_TYPE_U64, scratch_slot + 2, value->right, diag)) return false;
+  z_aarch64_emit_byte_copy_min_loop(text, reg);
+  return true;
+}
+
+static bool macho_emit_byte_fill_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return macho_diag_at(diag, "direct AArch64 Mach-O byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
+  if (!macho_emit_value_to_reg_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 8, IR_TYPE_U8, scratch_slot, value->left, diag)) return false;
+  if (!macho_emit_byte_view_ptr_at(text, fun, value->right, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->right, diag)) return false;
+  if (!macho_emit_byte_view_len_at(text, fun, value->right, 10, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!macho_emit_load_scratch(text, 8, IR_TYPE_U8, scratch_slot, value->left, diag)) return false;
+  if (!macho_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->right, diag)) return false;
+  z_aarch64_emit_byte_fill_loop(text, reg);
+  return true;
+}
+
+static bool macho_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return macho_diag_at(diag, "direct AArch64 Mach-O byte-view equality requires two byte views", value->line, value->column, "missing byte view");
+  if (!macho_emit_byte_view_len_at(text, fun, value->left, 8, frame_size, scratch_slot, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 8, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
+  if (!macho_emit_byte_view_len_at(text, fun, value->right, 9, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!macho_emit_load_scratch(text, 8, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
+  z_aarch64_emit_cmp_w(text, 8, 9);
+  size_t same_len = z_aarch64_emit_b_cond_placeholder(text, 0);
+  z_aarch64_emit_movz_w(text, reg, 0);
+  size_t end_patch = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_cond19(text, same_len, text->len);
+  z_aarch64_emit_mov_w(text, 10, 8);
+  if (!macho_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
+  if (!macho_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  if (!macho_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
+  if (!macho_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  z_aarch64_emit_byte_eq_loop(text, reg);
+  z_aarch64_patch_branch26(text, end_patch, text->len);
+  return true;
+}
+
 static bool macho_emit_index_load_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return macho_diag_at(diag, "direct AArch64 Mach-O indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -786,6 +836,12 @@ static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const 
       return true;
     case IR_VALUE_BYTE_VIEW_LEN:
       return macho_emit_byte_view_len_at(text, fun, value->left, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_COPY:
+      return macho_emit_byte_copy_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_FILL:
+      return macho_emit_byte_fill_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_EQ:
+      return macho_emit_byte_view_eq_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD:
       return macho_emit_byte_view_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_INDEX_LOAD:

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -587,11 +587,11 @@ static bool macho_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun,
   z_aarch64_emit_movz_w(text, reg, 0);
   size_t end_patch = z_aarch64_emit_b_placeholder(text);
   z_aarch64_patch_cond19(text, same_len, text->len);
-  z_aarch64_emit_mov_w(text, 10, 8);
   if (!macho_emit_byte_view_ptr_at(text, fun, value->left, 11, frame_size, scratch_slot + 1, ctx, diag)) return false;
   if (!macho_emit_store_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
   if (!macho_emit_byte_view_ptr_at(text, fun, value->right, 12, frame_size, scratch_slot + 2, ctx, diag)) return false;
   if (!macho_emit_load_scratch(text, 11, IR_TYPE_U64, scratch_slot + 1, value->left, diag)) return false;
+  if (!macho_emit_load_scratch(text, 10, IR_TYPE_U32, scratch_slot, value->left, diag)) return false;
   z_aarch64_emit_byte_eq_loop(text, reg);
   z_aarch64_patch_branch26(text, end_patch, text->len);
   return true;

--- a/native/zero-c/src/emit_macho_x64.c
+++ b/native/zero-c/src/emit_macho_x64.c
@@ -408,6 +408,57 @@ static bool machx64_emit_byte_view_index_load_value(ZBuf *text, const IrFunction
   return true;
 }
 
+static bool machx64_emit_byte_copy_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return machx64_diag_at(diag, "direct x86_64 Mach-O byte copy requires source and destination byte views", value->line, value->column, "missing byte view");
+  if (!machx64_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_pop_reg64(text, 7);
+  z_x64_emit_pop_reg64(text, 1);
+  z_x64_emit_pop_reg64(text, 6);
+  z_x64_emit_byte_copy_min_loop(text);
+  return true;
+}
+
+static bool machx64_emit_byte_fill_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return machx64_diag_at(diag, "direct x86_64 Mach-O byte fill requires a fill byte and destination byte view", value->line, value->column, "missing byte fill input");
+  if (!machx64_emit_value(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_mov_rdx_from_rax(text);
+  z_x64_emit_pop_reg64(text, 7);
+  z_x64_emit_pop_reg64(text, 9);
+  z_x64_emit_byte_fill_loop(text);
+  return true;
+}
+
+static bool machx64_emit_byte_view_eq_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left || !value->right) return machx64_diag_at(diag, "direct x86_64 Mach-O byte-view equality requires two byte views", value->line, value->column, "missing byte view");
+  if (!machx64_emit_byte_view_len(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_push_rax(text);
+  if (!machx64_emit_byte_view_len(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_pop_reg64(text, 1);
+  z_x64_emit_cmp_reg_reg(text, 1, 0, false);
+  size_t same_len = z_x64_emit_jcc32_placeholder(text, 0x84);
+  z_x64_emit_mov_eax_u32(text, 0);
+  size_t end = z_x64_emit_jmp32_placeholder(text, 0xe9);
+  z_x64_patch_rel32(text, same_len, text->len);
+  z_x64_emit_mov_reg_from_rax(text, 10, true);
+  if (!machx64_emit_byte_view_ptr(text, fun, value->left, ctx, diag)) return false;
+  z_x64_emit_mov_reg_from_rax(text, 8, true);
+  if (!machx64_emit_byte_view_ptr(text, fun, value->right, ctx, diag)) return false;
+  z_x64_emit_mov_r9_from_rax(text);
+  z_x64_emit_byte_eq_loop(text);
+  z_x64_patch_rel32(text, end, text->len);
+  return true;
+}
+
 static bool machx64_emit_index_load_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return machx64_diag_at(diag, "direct x86_64 Mach-O indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -464,6 +515,9 @@ static bool machx64_emit_value(ZBuf *text, const IrFunction *fun, const IrValue 
     case IR_VALUE_CHECK: return machx64_emit_check_value(text, fun, value, ctx, diag);
     case IR_VALUE_CALL: return machx64_emit_call_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_LEN: return machx64_emit_byte_view_len(text, fun, value->left, ctx, diag);
+    case IR_VALUE_BYTE_COPY: return machx64_emit_byte_copy_value(text, fun, value, ctx, diag);
+    case IR_VALUE_BYTE_FILL: return machx64_emit_byte_fill_value(text, fun, value, ctx, diag);
+    case IR_VALUE_BYTE_VIEW_EQ: return machx64_emit_byte_view_eq_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return machx64_emit_byte_view_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_INDEX_LOAD: return machx64_emit_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_FIELD_LOAD: return machx64_emit_field_load_value(text, fun, value, diag);

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -8497,7 +8497,7 @@ static void append_target_readiness_json(ZBuf *buf, SourceInput *input, const Pr
 }
 
 static void append_release_matrix_target_support_json(ZBuf *buf) {
-  const char *targets[] = {"linux-musl-x64", "linux-arm64", "darwin-arm64", "darwin-x64", "win32-x64.exe", NULL};
+  const char *targets[] = {"darwin-arm64", "darwin-x64", "linux-arm64", "linux-musl-arm64", "linux-musl-x64", "linux-x64", "win32-arm64.exe", "win32-x64.exe", NULL};
   zbuf_append(buf, "[");
   for (size_t i = 0; targets[i]; i++) {
     if (i > 0) zbuf_append(buf, ",");

--- a/native/zero-c/src/target_backend.c
+++ b/native/zero-c/src/target_backend.c
@@ -29,6 +29,7 @@ static const ZDirectBackendDescriptor direct_backend_descriptors[] = {
   {Z_DIRECT_BACKEND_MACHO64, "zero-macho64", "zero-macho64-exe", "macho64", "direct-macho64-object", "direct-macho64-exe", "direct-macho64-object-runtime-link", true},
   {Z_DIRECT_BACKEND_MACHO_X64, "zero-macho-x64", "zero-macho-x64-exe", "macho64", "direct-macho-x64-object", "direct-macho-x64-exe", "direct-macho-x64-object-runtime-link", true},
   {Z_DIRECT_BACKEND_COFF_X64, "zero-coff-x64", "zero-coff-x64-exe", "coff", "direct-coff-x64-object", "direct-coff-x64-exe", "unsupported", false},
+  {Z_DIRECT_BACKEND_COFF_AARCH64, "zero-coff-aarch64", "zero-coff-aarch64-exe", "coff", "direct-coff-aarch64-object", "direct-coff-aarch64-exe", "unsupported", false},
 };
 
 static const ZDirectBackendRule direct_backend_rules[] = {
@@ -39,6 +40,7 @@ static const ZDirectBackendRule direct_backend_rules[] = {
   {"macho", "macos", "aarch64", "darwin", Z_DIRECT_BACKEND_MACHO64, true, true},
   {"macho", "macos", "x86_64", "darwin", Z_DIRECT_BACKEND_MACHO_X64, true, true},
   {"coff", "windows", "x86_64", "msvc", Z_DIRECT_BACKEND_COFF_X64, true, true},
+  {"coff", "windows", "aarch64", "msvc", Z_DIRECT_BACKEND_COFF_AARCH64, true, true},
 };
 
 static const ZDirectBackendDescriptor *direct_backend_descriptor(ZDirectBackend backend) {
@@ -140,7 +142,8 @@ const char *z_direct_backend_runtime_object_cache_key(ZDirectBackend backend) {
 
 size_t z_direct_backend_symbol_overhead(ZDirectBackend backend, bool has_readonly_data) {
   switch (backend) {
-    case Z_DIRECT_BACKEND_COFF_X64: return has_readonly_data ? 2 : 1;
+    case Z_DIRECT_BACKEND_COFF_X64:
+    case Z_DIRECT_BACKEND_COFF_AARCH64: return has_readonly_data ? 2 : 1;
     case Z_DIRECT_BACKEND_ELF64:
     case Z_DIRECT_BACKEND_ELF_AARCH64:
     case Z_DIRECT_BACKEND_MACHO64:
@@ -208,7 +211,6 @@ const char *z_direct_backend_reason(const ZTargetInfo *target) {
     return "direct object backend available; direct executable linker is not implemented for this target";
   }
   if (strcmp(format, "elf") == 0 && strcmp(arch, "aarch64") == 0) return "AArch64 ELF machine-code backend is not implemented yet";
-  if (strcmp(format, "coff") == 0 && strcmp(arch, "aarch64") == 0) return "AArch64 COFF machine-code backend is not implemented yet";
   return "direct backend is not implemented for this target format/architecture pair";
 }
 
@@ -331,12 +333,13 @@ const char *z_direct_backend_expected(const ZTargetInfo *target) {
   ZDirectBackend backend = z_direct_object_backend(target);
   const char *format = target && target->object_format ? target->object_format : "";
   const char *arch = target && target->arch ? target->arch : "";
-  if (backend == Z_DIRECT_BACKEND_MACHO64) return "direct AArch64 Mach-O object MVP subset";
+  if (backend == Z_DIRECT_BACKEND_MACHO64) return "direct AArch64 Mach-O object subset";
   if (backend == Z_DIRECT_BACKEND_MACHO_X64) return "direct x86_64 Mach-O object subset";
   if (strcmp(format, "macho") == 0) return "direct Mach-O object subset";
-  if (backend == Z_DIRECT_BACKEND_COFF_X64 || strcmp(format, "coff") == 0) return "direct COFF x64 object MVP subset";
-  if (backend == Z_DIRECT_BACKEND_ELF_AARCH64 || (strcmp(format, "elf") == 0 && strcmp(arch, "aarch64") == 0)) return "direct AArch64 ELF object MVP subset";
-  if (backend == Z_DIRECT_BACKEND_ELF64 || strcmp(format, "elf") == 0) return "direct ELF64 object MVP subset";
+  if (backend == Z_DIRECT_BACKEND_COFF_AARCH64) return "direct COFF AArch64 object subset";
+  if (backend == Z_DIRECT_BACKEND_COFF_X64 || strcmp(format, "coff") == 0) return "direct COFF x64 object subset";
+  if (backend == Z_DIRECT_BACKEND_ELF_AARCH64 || (strcmp(format, "elf") == 0 && strcmp(arch, "aarch64") == 0)) return "direct AArch64 ELF object subset";
+  if (backend == Z_DIRECT_BACKEND_ELF64 || strcmp(format, "elf") == 0) return "direct ELF64 object subset";
   return "direct target with matching object format and architecture";
 }
 
@@ -347,8 +350,9 @@ const char *z_direct_backend_help(const ZTargetInfo *target) {
   if (backend == Z_DIRECT_BACKEND_MACHO_X64) return "reduce the program to primitive x86_64 Mach-O direct-backend constructs or choose a supported direct target";
   if (backend == Z_DIRECT_BACKEND_MACHO64 || backend == Z_DIRECT_BACKEND_ELF_AARCH64 ||
       strcmp(format, "macho") == 0 || (strcmp(format, "elf") == 0 && strcmp(arch, "aarch64") == 0)) {
-    return "choose a supported direct target or restrict this program to exported no-parameter functions returning small integer literals";
+    return "choose a supported direct target or reduce the program to supported AArch64 direct-backend constructs";
   }
+  if (backend == Z_DIRECT_BACKEND_COFF_AARCH64) return "reduce the program to AArch64 COFF supported direct-backend constructs or choose a supported direct target";
   if (backend == Z_DIRECT_BACKEND_COFF_X64 || strcmp(format, "coff") == 0) return "reduce the program to primitive direct-backend constructs or choose a supported direct target";
   return "choose a supported direct target or restrict this program to exported primitive integer arithmetic functions";
 }

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -436,8 +436,8 @@ void z_x64_emit_byte_copy_min_loop(ZBuf *buf) {
   size_t loop = buf->len;
   z_x64_emit_cmp_reg_reg(buf, 2, 8, true);
   size_t done = z_x64_emit_jcc32_placeholder(buf, 0x86);
-  z_x64_emit_load_reg8_base_index(buf, 3, 6, 8);
-  z_x64_emit_store_base_index_reg8(buf, 7, 8, 3);
+  z_x64_emit_load_reg8_base_index(buf, 10, 6, 8);
+  z_x64_emit_store_base_index_reg8(buf, 7, 8, 10);
   z_x64_emit_inc_r8(buf);
   size_t back = z_x64_emit_jmp32_placeholder(buf, 0xe9);
   z_x64_patch_rel32(buf, back, loop);

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -425,6 +425,60 @@ void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_r
   z_x64_append_u8(buf, value);
 }
 
+void z_x64_emit_byte_copy_min_loop(ZBuf *buf) {
+  // Inputs: rsi=source ptr, rcx=source len, rdi=destination ptr, rax=destination len. Output: rax=copied len.
+  z_x64_emit_cmp_rax_rcx(buf, true);
+  size_t keep_dst_len = z_x64_emit_jcc32_placeholder(buf, 0x86);
+  z_x64_emit_mov_rax_from_rcx(buf);
+  z_x64_patch_rel32(buf, keep_dst_len, buf->len);
+  z_x64_emit_mov_rdx_from_rax(buf);
+  z_x64_emit_xor_r8d_r8d(buf);
+  size_t loop = buf->len;
+  z_x64_emit_cmp_reg_reg(buf, 2, 8, true);
+  size_t done = z_x64_emit_jcc32_placeholder(buf, 0x86);
+  z_x64_emit_load_reg8_base_index(buf, 3, 6, 8);
+  z_x64_emit_store_base_index_reg8(buf, 7, 8, 3);
+  z_x64_emit_inc_r8(buf);
+  size_t back = z_x64_emit_jmp32_placeholder(buf, 0xe9);
+  z_x64_patch_rel32(buf, back, loop);
+  z_x64_patch_rel32(buf, done, buf->len);
+  z_x64_emit_mov_rax_from_rdx(buf);
+}
+
+void z_x64_emit_byte_fill_loop(ZBuf *buf) {
+  // Inputs: rdi=destination ptr, rdx=len, r9b=fill byte. Output: rax=len.
+  z_x64_emit_xor_r8d_r8d(buf);
+  size_t loop = buf->len;
+  z_x64_emit_cmp_reg_reg(buf, 2, 8, true);
+  size_t done = z_x64_emit_jcc32_placeholder(buf, 0x86);
+  z_x64_emit_store_base_index_reg8(buf, 7, 8, 9);
+  z_x64_emit_inc_r8(buf);
+  size_t back = z_x64_emit_jmp32_placeholder(buf, 0xe9);
+  z_x64_patch_rel32(buf, back, loop);
+  z_x64_patch_rel32(buf, done, buf->len);
+  z_x64_emit_mov_rax_from_rdx(buf);
+}
+
+void z_x64_emit_byte_eq_loop(ZBuf *buf) {
+  // Inputs: r8=left ptr, r9=right ptr, r10=len. Output: eax=Bool.
+  z_x64_emit_xor_ecx_ecx(buf);
+  size_t loop = buf->len;
+  z_x64_emit_cmp_reg_reg(buf, 1, 10, true);
+  size_t equal = z_x64_emit_jcc32_placeholder(buf, 0x83);
+  z_x64_emit_load_reg8_base_index(buf, 0, 8, 1);
+  z_x64_emit_cmp_base_index_reg8(buf, 9, 1, 0);
+  size_t mismatch = z_x64_emit_jcc32_placeholder(buf, 0x85);
+  z_x64_emit_inc_rcx(buf);
+  size_t back = z_x64_emit_jmp32_placeholder(buf, 0xe9);
+  z_x64_patch_rel32(buf, back, loop);
+  z_x64_patch_rel32(buf, mismatch, buf->len);
+  z_x64_emit_mov_eax_u32(buf, 0);
+  size_t after_false = z_x64_emit_jmp32_placeholder(buf, 0xe9);
+  z_x64_patch_rel32(buf, equal, buf->len);
+  z_x64_emit_mov_eax_u32(buf, 1);
+  z_x64_patch_rel32(buf, after_false, buf->len);
+}
+
 void z_x64_emit_load_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp, bool wide) {
   z_x64_emit_base_index_scale_disp_op(buf, 0x8b, dst_reg, base_reg, index_reg, scale, disp, wide, false);
 }

--- a/native/zero-c/src/x64_emit.h
+++ b/native/zero-c/src/x64_emit.h
@@ -50,6 +50,9 @@ void z_x64_emit_movzx_reg32_base_index_u8(ZBuf *buf, unsigned dst_reg, unsigned 
 void z_x64_emit_store_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned src_reg);
 void z_x64_emit_cmp_base_index_reg8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned reg);
 void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_reg, unsigned value);
+void z_x64_emit_byte_copy_min_loop(ZBuf *buf);
+void z_x64_emit_byte_fill_loop(ZBuf *buf);
+void z_x64_emit_byte_eq_loop(ZBuf *buf);
 void z_x64_emit_load_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp, bool wide);
 void z_x64_emit_lea_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp);
 void z_x64_emit_xor_r8d_r8d(ZBuf *buf);

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -27,7 +27,7 @@ const fileBudgets = {
   "native/zero-c/src/buildability_internal.h": { maxLines: 40, maxStrcmpCalls: 0 },
   "native/zero-c/src/buildability_context.c": { maxLines: 185, maxStrcmpCalls: 1 },
   "native/zero-c/src/buildability_targets.c": { maxLines: 190, maxStrcmpCalls: 0 },
-  "native/zero-c/src/buildability_value_targets.c": { maxLines: 270, maxStrcmpCalls: 0 },
+  "native/zero-c/src/buildability_value_targets.c": { maxLines: 285, maxStrcmpCalls: 0 },
   "native/zero-c/src/call_resolve.c": { maxLines: 200, maxStrcmpCalls: 2 },
   "native/zero-c/src/call_resolve.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_format.c": { maxLines: 370, maxStrcmpCalls: 0 },

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -15,7 +15,7 @@ type CScanState = {
 };
 
 const fileBudgets = {
-  "native/zero-c/include/zero.h": { maxLines: 970, maxStrcmpCalls: 0 },
+  "native/zero-c/include/zero.h": { maxLines: 980, maxStrcmpCalls: 0 },
   "native/zero-c/include/zero_runtime.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/checker.c": { maxLines: 9407, maxStrcmpCalls: 279 },
   "native/zero-c/src/main.c": { maxLines: 9876, maxStrcmpCalls: 441 },
@@ -25,8 +25,9 @@ const fileBudgets = {
   "native/zero-c/src/buildability.c": { maxLines: 295, maxStrcmpCalls: 2 },
   "native/zero-c/src/buildability.h": { maxLines: 20, maxStrcmpCalls: 0 },
   "native/zero-c/src/buildability_internal.h": { maxLines: 40, maxStrcmpCalls: 0 },
-  "native/zero-c/src/buildability_context.c": { maxLines: 180, maxStrcmpCalls: 1 },
+  "native/zero-c/src/buildability_context.c": { maxLines: 185, maxStrcmpCalls: 1 },
   "native/zero-c/src/buildability_targets.c": { maxLines: 190, maxStrcmpCalls: 0 },
+  "native/zero-c/src/buildability_value_targets.c": { maxLines: 270, maxStrcmpCalls: 0 },
   "native/zero-c/src/call_resolve.c": { maxLines: 200, maxStrcmpCalls: 2 },
   "native/zero-c/src/call_resolve.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_format.c": { maxLines: 370, maxStrcmpCalls: 0 },
@@ -34,22 +35,25 @@ const fileBudgets = {
   "native/zero-c/src/coff_emit_state.c": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_emit_state.h": { maxLines: 70, maxStrcmpCalls: 0 },
   "native/zero-c/src/direct_emit.c": { maxLines: 35, maxStrcmpCalls: 0 },
-  "native/zero-c/src/direct_metrics.c": { maxLines: 20, maxStrcmpCalls: 0 },
+  "native/zero-c/src/direct_metrics.c": { maxLines: 35, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.c": { maxLines: 220, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_format.h": { maxLines: 60, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_emit_state.c": { maxLines: 160, maxStrcmpCalls: 0 },
   "native/zero-c/src/elf_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.c": { maxLines: 470, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.h": { maxLines: 90, maxStrcmpCalls: 0 },
-  "native/zero-c/src/aarch64_emit.c": { maxLines: 320, maxStrcmpCalls: 0 },
+  "native/zero-c/src/aarch64_direct.c": { maxLines: 700, maxStrcmpCalls: 1 },
+  "native/zero-c/src/aarch64_direct.h": { maxLines: 40, maxStrcmpCalls: 0 },
+  "native/zero-c/src/aarch64_emit.c": { maxLines: 380, maxStrcmpCalls: 0 },
   "native/zero-c/src/aarch64_emit.h": { maxLines: 80, maxStrcmpCalls: 0 },
-  "native/zero-c/src/emit_macho64.c": { maxLines: 1520, maxStrcmpCalls: 2 },
-  "native/zero-c/src/emit_macho_x64.c": { maxLines: 1050, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_macho64.c": { maxLines: 1580, maxStrcmpCalls: 2 },
+  "native/zero-c/src/emit_macho_x64.c": { maxLines: 1110, maxStrcmpCalls: 1 },
   "native/zero-c/src/macho_emit_state.c": { maxLines: 210, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/emit_elf64.c": { maxLines: 2090, maxStrcmpCalls: 3 },
-  "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 205, maxStrcmpCalls: 1 },
-  "native/zero-c/src/emit_coff.c": { maxLines: 905, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 300, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff.c": { maxLines: 960, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff_aarch64.c": { maxLines: 340, maxStrcmpCalls: 0 },
   "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 32 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1300, maxStrcmpCalls: 0 },
   "native/zero-c/src/mir_verify.h": { maxLines: 50, maxStrcmpCalls: 0 },
@@ -57,14 +61,14 @@ const fileBudgets = {
   "native/zero-c/src/specialize.h": { maxLines: 50, maxStrcmpCalls: 0 },
   "native/zero-c/src/std_sig.c": { maxLines: 206, maxStrcmpCalls: 2 },
   "native/zero-c/src/std_sig.h": { maxLines: 48, maxStrcmpCalls: 0 },
-  "native/zero-c/src/target_backend.c": { maxLines: 355, maxStrcmpCalls: 32 },
+  "native/zero-c/src/target_backend.c": { maxLines: 360, maxStrcmpCalls: 32 },
   "native/zero-c/src/target.c": { maxLines: 465, maxStrcmpCalls: 15 },
   "native/zero-c/src/type_core.c": { maxLines: 900, maxStrcmpCalls: 8 },
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/unify.c": { maxLines: 500, maxStrcmpCalls: 14 },
   "native/zero-c/src/unify.h": { maxLines: 75, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.c": { maxLines: 765, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.h": { maxLines: 112, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.c": { maxLines: 825, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.h": { maxLines: 115, maxStrcmpCalls: 0 },
 };
 
 const knownLargeFunctionLimits = new Map([
@@ -923,7 +927,9 @@ function budgetViolations(files, allLargeFunctions, stdlib, backendFormats) {
     });
   }
   if (!backendFormats.aarch64.sharedEncodingPrimitives ||
+      !backendFormats.aarch64.directLayerUsesSharedEncodingPrimitives ||
       !backendFormats.aarch64.elfUsesSharedEncodingPrimitives ||
+      !backendFormats.aarch64.coffUsesSharedEncodingPrimitives ||
       !backendFormats.aarch64.machoUsesSharedEncodingPrimitives) {
     violations.push({
       kind: "aarch64-encoding-primitives-split",
@@ -1042,10 +1048,12 @@ const coffEmitStateSource = cCodeText(texts.get("native/zero-c/src/coff_emit_sta
 const machoFormatSource = texts.get("native/zero-c/src/macho_format.c") ?? "";
 const machoEmitStateSource = cCodeText(texts.get("native/zero-c/src/macho_emit_state.c") ?? "");
 const aarch64EmitSource = texts.get("native/zero-c/src/aarch64_emit.c") ?? "";
+const aarch64DirectSource = cCodeText(texts.get("native/zero-c/src/aarch64_direct.c") ?? "");
 const x64EmitSource = texts.get("native/zero-c/src/x64_emit.c") ?? "";
 const elfX64Source = cCodeText(texts.get("native/zero-c/src/emit_elf64.c") ?? "");
 const elfAarch64Source = cCodeText(texts.get("native/zero-c/src/emit_elf_aarch64.c") ?? "");
 const coffX64Source = cCodeText(texts.get("native/zero-c/src/emit_coff.c") ?? "");
+const coffAarch64Source = cCodeText(texts.get("native/zero-c/src/emit_coff_aarch64.c") ?? "");
 const machoArm64Source = cCodeText(texts.get("native/zero-c/src/emit_macho64.c") ?? "");
 const machoX64Source = cCodeText(texts.get("native/zero-c/src/emit_macho_x64.c") ?? "");
 const rawX64RegisterImmediateOpcode = /\bz_x64_append_u8\s*\(\s*(?:code|text)\s*,\s*0xb[8-9a-f]\s*\)/i;
@@ -1142,10 +1150,13 @@ const backendFormats = {
   },
   coff: {
     sharedWriter: /\bz_coff_write_object\s*\(/.test(coffFormatSource) && /\bz_coff_write_pe64_executable\s*\(/.test(coffFormatSource),
-    objectUsesSharedWriter: /\bz_coff_write_object\s*\(\s*out\s*,\s*&image\s*\)/.test(coffX64Source),
-    executableUsesSharedWriter: /\bz_coff_write_pe64_executable\s*\(\s*out\s*,\s*&image\s*\)/.test(coffX64Source),
+    objectUsesSharedWriter: /\bz_coff_write_object\s*\(\s*out\s*,\s*&image\s*\)/.test(coffX64Source) &&
+      /\bz_coff_write_object\s*\(\s*out\s*,\s*&image\s*\)/.test(coffAarch64Source),
+    executableUsesSharedWriter: /\bz_coff_write_pe64_executable\s*\(\s*out\s*,\s*&image\s*\)/.test(coffX64Source) &&
+      /\bz_coff_write_pe64_executable\s*\(\s*out\s*,\s*&image\s*\)/.test(coffAarch64Source),
     archFilesWithLocalContainerWriters: [
       ["native/zero-c/src/emit_coff.c", coffX64Source],
+      ["native/zero-c/src/emit_coff_aarch64.c", coffAarch64Source],
     ]
       .filter(([, text]) => /\bappend_coff_name\s*\(|\bcoff_append_import_table\s*\(|\bPE32\+|\bIMAGE_FILE_MACHINE_AMD64/.test(text))
       .map(([path]) => path),
@@ -1283,93 +1294,14 @@ const backendFormats = {
       /\bz_x64_emit_call32_placeholder\s*\(/.test(x64EmitSource) &&
       /\bz_x64_emit_call_rip32_placeholder\s*\(/.test(x64EmitSource) &&
       /\bz_x64_patch_rel32\s*\(/.test(x64EmitSource),
-    elfUsesSharedEncodingPrimitives: /\bz_x64_append_u8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_append_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_rbp_disp_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_load_rsp_offset_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_store_rsp_offset_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_lea_rsp_offset_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rsp_offset_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_inc_rsp_offset64\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_rax_rsp_offset\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_rax_rsp_offset\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_reg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_reg_i8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_reg_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_reg_from_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_reg_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_reg_i32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_reg_u64\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_reg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_reg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_sub_reg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_reg_from_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_reg_i8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_and_reg_i8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_and_reg_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_neg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_shr_reg_one\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_shl_reg_imm8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_imul_reg_i32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_rax_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_sub_rax_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_load_reg8_base_index\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_movzx_reg32_base_index_u8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_store_base_index_reg8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_base_index_reg8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_base_index_u8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_load_base_index_scale_disp_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_lea_base_index_scale_disp_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_r8d_r8d\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_jcc32_placeholder\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_prologue\s*\(/.test(elfX64Source) &&
+    elfUsesSharedEncodingPrimitives: /\bz_x64_emit_prologue\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_epilogue\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_mov_eax_u32\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_ud2\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_push_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_pop_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rcx_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_r9_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rax_from_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rdx_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rdi_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rsi_from_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rsi_from_rsp\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rax_from_rdx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rax_from_rdi\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_eax_from_ecx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rax_u64_patchable\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_mov_rax_u64\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_eax_eax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_ecx_ecx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_rdi_rdi\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_xor_rax_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_inc_ecx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_inc_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_inc_r8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_dec_r8d\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_sub_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_imul_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_and_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_or_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_add_rdx_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_shr_rcx_imm8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_movzx_reg32_ptr_reg_u8\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_load_reg_ptr_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_store_ptr_reg8_from_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_store_ptr_reg_from_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_reg_ptr_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_div_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_test_rax_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_test_ecx_ecx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_test_reg_reg\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_rax_rcx\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_setcc_al_to_bool\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_cmp_rax_rcx_to_bool\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_bool_from_nonnegative_rax\s*\(/.test(elfX64Source) &&
-      /\bz_x64_emit_call32_placeholder\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_jcc32_placeholder\s*\(/.test(elfX64Source) &&
       /\bz_x64_emit_syscall\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_byte_copy_min_loop\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_byte_fill_loop\s*\(/.test(elfX64Source) &&
+      /\bz_x64_emit_byte_eq_loop\s*\(/.test(elfX64Source) &&
       /\bz_x64_patch_rel32\s*\(/.test(elfX64Source),
     coffUsesSharedEncodingPrimitives: /\bz_x64_append_u8\s*\(/.test(coffX64Source) &&
       /\bz_x64_append_u32\s*\(/.test(coffX64Source) &&
@@ -1484,9 +1416,13 @@ const backendFormats = {
     sharedEncodingPrimitives: /\bz_aarch64_emit_movz_w\s*\(/.test(aarch64EmitSource) &&
       /\bz_aarch64_emit_bl_placeholder\s*\(/.test(aarch64EmitSource) &&
       /\bz_aarch64_patch_branch26\s*\(/.test(aarch64EmitSource),
-    elfUsesSharedEncodingPrimitives: /\bz_aarch64_emit_literal_return\s*\(/.test(elfAarch64Source) &&
-      /\bz_aarch64_emit_bl_placeholder\s*\(/.test(elfAarch64Source) &&
-      /\bz_aarch64_patch_branch26\s*\(/.test(elfAarch64Source),
+    directLayerUsesSharedEncodingPrimitives: /\bz_aarch64_emit_literal_return\s*\(/.test(aarch64DirectSource) &&
+      /\bz_aarch64_emit_byte_eq_loop\s*\(/.test(aarch64DirectSource) &&
+      /\bz_aarch64_patch_branch26\s*\(/.test(aarch64DirectSource),
+    elfUsesSharedEncodingPrimitives: /\bz_aarch64_direct_emit_function_text\s*\(/.test(elfAarch64Source) &&
+      /\bz_aarch64_direct_stack_bytes_from_ir\s*\(/.test(elfAarch64Source),
+    coffUsesSharedEncodingPrimitives: /\bz_aarch64_direct_emit_function_text\s*\(/.test(coffAarch64Source) &&
+      /\bz_aarch64_direct_find_main\s*\(/.test(coffAarch64Source),
     machoUsesSharedEncodingPrimitives: /\bz_aarch64_emit_movz_w\s*\(/.test(machoArm64Source) &&
       /\bz_aarch64_emit_bl_placeholder\s*\(/.test(machoArm64Source) &&
       /\bz_aarch64_patch_branch26\s*\(/.test(machoArm64Source),

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -27,7 +27,7 @@ const fileBudgets = {
   "native/zero-c/src/buildability_internal.h": { maxLines: 40, maxStrcmpCalls: 0 },
   "native/zero-c/src/buildability_context.c": { maxLines: 185, maxStrcmpCalls: 1 },
   "native/zero-c/src/buildability_targets.c": { maxLines: 190, maxStrcmpCalls: 0 },
-  "native/zero-c/src/buildability_value_targets.c": { maxLines: 285, maxStrcmpCalls: 0 },
+  "native/zero-c/src/buildability_value_targets.c": { maxLines: 320, maxStrcmpCalls: 0 },
   "native/zero-c/src/call_resolve.c": { maxLines: 200, maxStrcmpCalls: 2 },
   "native/zero-c/src/call_resolve.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/coff_format.c": { maxLines: 370, maxStrcmpCalls: 0 },

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -50,6 +50,13 @@ function repeatBuildHash(args, firstPath, repeatOut, repeatPath = repeatOut) {
   return repeatReport;
 }
 
+function hasAarch64Instruction(bytes, expected) {
+  for (let offset = 0; offset + 4 <= bytes.length; offset++) {
+    if (bytes.readUInt32LE(offset) === expected) return true;
+  }
+  return false;
+}
+
 function assertMachOLoadCommand(bytes, expectedCommand, expectedSize) {
   const ncmds = bytes.readUInt32LE(16);
   for (let offset = 32, i = 0; i < ncmds; i++) {
@@ -1124,6 +1131,8 @@ assert.equal(directCoffArm64HelloReport.generatedCBytes, 0);
 assert.equal(directCoffArm64HelloReport.objectBackend.objectEmission.path, "direct-coff-aarch64-exe");
 assert.equal(directCoffArm64HelloReport.objectBackend.directFacts.runtimeHelperCount, 1);
 assert(directCoffArm64HelloBytes.includes(Buffer.from("hello from zero")));
+assert(hasAarch64Instruction(directCoffArm64HelloBytes, 0xf90017fe));
+assert(hasAarch64Instruction(directCoffArm64HelloBytes, 0xf94017fe));
 const directCoffU8ExePath = join(outDir, "direct-coff-u8-return");
 rmSync(`${directCoffU8ExePath}.exe`, { force: true });
 const directCoffU8ExeReport = json(["build", "--json", "--emit", "exe", "--target", "win32-x64.exe", "examples/direct-string-literal.0", "--out", directCoffU8ExePath]).body;
@@ -1185,6 +1194,20 @@ assert.equal(directArm64ObjReport.objectBackend.targetFacts.status, "native-exe"
 assert.equal(directArm64ObjBytes.readUInt16LE(16), 1);
 assert.equal(directArm64ObjBytes.readUInt16LE(18), 183);
 assert(directArm64ObjBytes.includes(Buffer.from([0x40, 0x05, 0x80, 0x52, 0xc0, 0x03, 0x5f, 0xd6])));
+const directArm64IndexStoreSource = join(outDir, "direct-arm64-index-store-scratch.0");
+const directArm64IndexStoreObjPath = join(outDir, "direct-arm64-index-store-scratch.o");
+writeFileSync(directArm64IndexStoreSource, `export c fn main u32
+  mut values [4]u32 [0, 0, 0, 0]
+  set values[% 5_u32 4_u32] 7_u32
+  ret values[1]
+`);
+rmSync(directArm64IndexStoreObjPath, { force: true });
+const directArm64IndexStoreObjReport = json(["build", "--json", "--emit", "obj", "--target", "linux-arm64", directArm64IndexStoreSource, "--out", directArm64IndexStoreObjPath]).body;
+const directArm64IndexStoreObjBytes = readFileSync(directArm64IndexStoreObjPath);
+assert.equal(directArm64IndexStoreObjReport.compiler, "zero-elf-aarch64");
+assert.equal(directArm64IndexStoreObjReport.generatedCBytes, 0);
+assert(hasAarch64Instruction(directArm64IndexStoreObjBytes, 0xb90003ea));
+assert(hasAarch64Instruction(directArm64IndexStoreObjBytes, 0xb94003ea));
 const directWhilePath = join(outDir, "direct-while-sum");
 rmSync(directWhilePath, { force: true });
 const directWhileReport = json(["build", "--json", "--emit", "exe", "--backend", "zero-elf64", "--target", "linux-musl-x64", "examples/direct-while-sum.0", "--out", directWhilePath]).body;

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -57,6 +57,19 @@ function hasAarch64Instruction(bytes, expected) {
   return false;
 }
 
+function hasAarch64VoidReturnEpilogue(bytes) {
+  for (let offset = 0; offset + 12 <= bytes.length; offset++) {
+    if (bytes.readUInt32LE(offset) !== 0x52800000) continue;
+    let cursor = offset + 4;
+    const maybeAddSp = bytes.readUInt32LE(cursor);
+    if (((maybeAddSp & 0xffc003ff) >>> 0) === 0x910003ff) cursor += 4;
+    if (cursor + 8 <= bytes.length &&
+        bytes.readUInt32LE(cursor) === 0xa8c17bfd &&
+        bytes.readUInt32LE(cursor + 4) === 0xd65f03c0) return true;
+  }
+  return false;
+}
+
 function assertMachOLoadCommand(bytes, expectedCommand, expectedSize) {
   const ncmds = bytes.readUInt32LE(16);
   for (let offset = 32, i = 0; i < ncmds; i++) {
@@ -1158,6 +1171,18 @@ assert.equal(directAarch64HelloReport.generatedCBytes, 0);
 assert.equal(directAarch64HelloReport.objectBackend.objectEmission.path, "direct-elf-aarch64-exe");
 assert.equal(directAarch64HelloReport.objectBackend.directFacts.runtimeHelperCount, 1);
 assert(directAarch64HelloBytes.includes(Buffer.from("hello from zero")));
+assert(hasAarch64VoidReturnEpilogue(directAarch64HelloBytes));
+const directAarch64VoidImplicitSource = join(outDir, "direct-aarch64-void-implicit.0");
+const directAarch64VoidImplicitPath = join(outDir, "direct-aarch64-void-implicit");
+writeFileSync(directAarch64VoidImplicitSource, `export c fn main Void
+  let ok Bool true
+`);
+rmSync(directAarch64VoidImplicitPath, { force: true });
+const directAarch64VoidImplicitReport = json(["build", "--json", "--emit", "exe", "--target", "linux-musl-arm64", directAarch64VoidImplicitSource, "--out", directAarch64VoidImplicitPath]).body;
+const directAarch64VoidImplicitBytes = readFileSync(directAarch64VoidImplicitPath);
+assert.equal(directAarch64VoidImplicitReport.compiler, "zero-elf-aarch64");
+assert.equal(directAarch64VoidImplicitReport.generatedCBytes, 0);
+assert(hasAarch64VoidReturnEpilogue(directAarch64VoidImplicitBytes));
 assert.equal(directAarch64ExeReport.objectBackend.targetFacts.status, "native-exe");
 assert.equal(directAarch64ExeBytes.readUInt16LE(16), 2);
 assert.equal(directAarch64ExeBytes.readUInt16LE(18), 183);

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -1092,6 +1092,38 @@ repeatBuildHash(["build", "--json", "--emit", "exe", "--backend", "zero-coff-x64
 assert.equal(directCoffExeBytes.toString("ascii", directCoffPeOffset, directCoffPeOffset + 4), "PE\u0000\u0000");
 assert.equal(directCoffExeBytes.readUInt16LE(directCoffPeOffset + 4), 0x8664);
 assert(directCoffExeBytes.includes(Buffer.from("KERNEL32.dll")));
+const directCoffArm64ExePath = join(outDir, "direct-coff-arm64-exe-return");
+rmSync(`${directCoffArm64ExePath}.exe`, { force: true });
+const directCoffArm64ExeReport = json(["build", "--json", "--emit", "exe", "--backend", "zero-coff-aarch64", "--target", "win32-arm64.exe", "examples/direct-exe-return.0", "--out", directCoffArm64ExePath]).body;
+const directCoffArm64ExeBytes = readFileSync(`${directCoffArm64ExePath}.exe`);
+const directCoffArm64PeOffset = directCoffArm64ExeBytes.readUInt32LE(0x3c);
+assert.equal(directCoffArm64ExeReport.emit, "exe");
+assert.equal(directCoffArm64ExeReport.compiler, "zero-coff-aarch64");
+assert.equal(directCoffArm64ExeReport.generatedCBytes, 0);
+assert.equal(directCoffArm64ExeReport.objectBackend.objectEmission.path, "direct-coff-aarch64-exe");
+assert.equal(directCoffArm64ExeReport.objectBackend.targetFacts.status, "native-exe");
+assertReleaseTargetContract(directCoffArm64ExeReport, {
+  target: "win32-arm64.exe",
+  emit: "exe",
+  objectFormat: "coff",
+  artifactKind: "native-executable",
+  linkerFlavor: "coff",
+  targetLibcMode: "sysroot",
+});
+assert.equal(directCoffArm64ExeReport.releaseTargetContract.sysroot.requiredByTarget, true);
+assert.equal(directCoffArm64ExeReport.releaseTargetContract.sysroot.status, "not-used-by-direct-artifact");
+assert.equal(directCoffArm64ExeBytes.toString("ascii", directCoffArm64PeOffset, directCoffArm64PeOffset + 4), "PE\u0000\u0000");
+assert.equal(directCoffArm64ExeBytes.readUInt16LE(directCoffArm64PeOffset + 4), 0xaa64);
+assert(directCoffArm64ExeBytes.includes(Buffer.from("KERNEL32.dll")));
+const directCoffArm64HelloPath = join(outDir, "direct-coff-arm64-hello");
+rmSync(`${directCoffArm64HelloPath}.exe`, { force: true });
+const directCoffArm64HelloReport = json(["build", "--json", "--emit", "exe", "--target", "win32-arm64.exe", "examples/hello.0", "--out", directCoffArm64HelloPath]).body;
+const directCoffArm64HelloBytes = readFileSync(`${directCoffArm64HelloPath}.exe`);
+assert.equal(directCoffArm64HelloReport.compiler, "zero-coff-aarch64");
+assert.equal(directCoffArm64HelloReport.generatedCBytes, 0);
+assert.equal(directCoffArm64HelloReport.objectBackend.objectEmission.path, "direct-coff-aarch64-exe");
+assert.equal(directCoffArm64HelloReport.objectBackend.directFacts.runtimeHelperCount, 1);
+assert(directCoffArm64HelloBytes.includes(Buffer.from("hello from zero")));
 const directCoffU8ExePath = join(outDir, "direct-coff-u8-return");
 rmSync(`${directCoffU8ExePath}.exe`, { force: true });
 const directCoffU8ExeReport = json(["build", "--json", "--emit", "exe", "--target", "win32-x64.exe", "examples/direct-string-literal.0", "--out", directCoffU8ExePath]).body;
@@ -1108,6 +1140,15 @@ assert.equal(directAarch64ExeReport.compiler, "zero-elf-aarch64");
 assert.equal(directAarch64ExeReport.generatedCBytes, 0);
 assert(directAarch64ExeReport.artifactBytes < 512);
 assert.equal(directAarch64ExeReport.objectBackend.objectEmission.path, "direct-elf-aarch64-exe");
+const directAarch64HelloPath = join(outDir, "direct-aarch64-hello");
+rmSync(directAarch64HelloPath, { force: true });
+const directAarch64HelloReport = json(["build", "--json", "--emit", "exe", "--target", "linux-musl-arm64", "examples/hello.0", "--out", directAarch64HelloPath]).body;
+const directAarch64HelloBytes = readFileSync(directAarch64HelloPath);
+assert.equal(directAarch64HelloReport.compiler, "zero-elf-aarch64");
+assert.equal(directAarch64HelloReport.generatedCBytes, 0);
+assert.equal(directAarch64HelloReport.objectBackend.objectEmission.path, "direct-elf-aarch64-exe");
+assert.equal(directAarch64HelloReport.objectBackend.directFacts.runtimeHelperCount, 1);
+assert(directAarch64HelloBytes.includes(Buffer.from("hello from zero")));
 assert.equal(directAarch64ExeReport.objectBackend.targetFacts.status, "native-exe");
 assert.equal(directAarch64ExeBytes.readUInt16LE(16), 2);
 assert.equal(directAarch64ExeBytes.readUInt16LE(18), 183);
@@ -1187,6 +1228,48 @@ assert.equal(directLinuxGnuObjBytes[0], 0x7f);
 assert.equal(directLinuxGnuObjBytes[1], 0x45);
 assert.equal(directLinuxGnuObjBytes.readUInt16LE(16), 1);
 assert.equal(directLinuxGnuObjBytes.readUInt16LE(18), 62);
+const directStringEqlTargets: Array<{ target: string; outName: string; compiler: string; emissionPath: string; magic: Buffer }> = [
+  { target: "linux-musl-x64", outName: "direct-string-eql-linux-musl.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-x64", outName: "direct-string-eql-linux-gnu.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-arm64", outName: "direct-string-eql-linux-arm64.o", compiler: "zero-elf-aarch64", emissionPath: "direct-elf-aarch64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-musl-arm64", outName: "direct-string-eql-linux-musl-arm64.o", compiler: "zero-elf-aarch64", emissionPath: "direct-elf-aarch64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "darwin-arm64", outName: "direct-string-eql-darwin-arm64.o", compiler: "zero-macho64", emissionPath: "direct-macho64-object", magic: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  { target: "darwin-x64", outName: "direct-string-eql-darwin-x64.o", compiler: "zero-macho-x64", emissionPath: "direct-macho-x64-object", magic: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  { target: "win32-x64.exe", outName: "direct-string-eql-win-x64.obj", compiler: "zero-coff-x64", emissionPath: "direct-coff-x64-object", magic: Buffer.from([0x64, 0x86]) },
+  { target: "win32-arm64.exe", outName: "direct-string-eql-win-arm64.obj", compiler: "zero-coff-aarch64", emissionPath: "direct-coff-aarch64-object", magic: Buffer.from([0x64, 0xaa]) },
+];
+for (const { target, outName, compiler, emissionPath, magic } of directStringEqlTargets) {
+  const directStringEqlPath = join(outDir, outName);
+  rmSync(directStringEqlPath, { force: true });
+  const directStringEqlReport = json(["build", "--json", "--emit", "obj", "--target", target, "examples/direct-string-eql.0", "--out", directStringEqlPath]).body;
+  const directStringEqlBytes = readFileSync(directStringEqlPath);
+  assert.equal(directStringEqlReport.compiler, compiler);
+  assert.equal(directStringEqlReport.generatedCBytes, 0);
+  assert.equal(directStringEqlReport.objectBackend.objectEmission.path, emissionPath);
+  assert(directStringEqlBytes.subarray(0, magic.length).equals(magic));
+  assert(directStringEqlBytes.includes(Buffer.from("token")));
+}
+const directByteCopyFillTargets: Array<{ target: string; outName: string; compiler: string; emissionPath: string; magic: Buffer }> = [
+  { target: "linux-musl-x64", outName: "direct-byte-copy-fill-linux-musl.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-x64", outName: "direct-byte-copy-fill-linux-gnu.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-arm64", outName: "direct-byte-copy-fill-linux-arm64.o", compiler: "zero-elf-aarch64", emissionPath: "direct-elf-aarch64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "linux-musl-arm64", outName: "direct-byte-copy-fill-linux-musl-arm64.o", compiler: "zero-elf-aarch64", emissionPath: "direct-elf-aarch64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "darwin-arm64", outName: "direct-byte-copy-fill-darwin-arm64.o", compiler: "zero-macho64", emissionPath: "direct-macho64-object", magic: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  { target: "darwin-x64", outName: "direct-byte-copy-fill-darwin-x64.o", compiler: "zero-macho-x64", emissionPath: "direct-macho-x64-object", magic: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  { target: "win32-x64.exe", outName: "direct-byte-copy-fill-win-x64.obj", compiler: "zero-coff-x64", emissionPath: "direct-coff-x64-object", magic: Buffer.from([0x64, 0x86]) },
+  { target: "win32-arm64.exe", outName: "direct-byte-copy-fill-win-arm64.obj", compiler: "zero-coff-aarch64", emissionPath: "direct-coff-aarch64-object", magic: Buffer.from([0x64, 0xaa]) },
+];
+for (const { target, outName, compiler, emissionPath, magic } of directByteCopyFillTargets) {
+  const directByteCopyFillPath = join(outDir, outName);
+  rmSync(directByteCopyFillPath, { force: true });
+  const directByteCopyFillReport = json(["build", "--json", "--emit", "obj", "--target", target, "examples/direct-byte-copy-fill.0", "--out", directByteCopyFillPath]).body;
+  const directByteCopyFillBytes = readFileSync(directByteCopyFillPath);
+  assert.equal(directByteCopyFillReport.compiler, compiler);
+  assert.equal(directByteCopyFillReport.generatedCBytes, 0);
+  assert.equal(directByteCopyFillReport.objectBackend.objectEmission.path, emissionPath);
+  assert(directByteCopyFillBytes.subarray(0, magic.length).equals(magic));
+  assert(directByteCopyFillBytes.includes(Buffer.from("token")));
+}
 const directMachOPath = join(outDir, "direct-darwin-arm64.o");
 rmSync(directMachOPath, { force: true });
 const directMachOReport = json(["build", "--json", "--emit", "obj", "--target", "darwin-arm64", "examples/direct-call-add.0", "--out", directMachOPath]).body;
@@ -1324,6 +1407,27 @@ for (let i = 0; i < directCoffDataRelocCount; i++) {
   sawCoffAddr64Reloc ||= directCoffDataBytes.readUInt16LE(directCoffDataRelocOffset + i * 10 + 8) === 1;
 }
 assert.equal(sawCoffAddr64Reloc, true);
+const directCoffArm64DataPath = join(outDir, "direct-win-arm64-data.obj");
+rmSync(directCoffArm64DataPath, { force: true });
+const directCoffArm64DataReport = json(["build", "--json", "--emit", "obj", "--target", "win32-arm64.exe", "examples/direct-byte-view-reloc.0", "--out", directCoffArm64DataPath]).body;
+const directCoffArm64DataBytes = readFileSync(directCoffArm64DataPath);
+assert.equal(directCoffArm64DataReport.compiler, "zero-coff-aarch64");
+assert.equal(directCoffArm64DataReport.objectBackend.objectEmission.path, "direct-coff-aarch64-object");
+assert.equal(directCoffArm64DataReport.objectBackend.objectEmission.dataSections, true);
+assert.equal(directCoffArm64DataReport.objectBackend.directFacts.readonlyDataBytes, 6);
+assert.equal(directCoffArm64DataBytes.readUInt16LE(0), 0xaa64);
+assert.equal(directCoffArm64DataBytes.readUInt16LE(2), 2);
+assert(directCoffArm64DataBytes.includes(Buffer.from(".rdata\0")));
+assert(directCoffArm64DataBytes.includes(Buffer.from("token")));
+const directCoffArm64DataRelocOffset = directCoffArm64DataBytes.readUInt32LE(20 + 24);
+const directCoffArm64DataRelocCount = directCoffArm64DataBytes.readUInt16LE(20 + 32);
+assert(directCoffArm64DataRelocOffset > 0);
+assert(directCoffArm64DataRelocCount > 0);
+let sawCoffArm64Addr64Reloc = false;
+for (let i = 0; i < directCoffArm64DataRelocCount; i++) {
+  sawCoffArm64Addr64Reloc ||= directCoffArm64DataBytes.readUInt16LE(directCoffArm64DataRelocOffset + i * 10 + 8) === 0x000e;
+}
+assert.equal(sawCoffArm64Addr64Reloc, true);
 const directCoffWorldPath = join(outDir, "direct-win-x64-world.obj");
 rmSync(directCoffWorldPath, { force: true });
 const directCoffWorldReport = json(["build", "--json", "--emit", "obj", "--target", "win32-x64.exe", "examples/hello.0", "--out", directCoffWorldPath]).body;
@@ -1541,17 +1645,26 @@ assertMachOObjectBuildabilityBlocked(
   "macho-open-byte-slice.o",
   /byte-view length/,
 );
-const machOObjectBlockedReadiness = json(["check", "--json", "--emit", "obj", "--target", "darwin-arm64", "examples/memory-package"]).body;
-assert.equal(machOObjectBlockedReadiness.ok, true);
-assert.equal(machOObjectBlockedReadiness.diagnostics.length, 0);
-assert.equal(machOObjectBlockedReadiness.targetReadiness.ok, false);
-assert.equal(machOObjectBlockedReadiness.targetReadiness.buildable, false);
-assert.equal(machOObjectBlockedReadiness.targetReadiness.languageOk, true);
-assert.equal(machOObjectBlockedReadiness.targetReadiness.emit, "obj");
-assert.equal(machOObjectBlockedReadiness.targetReadiness.target, "darwin-arm64");
-assert.equal(machOObjectBlockedReadiness.targetReadiness.diagnostics[0].code, "BLD004");
-assert.equal(machOObjectBlockedReadiness.targetReadiness.diagnostics[0].backendBlocker.backend, "zero-macho64");
-assert.equal(machOObjectBlockedReadiness.targetReadiness.diagnostics[0].backendBlocker.stage, "buildability");
+const machOMemoryPackageReadiness = json(["check", "--json", "--emit", "obj", "--target", "darwin-arm64", "examples/memory-package"]).body;
+assert.equal(machOMemoryPackageReadiness.ok, true);
+assert.equal(machOMemoryPackageReadiness.diagnostics.length, 0);
+assert.equal(machOMemoryPackageReadiness.targetReadiness.ok, true);
+assert.equal(machOMemoryPackageReadiness.targetReadiness.buildable, true);
+assert.equal(machOMemoryPackageReadiness.targetReadiness.languageOk, true);
+assert.equal(machOMemoryPackageReadiness.targetReadiness.emit, "obj");
+assert.equal(machOMemoryPackageReadiness.targetReadiness.target, "darwin-arm64");
+assert.equal(machOMemoryPackageReadiness.targetReadiness.backend, "zero-macho64");
+const machOMemoryPackagePath = join(outDir, "direct-darwin-arm64-memory-package.o");
+rmSync(machOMemoryPackagePath, { force: true });
+const machOMemoryPackageReport = json(["build", "--json", "--emit", "obj", "--target", "darwin-arm64", "examples/memory-package", "--out", machOMemoryPackagePath]).body;
+const machOMemoryPackageBytes = readFileSync(machOMemoryPackagePath);
+assert.equal(machOMemoryPackageReport.compiler, "zero-macho64");
+assert.equal(machOMemoryPackageReport.generatedCBytes, 0);
+assert.equal(machOMemoryPackageReport.objectBackend.objectEmission.path, "direct-macho64-object");
+assert.equal(machOMemoryPackageReport.objectBackend.directFacts.moduleCount, 3);
+assert.equal(machOMemoryPackageReport.objectBackend.directFacts.runtimeHelperCount, 1);
+assert.equal(machOMemoryPackageBytes.readUInt32LE(0), 0xfeedfacf);
+assert(machOMemoryPackageBytes.includes(Buffer.from("memory package ok")));
 
 const diagnostics = [
   ["PAR100", ["check", "--json", "conformance/check/fail/parse-missing-brace.0"]],
@@ -1702,7 +1815,9 @@ assert.equal(generatedCBytesAfterReadOnlyCommands, generatedCBytesBeforeReadOnly
 const targets = json(["targets"]).body;
 assert.equal(targets.schemaVersion, 1);
 assert.equal(typeof targets.host, "string");
-for (const targetName of ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-x64", "linux-musl-arm64", "linux-musl-x64", "win32-arm64.exe", "win32-x64.exe"]) {
+const publicTargetNames = ["darwin-arm64", "darwin-x64", "linux-arm64", "linux-musl-arm64", "linux-musl-x64", "linux-x64", "win32-arm64.exe", "win32-x64.exe"];
+assert.deepEqual([...targets.targets.map((target) => target.name)].sort(), [...publicTargetNames].sort());
+for (const targetName of publicTargetNames) {
   assert(targets.targets.some((target) => target.name === targetName), `${targetName} should be listed`);
 }
 assert(targets.targets.some((target) => target.hosted === true && target.capabilities.includes("fs")));
@@ -1712,6 +1827,7 @@ const linuxMuslTarget = targets.targets.find((target) => target.name === "linux-
 const darwinArm64Target = targets.targets.find((target) => target.name === "darwin-arm64");
 const darwinX64Target = targets.targets.find((target) => target.name === "darwin-x64");
 const winX64Target = targets.targets.find((target) => target.name === "win32-x64.exe");
+const winArm64Target = targets.targets.find((target) => target.name === "win32-arm64.exe");
 const linuxArm64Target = targets.targets.find((target) => target.name === "linux-arm64");
 assert.equal(linuxMuslTarget.directBackend.exeSupported, true);
 assert.equal(linuxMuslTarget.directBackend.exeEmitter, "zero-elf64-exe");
@@ -1728,6 +1844,10 @@ assert.equal(winX64Target.directBackend.objectEmitter, "zero-coff-x64");
 assert.equal(winX64Target.directBackend.objectSupported, true);
 assert.equal(winX64Target.directBackend.exeSupported, true);
 assert.equal(winX64Target.directBackend.exeEmitter, "zero-coff-x64-exe");
+assert.equal(winArm64Target.directBackend.status, "native-exe");
+assert.equal(winArm64Target.directBackend.objectEmitter, "zero-coff-aarch64");
+assert.equal(winArm64Target.directBackend.exeEmitter, "zero-coff-aarch64-exe");
+assert.match(winArm64Target.directBackend.reason, /direct object and executable backend available/);
 assert.equal(linuxArm64Target.directBackend.status, "native-exe");
 assert.equal(linuxArm64Target.directBackend.objectEmitter, "zero-elf-aarch64");
 assert.equal(linuxArm64Target.directBackend.exeEmitter, "zero-elf-aarch64-exe");

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -1272,6 +1272,30 @@ for (const { target, outName, compiler, emissionPath, magic } of directStringEql
   assert(directStringEqlBytes.subarray(0, magic.length).equals(magic));
   assert(directStringEqlBytes.includes(Buffer.from("token")));
 }
+const directArm64DynamicStringEqlSource = join(outDir, "direct-arm64-dynamic-string-eql.0");
+writeFileSync(directArm64DynamicStringEqlSource, `export c fn main u8
+  let text String "token"
+  let start usize 0
+  let end usize 5
+  if std.mem.eqlBytes text[(% start 1_usize)..end] "token"[(% start 1_usize)..end]
+    ret 1_u8
+  ret 0_u8
+`);
+for (const { target, outName, compiler, emissionPath, magic } of [
+  { target: "linux-arm64", outName: "direct-dynamic-string-eql-linux-arm64.o", compiler: "zero-elf-aarch64", emissionPath: "direct-elf-aarch64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
+  { target: "darwin-arm64", outName: "direct-dynamic-string-eql-darwin-arm64.o", compiler: "zero-macho64", emissionPath: "direct-macho64-object", magic: Buffer.from([0xcf, 0xfa, 0xed, 0xfe]) },
+  { target: "win32-arm64.exe", outName: "direct-dynamic-string-eql-win-arm64.obj", compiler: "zero-coff-aarch64", emissionPath: "direct-coff-aarch64-object", magic: Buffer.from([0x64, 0xaa]) },
+]) {
+  const directArm64DynamicStringEqlPath = join(outDir, outName);
+  rmSync(directArm64DynamicStringEqlPath, { force: true });
+  const directArm64DynamicStringEqlReport = json(["build", "--json", "--emit", "obj", "--target", target, directArm64DynamicStringEqlSource, "--out", directArm64DynamicStringEqlPath]).body;
+  const directArm64DynamicStringEqlBytes = readFileSync(directArm64DynamicStringEqlPath);
+  assert.equal(directArm64DynamicStringEqlReport.compiler, compiler);
+  assert.equal(directArm64DynamicStringEqlReport.generatedCBytes, 0);
+  assert.equal(directArm64DynamicStringEqlReport.objectBackend.objectEmission.path, emissionPath);
+  assert(directArm64DynamicStringEqlBytes.subarray(0, magic.length).equals(magic));
+  assert(hasAarch64Instruction(directArm64DynamicStringEqlBytes, 0xb94003ea));
+}
 const directByteCopyFillTargets: Array<{ target: string; outName: string; compiler: string; emissionPath: string; magic: Buffer }> = [
   { target: "linux-musl-x64", outName: "direct-byte-copy-fill-linux-musl.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },
   { target: "linux-x64", outName: "direct-byte-copy-fill-linux-gnu.o", compiler: "zero-elf64", emissionPath: "direct-elf64-object", magic: Buffer.from([0x7f, 0x45, 0x4c, 0x46]) },


### PR DESCRIPTION
- Add shared AArch64 direct emission for ELF and COFF
- Support byte memory helpers across direct backends
- Guard target drift with docs, contracts, and metrics