### PR TITLE
Clarify graph command input modes

### DIFF
--- a/docs/articles/cli-reference.md
+++ b/docs/articles/cli-reference.md
@@ -110,7 +110,9 @@ linking facts such as retained runtime objects, provider libraries, and
 
 Graph artifact commands (`validate`, `view`, `check`, `size`, `build`, `run`,
 `test`, and `patch`) also accept a package directory or `zero.json` when
-`targets.cli.graph` points at a saved ProgramGraph artifact.
+`targets.cli.graph` points at a saved ProgramGraph artifact. `zero graph
+roundtrip` uses that artifact for packages that declare it, and otherwise
+roundtrips source input.
 The direct `check`, `size`, `build`, `run`, `test`, and `ship` commands use
 that graph entrypoint for packages that declare it; packages without
 `targets.cli.graph` continue to use `targets.cli.main`.

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -10023,20 +10023,30 @@ static int run_graph_artifact_roundtrip_command(const Command *command, ZDiag *d
   return ok ? 0 : 1;
 }
 
-static bool graph_roundtrip_input_is_artifact(const Command *command) {
-  if (!command || !command->input || is_row_source_path(command->input)) return false;
-  char *manifest_path = z_manifest_path_for_input(command->input);
-  bool package_input = manifest_path != NULL;
-  free(manifest_path);
-  return !package_input;
-}
+static bool resolve_graph_command_manifest_input(Command *command, bool *artifact_input, ZDiag *diag) {
+  if (artifact_input) *artifact_input = false;
+  if (!command || !command->command || !command->input || strcmp(command->command, "graph") != 0 || !command->kind) return true;
+  ZProgramGraphInputMode input_mode = z_program_graph_command_input_mode(command->kind);
+  if (input_mode == Z_PROGRAM_GRAPH_INPUT_SOURCE || input_mode == Z_PROGRAM_GRAPH_INPUT_UNKNOWN) return true;
+  if (input_mode == Z_PROGRAM_GRAPH_INPUT_SOURCE_OR_ARTIFACT && is_row_source_path(command->input)) return true;
 
-static bool resolve_graph_command_manifest_input(Command *command, ZDiag *diag) {
-  if (!command || !command->command || !command->input || strcmp(command->command, "graph") != 0 || !z_program_graph_command_kind_uses_artifact_input(command->kind)) return true;
   char *artifact_path = NULL;
   bool handled = false;
-  if (!z_resolve_manifest_graph_artifact_path(command->input, &artifact_path, &handled, true, diag)) return false;
-  if (handled) command->input = artifact_path;
+  bool require_graph = input_mode == Z_PROGRAM_GRAPH_INPUT_ARTIFACT;
+  if (!z_resolve_manifest_graph_artifact_path(command->input, &artifact_path, &handled, require_graph, diag)) return false;
+  if (handled) {
+    command->input = artifact_path;
+    if (artifact_input) *artifact_input = true;
+    return true;
+  }
+  if (input_mode == Z_PROGRAM_GRAPH_INPUT_SOURCE_OR_ARTIFACT) {
+    char *manifest_path = z_manifest_path_for_input(command->input);
+    if (manifest_path) {
+      free(manifest_path);
+      return true;
+    }
+  }
+  if (artifact_input) *artifact_input = true;
   return true;
 }
 
@@ -10402,7 +10412,8 @@ int main(int argc, char **argv) {
     return 1;
   }
 
-  if (!resolve_graph_command_manifest_input(&command, &diag)) {
+  bool graph_command_artifact_input = false;
+  if (!resolve_graph_command_manifest_input(&command, &graph_command_artifact_input, &diag)) {
     if (command.json) print_diag_json(diag.path ? diag.path : command.input, &diag);
     else print_diag(diag.path ? diag.path : command.input, &diag);
     return 1;
@@ -10414,7 +10425,7 @@ int main(int argc, char **argv) {
     if (strcmp(command.kind, "check") == 0) return run_graph_check_command(&command, target, &diag);
     if (strcmp(command.kind, "size") == 0) return run_graph_size_command(&command, target, &diag);
     if (strcmp(command.kind, "patch") == 0) return run_graph_patch_command(&command, &diag);
-    if (strcmp(command.kind, "roundtrip") == 0 && graph_roundtrip_input_is_artifact(&command)) return run_graph_artifact_roundtrip_command(&command, &diag);
+    if (strcmp(command.kind, "roundtrip") == 0 && graph_command_artifact_input) return run_graph_artifact_roundtrip_command(&command, &diag);
   }
 
   if (strcmp(command.command, "fmt") == 0) {

--- a/native/zero-c/src/program_graph_command.c
+++ b/native/zero-c/src/program_graph_command.c
@@ -5,50 +5,50 @@
 
 typedef struct {
   const char *name;
-  bool uses_artifact_input;
+  ZProgramGraphInputMode input_mode;
   bool supports_out;
   ZProgramGraphOutputContract out_contract;
 } ZProgramGraphCommandKind;
 
-#define GRAPH_OUT(name, artifact_input) \
-  {name, artifact_input, true, {true, NULL, NULL, NULL, NULL}}
-#define GRAPH_NO_OUT(name, artifact_input, message, expected, actual, help) \
-  {name, artifact_input, false, {false, message, expected, actual, help}}
+#define GRAPH_OUT(name, input_mode) \
+  {name, input_mode, true, {true, NULL, NULL, NULL, NULL}}
+#define GRAPH_NO_OUT(name, input_mode, message, expected, actual, help) \
+  {name, input_mode, false, {false, message, expected, actual, help}}
 
 static const ZProgramGraphCommandKind z_graph_command_kinds[] = {
-  GRAPH_OUT("dump", false),
-  GRAPH_OUT("import", false),
+  GRAPH_OUT("dump", Z_PROGRAM_GRAPH_INPUT_SOURCE),
+  GRAPH_OUT("import", Z_PROGRAM_GRAPH_INPUT_SOURCE),
   GRAPH_NO_OUT(
     "inspect",
-    false,
+    Z_PROGRAM_GRAPH_INPUT_SOURCE,
     "graph inspect does not support --out",
     "zero graph inspect [--json] <file.0|file.row|project|zero.json>",
     "zero graph inspect --out",
     "use zero graph dump or zero graph import with --out when you need a ProgramGraph artifact"
   ),
-  GRAPH_OUT("validate", true),
-  GRAPH_OUT("view", true),
+  GRAPH_OUT("validate", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
+  GRAPH_OUT("view", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
   GRAPH_NO_OUT(
     "check",
-    true,
+    Z_PROGRAM_GRAPH_INPUT_ARTIFACT,
     "graph check does not write generated source views",
     "zero graph view --out <file.0> <graph-artifact-or-package>",
     "zero graph check --out",
     "run zero graph view to render a generated source view, or run zero graph check without --out to typecheck the artifact"
   ),
-  GRAPH_OUT("size", true),
-  GRAPH_OUT("build", true),
-  GRAPH_OUT("run", true),
+  GRAPH_OUT("size", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
+  GRAPH_OUT("build", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
+  GRAPH_OUT("run", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
   GRAPH_NO_OUT(
     "test",
-    true,
+    Z_PROGRAM_GRAPH_INPUT_ARTIFACT,
     "graph test does not support --out",
     "zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>",
     "zero graph test --out",
     "test results are reported on stdout; remove --out"
   ),
-  GRAPH_OUT("patch", true),
-  GRAPH_OUT("roundtrip", false),
+  GRAPH_OUT("patch", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
+  GRAPH_OUT("roundtrip", Z_PROGRAM_GRAPH_INPUT_SOURCE_OR_ARTIFACT),
 };
 
 #undef GRAPH_OUT
@@ -65,9 +65,9 @@ bool z_program_graph_command_kind_is_known(const char *kind) {
   return graph_kind(kind) != NULL;
 }
 
-bool z_program_graph_command_kind_uses_artifact_input(const char *kind) {
+ZProgramGraphInputMode z_program_graph_command_input_mode(const char *kind) {
   const ZProgramGraphCommandKind *item = graph_kind(kind);
-  return item && item->uses_artifact_input;
+  return item ? item->input_mode : Z_PROGRAM_GRAPH_INPUT_UNKNOWN;
 }
 
 bool z_program_graph_command_kind_supports_out(const char *kind) {

--- a/native/zero-c/src/program_graph_command.h
+++ b/native/zero-c/src/program_graph_command.h
@@ -11,8 +11,13 @@ typedef struct {
   const char *help;
 } ZProgramGraphOutputContract;
 
+typedef enum {
+  Z_PROGRAM_GRAPH_INPUT_UNKNOWN = 0, Z_PROGRAM_GRAPH_INPUT_SOURCE,
+  Z_PROGRAM_GRAPH_INPUT_ARTIFACT, Z_PROGRAM_GRAPH_INPUT_SOURCE_OR_ARTIFACT,
+} ZProgramGraphInputMode;
+
 bool z_program_graph_command_kind_is_known(const char *kind);
-bool z_program_graph_command_kind_uses_artifact_input(const char *kind);
+ZProgramGraphInputMode z_program_graph_command_input_mode(const char *kind);
 bool z_program_graph_command_kind_supports_out(const char *kind);
 ZProgramGraphOutputContract z_program_graph_command_output_contract(const char *kind);
 bool z_program_graph_direct_command_uses_manifest_input(const char *command);

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -727,6 +727,14 @@ const graphManifestTestJson = json(["graph", "test", "--json", graphManifestPack
 assert.equal(graphManifestTestJson.ok, true);
 assert.equal(graphManifestTestJson.graph.artifact, graphManifestArtifactPath);
 assert.equal(graphManifestTestJson.testDiscovery.mode, "package-graph");
+const graphManifestRoundtripJson = json(["graph", "roundtrip", "--json", graphManifestPackageDir]).body;
+assert.equal(graphManifestRoundtripJson.ok, true);
+assert.equal(graphManifestRoundtripJson.artifact, graphManifestArtifactPath);
+assert.equal(graphManifestRoundtripJson.semanticStable, true);
+assert.equal(graphManifestRoundtripJson.lowering, "direct-program-graph");
+assert.equal(graphManifestRoundtripJson.moduleIdentity, "package:test-app@0.1.0");
+assert.equal(graphManifestRoundtripJson.roundtripModuleIdentity, "package:test-app@0.1.0");
+assert.equal(graphManifestRoundtripJson.view, null);
 const directGraphManifestCheckJson = json(["check", "--json", graphManifestPackageDir]).body;
 assert.equal(directGraphManifestCheckJson.ok, true);
 assert.equal(directGraphManifestCheckJson.graph.artifact, graphManifestArtifactPath);


### PR DESCRIPTION
- Route graph roundtrip packages through declared graph artifacts
- Cover manifest roundtrip behavior in command contracts
- Document package graph roundtrip routing