### PR TITLE
Add gcd benchmark case

### DIFF
--- a/benchmarks/zero/gcd.0
+++ b/benchmarks/zero/gcd.0
@@ -1,0 +1,17 @@
+fn gcd i32 a i32 b i32
+  mut left a
+  mut right b
+  while != right 0
+    let next % left right
+    set left right
+    set right next
+  ret left
+
+pub fn main Void world World !
+  mut acc 0
+  mut i 0
+  while < i 50000
+    set acc + acc (gcd 462 1071)
+    set i + i 1
+  if == acc 1050000
+    check world.out.write "gcd\n"

--- a/docs/articles/benchmarks.md
+++ b/docs/articles/benchmarks.md
@@ -35,6 +35,7 @@ The current cases include:
 - `codec`: `std.codec` loops, varint length, and CRC-32
 - `parse`: scanner-style digit parsing
 - `slices`, `arena`, `fallibility`, `branches`: memory views, fixed-buffer allocation style, explicit fallible branching, and branch-heavy loops
+- `gcd`: integer Euclid loop exercising `%`, mutation, and a hot inner branch
 - `module-package`, `rescue`: package graph overhead and local rescue lowering
 - `fs-resource`, `mem-copy-fill`, `zero-hash`: focused Zero cases for file-resource metadata, memory helpers, and deterministic byte payload processing
 

--- a/scripts/bench.mts
+++ b/scripts/bench.mts
@@ -38,6 +38,7 @@ const cases = [
   { name: "fallibility", expectedStdout: "fallibility" },
   { name: "readall", expectedStdout: "readall", skipLanguages: ["zero"] },
   { name: "branches", expectedStdout: "branches" },
+  { name: "gcd", expectedStdout: "gcd" },
   { name: "module-package", expectedStdout: "module package", languages: ["zero"], sources: { zero: "benchmarks/zero/module-package" } },
   { name: "owned-file", expectedStdout: "owned file", languages: ["zero"], skipLanguages: ["zero"] },
   { name: "rescue", expectedStdout: "rescue", languages: ["zero"] },


### PR DESCRIPTION
## Summary

Closes the first item in the "narrow first implementation" list of #8: a small integer Euclid GCD benchmark registered alongside the existing math/branch cases.

- New source `benchmarks/zero/gcd.0` — `fn gcd i32` with a `mut`/`set` Euclid loop, driven 50k times from `main`
- Registers `{ name: "gcd", expectedStdout: "gcd" }` in `scripts/bench.mts`
- Adds `gcd` to the case list in `docs/articles/benchmarks.md`

## Why this case

Per #8, the gap is small kernels that resemble what agents commonly generate or repair. GCD exercises an integer loop, `%`, mutable locals, and a hot inner branch on the direct backends without adding any new stdlib surface or harness mechanics.

## Test plan

- [x] `bin/zero check benchmarks/zero/gcd.0` → `ok`
- [x] `bin/zero build --target darwin-arm64 …` → 16.2 KiB Mach-O, runs and prints `gcd`
- [x] Full local `bash scripts/bench.sh` run (darwin-arm64): `gcd` row status `ok`, `outputMatches: true`, direct-Zero ok count 18 → 19, all `assertBenchmarkGuardrails`/`assertDirectBenchmarks`/`assertBenchmarkCoverage`/`assertMeasurementCoverage`/`assertBenchmarkTrendSummary` assertions pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)