### PR TITLE
Add manifest graph artifact entrypoints

### DIFF
--- a/docs/articles/cli-reference.md
+++ b/docs/articles/cli-reference.md
@@ -108,6 +108,10 @@ linking facts such as retained runtime objects, provider libraries, and
 `zero ship --json` nests the same contract under
 `releasePreview.targetContract`.
 
+Graph artifact commands (`validate`, `view`, `check`, `size`, `build`, `run`,
+`test`, and `patch`) also accept a package directory or `zero.json` when
+`targets.cli.graph` points at a saved ProgramGraph artifact.
+
 ## ProgramGraph Patches
 
 `zero graph patch` applies checked edits to a saved ProgramGraph artifact and
@@ -205,9 +209,9 @@ zero ship [--json] [--target <target>] [--profile release-small|tiny|audit] [--o
 zero test [--json] [--filter <name>] [--target <target>] [--cc <path>] [--out <file>] <input>
 zero fmt [--check] <input>
 zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] [--out <file>] <input> [patch-file]
-zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact>
-zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact> [-- args...]
-zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact>
+zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package>
+zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package> [-- args...]
+zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>
 zero doc [--json] [--target <target>] <input>
 zero size [--json] [--target <target>] [--out <artifact>] <input>
 zero explain [--json] <diagnostic-code>

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -768,6 +768,7 @@ typedef struct {
   char *package_name;
   char *package_version;
   char *main_path;
+  char *graph_path;
   char *kind;
   ZManifestDependency *dependencies;
   ZManifestCLib *c_libs;
@@ -883,6 +884,8 @@ bool z_map_source_diag(const SourceInput *input, ZDiag *diag);
 void z_free_source(SourceInput *input);
 bool z_parse_manifest_json(const char *manifest, ZManifest *out, ZDiag *diag);
 bool z_resolve_package_metadata(const char *manifest_path, const char *manifest, const ZManifest *parsed_manifest, SourceInput *out, ZDiag *diag);
+char *z_manifest_path_for_input(const char *input_path);
+bool z_resolve_manifest_graph_artifact_path(const char *input_path, char **out_artifact_path, bool *handled, ZDiag *diag);
 void z_free_manifest(ZManifest *manifest);
 char *z_default_out_path(const char *source_file);
 ZToolchainPlan z_plan_toolchain(const char *cc, const char *profile, const ZTargetInfo *target);

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -583,10 +583,12 @@ bool z_parse_manifest_json(const char *manifest, ZManifest *out, ZDiag *diag) {
   const char *package_name_path[] = {"package", "name"};
   const char *package_version_path[] = {"package", "version"};
   const char *main_path[] = {"targets", "cli", "main"};
+  const char *graph_path[] = {"targets", "cli", "graph"};
   const char *kind_path[] = {"targets", "cli", "kind"};
   out->package_name = json_get_string_path(manifest, package_name_path, 2);
   out->package_version = json_get_string_path(manifest, package_version_path, 2);
   out->main_path = json_get_string_path(manifest, main_path, 3);
+  out->graph_path = json_get_string_path(manifest, graph_path, 3);
   out->kind = json_get_string_path(manifest, kind_path, 3);
 
   const char *dependencies_path[] = {"dependencies"};
@@ -665,6 +667,7 @@ void z_free_manifest(ZManifest *manifest) {
   free(manifest->package_name);
   free(manifest->package_version);
   free(manifest->main_path);
+  free(manifest->graph_path);
   free(manifest->kind);
   for (size_t i = 0; i < manifest->dependency_count; i++) {
     free(manifest->dependencies[i].name);
@@ -684,6 +687,95 @@ void z_free_manifest(ZManifest *manifest) {
   free(manifest->dependencies);
   free(manifest->c_libs);
   memset(manifest, 0, sizeof(*manifest));
+}
+
+char *z_manifest_path_for_input(const char *input_path) {
+  if (!input_path || !input_path[0]) return NULL;
+  if (strcmp(input_path, "zero.json") == 0 || ends_with(input_path, "/zero.json")) return z_strdup(input_path);
+  char *manifest_path = join_path(input_path, "zero.json");
+  if (file_exists(manifest_path)) return manifest_path;
+  free(manifest_path);
+  return NULL;
+}
+
+static char *manifest_relative_path(const char *manifest_path, const char *relative_path) {
+  if (!relative_path || !relative_path[0]) return NULL;
+  if (relative_path[0] == '/') return normalize_path_text(relative_path);
+  char *root = dirname_of(manifest_path);
+  char *joined = join_path(root, relative_path);
+  char *normalized = normalize_path_text(joined);
+  free(joined);
+  free(root);
+  return normalized;
+}
+
+static void set_manifest_graph_diag(ZDiag *diag, const char *manifest_path, const char *message, const char *expected, const char *actual, const char *help) {
+  if (!diag) return;
+  diag->code = 2002;
+  diag->path = z_strdup(manifest_path ? manifest_path : "");
+  diag->line = 1;
+  diag->column = 1;
+  diag->length = 1;
+  snprintf(diag->message, sizeof(diag->message), "%s", message ? message : "invalid graph target");
+  snprintf(diag->expected, sizeof(diag->expected), "%s", expected ? expected : "targets.cli.graph pointing at a ProgramGraph artifact");
+  snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "invalid targets.cli.graph");
+  snprintf(diag->help, sizeof(diag->help), "%s", help ? help : "set targets.cli.graph to a saved ProgramGraph artifact");
+}
+
+bool z_resolve_manifest_graph_artifact_path(const char *input_path, char **out_artifact_path, bool *handled, ZDiag *diag) {
+  if (out_artifact_path) *out_artifact_path = NULL;
+  if (handled) *handled = false;
+  char *manifest_path = z_manifest_path_for_input(input_path);
+  if (!manifest_path) return true;
+  if (handled) *handled = true;
+
+  char *manifest = z_read_file(manifest_path, diag);
+  if (!manifest) {
+    if (diag) diag->path = z_strdup(manifest_path);
+    free(manifest_path);
+    return false;
+  }
+
+  ZManifest parsed_manifest = {0};
+  if (!z_parse_manifest_json(manifest, &parsed_manifest, diag)) {
+    if (diag && !diag->path) diag->path = z_strdup(manifest_path);
+    free(manifest);
+    free(manifest_path);
+    return false;
+  }
+
+  bool ok = true;
+  char *artifact_path = NULL;
+  if (!parsed_manifest.graph_path || !parsed_manifest.graph_path[0]) {
+    set_manifest_graph_diag(diag,
+                            manifest_path,
+                            "zero.json is missing targets.cli.graph",
+                            "targets.cli.graph pointing at a saved ProgramGraph artifact",
+                            "missing targets.cli.graph",
+                            "run zero graph import --out <artifact> <source>, then set targets.cli.graph");
+    ok = false;
+  } else {
+    artifact_path = manifest_relative_path(manifest_path, parsed_manifest.graph_path);
+    if (!artifact_path || !file_exists(artifact_path)) {
+      set_manifest_graph_diag(diag,
+                              manifest_path,
+                              "target graph artifact does not exist",
+                              artifact_path ? artifact_path : parsed_manifest.graph_path,
+                              "missing ProgramGraph artifact",
+                              "create the artifact or update targets.cli.graph");
+      ok = false;
+    }
+  }
+
+  if (ok && out_artifact_path) {
+    *out_artifact_path = artifact_path;
+    artifact_path = NULL;
+  }
+  free(artifact_path);
+  z_free_manifest(&parsed_manifest);
+  free(manifest);
+  free(manifest_path);
+  return ok;
 }
 
 static char *dependency_manifest_path(const char *current_manifest_path, const char *dependency_path) {

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -4249,17 +4249,9 @@ static bool resolve_direct_row_source(const char *path, SourceInput *input, ZDia
   return ok;
 }
 
-static char *direct_manifest_path_for_input(const char *input_path) {
-  if (strcmp(input_path, "zero.json") == 0 || has_suffix(input_path, "/zero.json")) return z_strdup(input_path);
-  char *manifest_path = direct_join_path(input_path, "zero.json");
-  if (direct_file_exists(manifest_path)) return manifest_path;
-  free(manifest_path);
-  return NULL;
-}
-
 static bool resolve_direct_row_package_source(const char *input_path, SourceInput *input, ZDiag *diag, bool *handled) {
   *handled = false;
-  char *manifest_path = direct_manifest_path_for_input(input_path);
+  char *manifest_path = z_manifest_path_for_input(input_path);
   if (!manifest_path) return false;
   *handled = true;
 
@@ -10098,10 +10090,19 @@ static int run_graph_artifact_roundtrip_command(const Command *command, ZDiag *d
 
 static bool graph_roundtrip_input_is_artifact(const Command *command) {
   if (!command || !command->input || is_row_source_path(command->input)) return false;
-  char *manifest_path = direct_manifest_path_for_input(command->input);
+  char *manifest_path = z_manifest_path_for_input(command->input);
   bool package_input = manifest_path != NULL;
   free(manifest_path);
   return !package_input;
+}
+
+static bool resolve_graph_command_manifest_input(Command *command, ZDiag *diag) {
+  if (!command || !command->command || !command->input || strcmp(command->command, "graph") != 0 || !z_program_graph_command_kind_uses_artifact_input(command->kind)) return true;
+  char *artifact_path = NULL;
+  bool handled = false;
+  if (!z_resolve_manifest_graph_artifact_path(command->input, &artifact_path, &handled, diag)) return false;
+  if (handled) command->input = artifact_path;
+  return true;
 }
 
 static void graph_roundtrip_replace_path(char **slot, const char *old_path, const char *new_path) {
@@ -10527,6 +10528,12 @@ int main(int argc, char **argv) {
     snprintf(diag.help, sizeof(diag.help), "rerun with --plan to inspect repairs, --patch to preview edits, or --apply for behavior-preserving edits");
     if (command.json) print_diag_json(command.input, &diag);
     else print_diag(command.input, &diag);
+    return 1;
+  }
+
+  if (!resolve_graph_command_manifest_input(&command, &diag)) {
+    if (command.json) print_diag_json(diag.path ? diag.path : command.input, &diag);
+    else print_diag(diag.path ? diag.path : command.input, &diag);
     return 1;
   }
 

--- a/native/zero-c/src/program_graph_build.c
+++ b/native/zero-c/src/program_graph_build.c
@@ -6,12 +6,21 @@
 
 #include <string.h>
 
-bool z_program_graph_command_kind_is_known(const char *kind) {
-  static const char *kinds[] = {"dump", "import", "inspect", "validate", "view", "check", "size", "build", "run", "test", "patch", "roundtrip"};
-  for (size_t i = 0; kind && i < sizeof(kinds) / sizeof(kinds[0]); i++) {
+static bool graph_kind_in_list(const char *kind, const char *const *kinds, size_t count) {
+  for (size_t i = 0; kind && i < count; i++) {
     if (strcmp(kind, kinds[i]) == 0) return true;
   }
   return false;
+}
+
+bool z_program_graph_command_kind_is_known(const char *kind) {
+  static const char *const kinds[] = {"dump", "import", "inspect", "validate", "view", "check", "size", "build", "run", "test", "patch", "roundtrip"};
+  return graph_kind_in_list(kind, kinds, sizeof(kinds) / sizeof(kinds[0]));
+}
+
+bool z_program_graph_command_kind_uses_artifact_input(const char *kind) {
+  static const char *const kinds[] = {"validate", "view", "check", "size", "build", "run", "test", "patch"};
+  return graph_kind_in_list(kind, kinds, sizeof(kinds) / sizeof(kinds[0]));
 }
 
 bool z_program_graph_artifact_source_present(const ZProgramGraphArtifactSource *source) {

--- a/native/zero-c/src/program_graph_build.h
+++ b/native/zero-c/src/program_graph_build.h
@@ -11,6 +11,7 @@ typedef struct {
 } ZProgramGraphArtifactSource;
 
 bool z_program_graph_command_kind_is_known(const char *kind);
+bool z_program_graph_command_kind_uses_artifact_input(const char *kind);
 bool z_program_graph_artifact_source_present(const ZProgramGraphArtifactSource *source);
 bool z_program_graph_prepare_artifact_input(const char *artifact_path, const ZTargetInfo *target, Program *program, SourceInput *input, ZProgramGraphArtifactSource *source, ZDiag *diag);
 

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -15,10 +15,10 @@ type CScanState = {
 };
 
 const fileBudgets = {
-  "native/zero-c/include/zero.h": { maxLines: 980, maxStrcmpCalls: 0 },
+  "native/zero-c/include/zero.h": { maxLines: 981, maxStrcmpCalls: 0 },
   "native/zero-c/include/zero_runtime.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/checker.c": { maxLines: 9846, maxStrcmpCalls: 279 },
-  "native/zero-c/src/main.c": { maxLines: 11109, maxStrcmpCalls: 462 },
+  "native/zero-c/src/main.c": { maxLines: 11116, maxStrcmpCalls: 462 },
   "native/zero-c/src/ir.c": { maxLines: 3750, maxStrcmpCalls: 226 },
   "native/zero-c/src/row_syntax.c": { maxLines: 2150, maxStrcmpCalls: 11 },
   "native/zero-c/src/ast.c": { maxLines: 250, maxStrcmpCalls: 0 },
@@ -54,12 +54,12 @@ const fileBudgets = {
   "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 330, maxStrcmpCalls: 1 },
   "native/zero-c/src/emit_coff.c": { maxLines: 1195, maxStrcmpCalls: 1 },
   "native/zero-c/src/emit_coff_aarch64.c": { maxLines: 380, maxStrcmpCalls: 0 },
-  "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 32 },
+  "native/zero-c/src/fs.c": { maxLines: 1250, maxStrcmpCalls: 33 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1300, maxStrcmpCalls: 0 },
   "native/zero-c/src/mir_verify.h": { maxLines: 50, maxStrcmpCalls: 0 },
   "native/zero-c/src/program_graph.c": { maxLines: 117, maxStrcmpCalls: 4 },
-  "native/zero-c/src/program_graph_build.c": { maxLines: 50, maxStrcmpCalls: 8 },
-  "native/zero-c/src/program_graph_build.h": { maxLines: 17, maxStrcmpCalls: 0 },
+  "native/zero-c/src/program_graph_build.c": { maxLines: 55, maxStrcmpCalls: 8 },
+  "native/zero-c/src/program_graph_build.h": { maxLines: 18, maxStrcmpCalls: 0 },
   "native/zero-c/src/program_graph_compare.c": { maxLines: 445, maxStrcmpCalls: 1 },
   "native/zero-c/src/program_graph_compare.h": { maxLines: 25, maxStrcmpCalls: 0 },
   "native/zero-c/src/program_graph_format.c": { maxLines: 707, maxStrcmpCalls: 1 },

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -339,6 +339,10 @@ const graphArgsDumpPath = join(outDir, "std-args.program-graph");
 const graphArgsRunPath = join(outDir, "std-args.program-graph-run");
 const graphTestDumpPath = join(outDir, "test-blocks.program-graph");
 const graphPackageTestDumpPath = join(outDir, "test-app.program-graph");
+const graphManifestPackageDir = join(outDir, "graph-manifest-package");
+const graphManifestArtifactPath = join(graphManifestPackageDir, "artifacts", "test-app.program-graph");
+const graphManifestBuildPath = join(outDir, "graph-manifest-package-build");
+const graphManifestRunPath = join(outDir, "graph-manifest-package-run");
 const graphSizeNoisePatchPath = join(outDir, "hello.program-graph.size-noise.patch");
 const graphSizeNoisePath = join(outDir, "hello.program-graph.size-noise.program-graph");
 const graphRoundtripViewPath = join(outDir, "hello.roundtrip.0");
@@ -411,6 +415,9 @@ rmSync(graphArgsDumpPath, { force: true });
 rmSync(graphArgsRunPath, { force: true });
 rmSync(graphTestDumpPath, { force: true });
 rmSync(graphPackageTestDumpPath, { force: true });
+rmSync(graphManifestPackageDir, { force: true, recursive: true });
+rmSync(graphManifestBuildPath, { force: true });
+rmSync(graphManifestRunPath, { force: true });
 rmSync(graphSizeNoisePatchPath, { force: true });
 rmSync(graphSizeNoisePath, { force: true });
 rmSync(graphRoundtripViewPath, { force: true });
@@ -645,6 +652,34 @@ assert.equal(graphPackageExpectedFail.location.sourceFile, "conformance/packages
 assert.equal(graphPackageExpectedFail.location.line, 7);
 assert.equal(graphPackageExpectedFail.failure.sourceFile, "conformance/packages/test-app/src/helper.0");
 assert.equal(graphPackageExpectedFail.failure.line, 8);
+mkdirSync(join(graphManifestPackageDir, "src"), { recursive: true });
+mkdirSync(join(graphManifestPackageDir, "artifacts"), { recursive: true });
+writeFileSync(join(graphManifestPackageDir, "src", "main.0"), readFileSync("conformance/packages/test-app/src/main.0", "utf8"));
+writeFileSync(join(graphManifestPackageDir, "zero.json"), `${JSON.stringify({
+  package: { name: "graph-manifest-package", version: "0.1.0" },
+  targets: { cli: { kind: "exe", main: "src/main.0", graph: "artifacts/test-app.program-graph" } },
+}, null, 2)}\n`);
+assert.equal(zero(["graph", "import", "--out", graphManifestArtifactPath, "conformance/packages/test-app"]).stdout, "");
+assert.equal(zero(["graph", "validate", graphManifestPackageDir]).stdout, "program graph ok\n");
+const graphManifestCheckJson = json(["graph", "check", "--json", graphManifestPackageDir]).body;
+assert.equal(graphManifestCheckJson.ok, true);
+assert.equal(graphManifestCheckJson.artifact, graphManifestArtifactPath);
+assert.equal(graphManifestCheckJson.moduleIdentity, "package:test-app@0.1.0");
+assert.equal(graphManifestCheckJson.check.lowering, "direct-program-graph");
+const graphManifestSizeJson = json(["graph", "size", "--json", "--target", "linux-musl-x64", graphManifestPackageDir]).body;
+assert.equal(graphManifestSizeJson.graph.artifact, graphManifestArtifactPath);
+assert.equal(graphManifestSizeJson.graph.lowering, "direct-program-graph");
+const graphManifestBuildJson = json(["graph", "build", "--json", "--target", "linux-musl-x64", "--out", graphManifestBuildPath, graphManifestPackageDir]).body;
+assert.equal(graphManifestBuildJson.graph.artifact, graphManifestArtifactPath);
+assert.equal(graphManifestBuildJson.graph.lowering, "direct-program-graph");
+assert.equal(zero(["graph", "run", "--out", graphManifestRunPath, graphManifestPackageDir]).stdout, "package tests\n");
+const graphManifestTestJson = json(["graph", "test", "--json", graphManifestPackageDir]).body;
+assert.equal(graphManifestTestJson.ok, true);
+assert.equal(graphManifestTestJson.graph.artifact, graphManifestArtifactPath);
+assert.equal(graphManifestTestJson.testDiscovery.mode, "package-graph");
+const graphManifestMissingJson = json(["graph", "check", "--json", "conformance/packages/test-app"], { allowFailure: true });
+assert.equal(graphManifestMissingJson.code, 1);
+assert.equal(graphManifestMissingJson.body.diagnostics[0].message, "zero.json is missing targets.cli.graph");
 writeFileSync(graphSizeNoisePatchPath, [
   "zero-program-graph-patch v1",
   `expect graphHash "${graphDumpJson.graphHash}"`,


### PR DESCRIPTION
- Resolve graph artifact package inputs through targets.cli.graph
- Keep source graph commands on source entrypoints
- Cover manifest graph commands in CLI contracts