### PR TITLE
feat(benchmarks): add agent-oriented math and transform benchmark cases

### DIFF
--- a/benchmarks/agent/gcd.0
+++ b/benchmarks/agent/gcd.0
@@ -1,0 +1,14 @@
+fn gcd u32 a u32 b u32
+  mut x u32 a
+  mut y u32 b
+  while != y 0
+    let temp y
+    set y % x y
+    set x temp
+  ret x
+
+pub fn main Void world World !
+  if && (&& (== (gcd 12 8) 4) (== (gcd 1071 462) 21)) (== (gcd 17 5) 1)
+    check world.out.write "gcd ok\n"
+  else
+    check world.out.write "gcd fail\n"

--- a/benchmarks/agent/stats.0
+++ b/benchmarks/agent/stats.0
@@ -1,0 +1,17 @@
+pub fn main Void world World !
+  let data [5]i32 [3, 1, 7, 0, 12]
+  mut min i32 data[0]
+  mut max i32 data[0]
+  mut sum i32 0
+  mut i usize 0
+  while < i 5
+    set sum + sum data[i]
+    if < data[i] min
+      set min data[i]
+    if > data[i] max
+      set max data[i]
+    set i + i 1
+  if && (&& (== min 0) (== max 12)) (== sum 23)
+    check world.out.write "stats ok\n"
+  else
+    check world.out.write "stats fail\n"

--- a/benchmarks/agent/token-count.0
+++ b/benchmarks/agent/token-count.0
@@ -1,0 +1,16 @@
+fn tokenCount u32 text Span<u8> delim u8
+  mut count u32 1
+  mut i usize 0
+  while < i (std.mem.len text)
+    if == text[i] delim
+      set count + count 1
+    set i + i 1
+  ret count
+
+pub fn main Void world World !
+  let text Span<u8> std.mem.span "zero lang agent test"
+  let count tokenCount text 32_u8
+  if == count 4
+    check world.out.write "token count ok\n"
+  else
+    check world.out.write "token count fail\n"

--- a/docs/articles/benchmarks.md
+++ b/docs/articles/benchmarks.md
@@ -39,8 +39,17 @@ The current cases include:
 - `fs-resource`, `mem-copy-fill`, `zero-hash`: focused Zero cases for file-resource metadata, memory helpers, and deterministic byte payload processing
 
 The Zero sources for these cases live under `benchmarks/zero`.
+Agent-oriented math and transform benchmarks live under `benchmarks/agent`.
 Host targets that do not support a direct executable runner for a case report it
 as `skipped` with a reason instead of failing the whole benchmark run.
+
+## Agent-Oriented Cases
+
+The `benchmarks/agent` cases exercise patterns common in code agents generate or repair:
+
+- `gcd`: Euclidean GCD with integer loop and branch behavior.
+- `stats`: Min, max, and sum over a fixed-size array.
+- `token-count`: Delimiter token scan over a byte span.
 
 ## Metrics
 

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -46,6 +46,9 @@ const cases = [
   { name: "zero-hash", expectedStdout: "zero-hash ok", languages: ["zero"] },
   { name: "json", expectedStdout: "json", languages: ["zero"] },
   { name: "networking", expectedStdout: "networking", languages: ["zero"], skipLanguages: ["zero"] },
+  { name: "gcd", expectedStdout: "gcd ok", languages: ["zero"], sources: { zero: "benchmarks/agent/gcd.0" } },
+  { name: "stats", expectedStdout: "stats ok", languages: ["zero"], sources: { zero: "benchmarks/agent/stats.0" } },
+  { name: "token-count", expectedStdout: "token count ok", languages: ["zero"], sources: { zero: "benchmarks/agent/token-count.0" } },
 ];
 
 const languages = [


### PR DESCRIPTION
## Summary

Adds three small agent-oriented benchmark cases under enchmarks/agent/ exercising patterns that code agents commonly generate or repair.

Closes #8

### Cases

- **gcd**: Euclidean GCD with integer loop and branch behavior.
- **stats**: Min, max, and sum over a fixed-size array.
- **token-count**: Delimiter token scan over a byte span.

### Changes

| File | Description |
|------|-------------|
| enchmarks/agent/gcd.0 | GCD benchmark source |
| enchmarks/agent/stats.0 | Stats benchmark source |
| enchmarks/agent/token-count.0 | Token count benchmark source |
| scripts/bench.mts | Registered new cases in benchmark harness |
| docs/articles/benchmarks.md | Documented agent-oriented cases |

### Verification

All three source files pass zero check on v0.1.4. Direct executable builds are blocked on Windows by the win32-x64 COFF backend limitation (BLD004), which existing benchmarks also hit. Recommended to verify full runtime correctness with pnpm run bench on a host with a complete direct backend.