### PR TITLE
Clarify ProgramGraph input surface

### DIFF
--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -2784,7 +2784,7 @@ await writeFile(programGraphFailedArtifactPath, [
 ].join("\n"));
 const programGraphFailedArtifact = await execFileAsync(zero, ["graph", "validate", "--json", programGraphFailedArtifactPath]).catch((error) => error);
 assert(programGraphFailedArtifact.code);
-assert.equal(JSON.parse(programGraphFailedArtifact.stdout).diagnostics[0].message, "program graph artifact reports failed validation");
+assert.equal(JSON.parse(programGraphFailedArtifact.stdout).diagnostics[0].message, "program graph input reports failed validation");
 const programGraphTrailingArtifactPath = `${outDir}/trailing-content.program-graph`;
 await writeFile(programGraphTrailingArtifactPath, `${programGraphDump}\nextra\n`);
 const programGraphTrailingArtifact = await execFileAsync(zero, ["graph", "validate", "--json", programGraphTrailingArtifactPath]).catch((error) => error);

--- a/docs/articles/cli-reference.md
+++ b/docs/articles/cli-reference.md
@@ -75,13 +75,13 @@ Use `--json` when another tool will read the result. Text output is for people.
 | `zero graph --json` | Modules, public symbols, capabilities, static facts, helper use, and nested `programGraph`. |
 | `zero graph dump --json` | The bare deterministic ProgramGraph with `moduleIdentity`, `graphHash`, validation, counts, nodes, and edges. Use `--out <program-graph-or-module.0>` to also write graph storage. |
 | `zero graph import --json` | Source-to-ProgramGraph import with graph identity and validation. With `--out <program-graph-or-module.0>`, writes graph storage and reports `saved.path`. |
-| `zero graph validate --json` | A ProgramGraph artifact readback check with `moduleIdentity`, `graphHash`, `canonicalSource`, counts, validation state, and optional canonical output path. |
-| `zero graph view --json` | A generated Zero-shaped view for a ProgramGraph artifact with `moduleIdentity`, `graphHash`, `canonicalSource`, and optional output path. |
-| `zero graph check --json` | Typecheck a ProgramGraph artifact through direct graph lowering with artifact identity, target, `check.lowering: "direct-program-graph"`, target readiness, and graph-source-mapped diagnostics. |
-| `zero graph size --json` | Size, helper, runtime, profile, and backend facts for a ProgramGraph artifact lowered through `direct-program-graph`, with graph identity and `canonicalSource`. |
-| `zero graph build --json` | Build a ProgramGraph artifact through direct graph lowering, including graph identity, selected `emit` kind, target, artifact path and size, compiler cache facts, and graph-aware incremental invalidation. |
-| `zero graph patch --json` | Checked ProgramGraph artifact edits with graph-hash preconditions, per-operation node/field results, the changed graph hash, and optional ProgramGraph artifact output path. |
-| `zero graph roundtrip --json` | Source or artifact ProgramGraph stability through direct graph lowering with `semanticStable`, lowering mode, original and roundtripped graph hashes, raw counts, normalized semantic counts, and optional ProgramGraph artifact output. |
+| `zero graph validate --json` | A saved ProgramGraph input readback check with `moduleIdentity`, `graphHash`, `canonicalSource`, counts, validation state, and optional canonical output path. |
+| `zero graph view --json` | A generated Zero-shaped view for saved ProgramGraph input with `moduleIdentity`, `graphHash`, `canonicalSource`, and optional output path. |
+| `zero graph check --json` | Typecheck saved ProgramGraph input through direct graph lowering with graph identity, target, `check.lowering: "direct-program-graph"`, target readiness, and graph-source-mapped diagnostics. |
+| `zero graph size --json` | Size, helper, runtime, profile, and backend facts for saved ProgramGraph input lowered through `direct-program-graph`, with graph identity and `canonicalSource`. |
+| `zero graph build --json` | Build saved ProgramGraph input through direct graph lowering, including graph identity, selected `emit` kind, target, artifact path and size, compiler cache facts, and graph-aware incremental invalidation. |
+| `zero graph patch --json` | Checked ProgramGraph input edits with graph-hash preconditions, per-operation node/field results, the changed graph hash, and optional ProgramGraph output path. |
+| `zero graph roundtrip --json` | Source or saved ProgramGraph input stability through direct graph lowering with `semanticStable`, lowering mode, original and roundtripped graph hashes, raw counts, normalized semantic counts, and optional ProgramGraph output. |
 | `zero dev --json` | A watch plan for changed source, manifest, package-lock, and generated-binding inputs. |
 | `zero dev --json --trace` | Adds phase timing, cache hit/miss facts, diagnostics passthrough, and `interfaceFingerprints`. |
 | `zero time --json` | Compiler phase timing plus `interfaceFingerprints` and incremental invalidation facts. |
@@ -108,11 +108,12 @@ linking facts such as retained runtime objects, provider libraries, and
 `zero ship --json` nests the same contract under
 `releasePreview.targetContract`.
 
-Graph artifact commands (`validate`, `view`, `check`, `size`, `build`, `run`,
-`test`, and `patch`) also accept a package directory or `zero.json` when
-`targets.cli.graph` points at a saved ProgramGraph artifact. `zero graph
-roundtrip` uses that artifact for packages that declare it, and otherwise
-roundtrips source input.
+ProgramGraph input commands (`validate`, `view`, `check`, `size`, `build`,
+`run`, `test`, and `patch`) accept saved `.program-graph` files, canonical graph
+`.0` files, or a package directory or `zero.json` when `targets.cli.graph`
+points at saved ProgramGraph input. `zero graph roundtrip` uses that
+ProgramGraph input for packages that declare it, and otherwise roundtrips source
+input.
 The direct `check`, `size`, `build`, `run`, `test`, and `ship` commands use
 that graph entrypoint for packages that declare it; packages without
 `targets.cli.graph` continue to use `targets.cli.main`.
@@ -122,7 +123,7 @@ continue through the row parser.
 
 ## ProgramGraph Patches
 
-`zero graph patch` applies checked edits to a saved ProgramGraph artifact and
+`zero graph patch` applies checked edits to saved ProgramGraph input and
 prints or writes the canonical patched artifact. Patch files are line-oriented
 text:
 
@@ -218,12 +219,12 @@ zero test [--json] [--filter <name>] [--target <target>] [--cc <path>] [--out <f
 zero fmt [--check] <input>
 zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] <input> [patch-file]
 zero graph [dump|import|validate|roundtrip] [--json] --out <program-graph-or-module.0> <input>
-zero graph view [--json] --out <file.0> <graph-artifact-or-package>
-zero graph size [--json] [--target <target>] --out <artifact> <graph-artifact-or-package>
-zero graph patch [--json] --out <program-graph-or-module.0> <graph-artifact-or-package> <patch-file>
-zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package>
-zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package> [-- args...]
-zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>
+zero graph view [--json] --out <file.0> <program-graph-or-package>
+zero graph size [--json] [--target <target>] --out <artifact> <program-graph-or-package>
+zero graph patch [--json] --out <program-graph-or-module.0> <program-graph-or-package> <patch-file>
+zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package>
+zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package> [-- args...]
+zero graph test [--json] [--filter <name>] [--target <target>] <program-graph-or-package>
 zero doc [--json] [--target <target>] <input>
 zero size [--json] [--target <target>] [--out <artifact>] <input>
 zero explain [--json] <diagnostic-code>

--- a/native/zero-c/src/fs.c
+++ b/native/zero-c/src/fs.c
@@ -717,9 +717,9 @@ static void set_manifest_graph_diag(ZDiag *diag, const char *manifest_path, cons
   diag->column = 1;
   diag->length = 1;
   snprintf(diag->message, sizeof(diag->message), "%s", message ? message : "invalid graph target");
-  snprintf(diag->expected, sizeof(diag->expected), "%s", expected ? expected : "targets.cli.graph pointing at a ProgramGraph artifact");
+  snprintf(diag->expected, sizeof(diag->expected), "%s", expected ? expected : "targets.cli.graph pointing at saved ProgramGraph input");
   snprintf(diag->actual, sizeof(diag->actual), "%s", actual ? actual : "invalid targets.cli.graph");
-  snprintf(diag->help, sizeof(diag->help), "%s", help ? help : "set targets.cli.graph to a saved ProgramGraph artifact");
+  snprintf(diag->help, sizeof(diag->help), "%s", help ? help : "set targets.cli.graph to saved ProgramGraph input");
 }
 
 bool z_resolve_manifest_graph_artifact_path(const char *input_path, char **out_artifact_path, bool *handled, bool require_graph, ZDiag *diag) {
@@ -751,9 +751,9 @@ bool z_resolve_manifest_graph_artifact_path(const char *input_path, char **out_a
       set_manifest_graph_diag(diag,
                               manifest_path,
                               "zero.json is missing targets.cli.graph",
-                              "targets.cli.graph pointing at a saved ProgramGraph artifact",
+                              "targets.cli.graph pointing at saved ProgramGraph input",
                               "missing targets.cli.graph",
-                              "run zero graph import --out <artifact> <source>, then set targets.cli.graph");
+                              "run zero graph import --out <program-graph> <source>, then set targets.cli.graph");
       ok = false;
     }
   } else {
@@ -761,10 +761,10 @@ bool z_resolve_manifest_graph_artifact_path(const char *input_path, char **out_a
     if (!artifact_path || !file_exists(artifact_path)) {
       set_manifest_graph_diag(diag,
                               manifest_path,
-                              "target graph artifact does not exist",
+                              "target ProgramGraph input does not exist",
                               artifact_path ? artifact_path : parsed_manifest.graph_path,
-                              "missing ProgramGraph artifact",
-                              "create the artifact or update targets.cli.graph");
+                              "missing ProgramGraph input",
+                              "create the ProgramGraph input or update targets.cli.graph");
       ok = false;
     } else {
       resolved_graph = true;

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -1905,11 +1905,11 @@ static void append_compiler_caches_json_ex(ZBuf *buf, const SourceInput *input, 
     wrote = true; \
   } while (0)
   bool wrote = false;
-  APPEND_CACHE("parseTree", parse_key, input && input->parse_cache_hit, graph_input ? "graph artifact" : "source");
+  APPEND_CACHE("parseTree", parse_key, input && input->parse_cache_hit, graph_input ? "ProgramGraph input" : "source");
   APPEND_CACHE("interface", interface_key, input && input->interface_cache_hit, graph_input ? "graph public symbols/import graph" : "public symbols/import graph");
-  APPEND_CACHE("checkedBody", check_key, input && input->check_cache_hit, graph_input ? "graph artifact or target" : "source or target");
-  APPEND_CACHE("specialization", specialization_key, input && input->specialization_cache_hit, graph_input ? "graph artifact, target, or profile" : "source, target, or profile");
-  APPEND_CACHE("emittedObject", object_key, input && input->emitted_object_cache_hit, graph_input ? "graph artifact, target, profile, or backend" : "source, target, profile, or backend");
+  APPEND_CACHE("checkedBody", check_key, input && input->check_cache_hit, graph_input ? "ProgramGraph input or target" : "source or target");
+  APPEND_CACHE("specialization", specialization_key, input && input->specialization_cache_hit, graph_input ? "ProgramGraph input, target, or profile" : "source, target, or profile");
+  APPEND_CACHE("emittedObject", object_key, input && input->emitted_object_cache_hit, graph_input ? "ProgramGraph input, target, profile, or backend" : "source, target, profile, or backend");
 #undef APPEND_CACHE
   zbuf_append(buf, "]");
 }
@@ -2314,7 +2314,7 @@ static void append_test_json_location(ZBuf *buf, const SourceInput *input, int p
 
 static const char *test_discovery_mode(const SourceInput *input, const Command *command) {
   if (command && z_program_graph_artifact_source_present(&command->graph_source)) {
-    return input && input->package_name && input->package_name[0] ? "package-graph" : "graph-artifact";
+    return input && input->package_name && input->package_name[0] ? "package-graph" : "program-graph";
   }
   return input && input->package_root ? "package" : "single-file";
 }
@@ -3326,12 +3326,12 @@ static void print_help(void) {
   printf("  zero ship [--json] [--target <target>] [--profile release-small|tiny|audit] [--out <file>] <file.0|file.row|project|zero.json>\n");
   printf("  zero tokens --json <file.0|file.row|project|zero.json>\n");
   printf("  zero parse --json <file.0|file.row|project|zero.json>\n");
-  printf("  zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] <file.0|file.row|project|zero.json|graph-artifact> [patch-file]\n");
-  printf("  zero graph [dump|import|validate|roundtrip] [--json] --out <program-graph-or-module.0> <file.0|file.row|project|zero.json|graph-artifact>\n");
-  printf("  zero graph view [--json] --out <file.0> <graph-artifact-or-package>\n");
-  printf("  zero graph size [--json] [--target <target>] --out <artifact> <graph-artifact-or-package>\n");
-  printf("  zero graph patch [--json] --out <program-graph-or-module.0> <graph-artifact-or-package> <patch-file>\n");
-  printf("  zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package>\n  zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package> [-- args...]\n  zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>\n");
+  printf("  zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] <input> [patch-file]\n");
+  printf("  zero graph [dump|import|validate|roundtrip] [--json] --out <program-graph-or-module.0> <input>\n");
+  printf("  zero graph view [--json] --out <file.0> <program-graph-or-package>\n");
+  printf("  zero graph size [--json] [--target <target>] --out <artifact> <program-graph-or-package>\n");
+  printf("  zero graph patch [--json] --out <program-graph-or-module.0> <program-graph-or-package> <patch-file>\n");
+  printf("  zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package>\n  zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package> [-- args...]\n  zero graph test [--json] [--filter <name>] [--target <target>] <program-graph-or-package>\n");
   printf("  zero doc [--json] <file.0|file.row|project|zero.json>\n");
   printf("  zero size [--json] [--out <artifact>] <file.0|file.row|project|zero.json>\n");
   printf("  zero mem [--json] [--target <target>] <file.0|file.row|project|zero.json>\n");
@@ -3409,23 +3409,23 @@ static void print_command_help(const char *command) {
     printf("Usage: zero abi check|dump [--json] [--target <target>] <file.0|file.row|project|zero.json>\n\n");
     printf("Check ABI-safe declarations or dump target-aware source layout facts.\n");
   } else if (strcmp(command, "graph") == 0) {
-    printf("Usage: zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] <file.0|file.row|project|zero.json|graph-artifact> [patch-file]\n\n");
+    printf("Usage: zero graph [dump|import|inspect|validate|view|check|size|build|run|test|patch|roundtrip] [--json] [--target <target>] <input> [patch-file]\n\n");
     printf("Output usage: zero graph [dump|import|validate|roundtrip] [--json] --out <program-graph-or-module.0> <input>\n");
-    printf("View output usage: zero graph view [--json] --out <file.0> <graph-artifact-or-package>\n");
+    printf("View output usage: zero graph view [--json] --out <file.0> <program-graph-or-package>\n");
     printf("Size output usage: zero graph size [--json] [--target <target>] --out <artifact> <input>\n");
     printf("Patch output usage: zero graph patch [--json] --out <program-graph-or-module.0> <input> <patch-file>\n\n");
-    printf("Build usage: zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package>\n\nRun usage: zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <graph-artifact-or-package> [-- args...]\n\nTest usage: zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>\n\n");
-    printf("Inspect modules, symbols, capabilities, static metadata, stdlib helpers, or deterministic ProgramGraph artifacts.\n\n");
+    printf("Build usage: zero graph build [--json] [--emit exe|obj] [--target <target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package>\n\nRun usage: zero graph run [--target <host-target>] [--profile debug|dev|release-fast|release-small|tiny|audit] [--release <profile>] [--out <file>] <program-graph-or-package> [-- args...]\n\nTest usage: zero graph test [--json] [--filter <name>] [--target <target>] <program-graph-or-package>\n\n");
+    printf("Inspect modules, symbols, capabilities, static metadata, stdlib helpers, or deterministic ProgramGraph inputs.\n\n");
     printf("Subcommands:\n");
     printf("  dump      print or write only the deterministic ProgramGraph\n");
-    printf("  import    convert current Zero source into a deterministic ProgramGraph artifact\n");
+    printf("  import    convert current Zero source into deterministic ProgramGraph input\n");
     printf("  inspect   report semantic graph and compiler facts as JSON\n");
-    printf("  validate  read a ProgramGraph artifact and optionally write its canonical form\n");
-    printf("  view      render a ProgramGraph artifact as a generated Zero view\n");
-    printf("  check     typecheck a ProgramGraph artifact through direct graph lowering\n");
-    printf("  size      report size, helper, runtime, and backend facts for a ProgramGraph artifact\n");
-    printf("  build     build a ProgramGraph artifact through direct graph lowering\n  run       build and run a ProgramGraph artifact through direct graph lowering\n  test      run test blocks from a ProgramGraph artifact through direct graph lowering\n");
-    printf("  patch     apply checked edits to a ProgramGraph artifact\n");
+    printf("  validate  read ProgramGraph input and optionally write its canonical form\n");
+    printf("  view      render ProgramGraph input as a generated Zero view\n");
+    printf("  check     typecheck ProgramGraph input through direct graph lowering\n");
+    printf("  size      report size, helper, runtime, and backend facts for ProgramGraph input\n");
+    printf("  build     build ProgramGraph input through direct graph lowering\n  run       build and run ProgramGraph input through direct graph lowering\n  test      run test blocks from ProgramGraph input through direct graph lowering\n");
+    printf("  patch     apply checked edits to ProgramGraph input\n");
     printf("  roundtrip compare graph semantics after direct ProgramGraph lowering\n");
   } else if (strcmp(command, "doc") == 0) {
     printf("Usage: zero doc [--json] [--target <target>] <file.0|file.row|project|zero.json>\n\n");
@@ -9819,7 +9819,7 @@ static int run_graph_patch_command(const Command *command, ZDiag *diag) {
     diag->column = 1;
     diag->length = 1;
     snprintf(diag->message, sizeof(diag->message), "graph patch requires a patch file");
-    snprintf(diag->expected, sizeof(diag->expected), "zero graph patch <graph-artifact> <patch-file>");
+    snprintf(diag->expected, sizeof(diag->expected), "zero graph patch <program-graph> <patch-file>");
     snprintf(diag->actual, sizeof(diag->actual), "missing patch file");
     snprintf(diag->help, sizeof(diag->help), "pass a zero-program-graph-patch v1 file as the second positional argument");
     if (command->json) print_diag_json(diag->path ? diag->path : command->input, diag);

--- a/native/zero-c/src/program_graph_command.c
+++ b/native/zero-c/src/program_graph_command.c
@@ -24,7 +24,7 @@ static const ZProgramGraphCommandKind z_graph_command_kinds[] = {
     "graph inspect does not support --out",
     "zero graph inspect [--json] <file.0|file.row|project|zero.json>",
     "zero graph inspect --out",
-    "use zero graph dump or zero graph import with --out when you need a ProgramGraph artifact"
+    "use zero graph dump or zero graph import with --out when you need saved ProgramGraph input"
   ),
   GRAPH_OUT("validate", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
   GRAPH_OUT("view", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
@@ -32,9 +32,9 @@ static const ZProgramGraphCommandKind z_graph_command_kinds[] = {
     "check",
     Z_PROGRAM_GRAPH_INPUT_ARTIFACT,
     "graph check does not write generated source views",
-    "zero graph view --out <file.0> <graph-artifact-or-package>",
+    "zero graph view --out <file.0> <program-graph-or-package>",
     "zero graph check --out",
-    "run zero graph view to render a generated source view, or run zero graph check without --out to typecheck the artifact"
+    "run zero graph view to render a generated source view, or run zero graph check without --out to typecheck the ProgramGraph input"
   ),
   GRAPH_OUT("size", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
   GRAPH_OUT("build", Z_PROGRAM_GRAPH_INPUT_ARTIFACT),
@@ -43,7 +43,7 @@ static const ZProgramGraphCommandKind z_graph_command_kinds[] = {
     "test",
     Z_PROGRAM_GRAPH_INPUT_ARTIFACT,
     "graph test does not support --out",
-    "zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>",
+    "zero graph test [--json] [--filter <name>] [--target <target>] <program-graph-or-package>",
     "zero graph test --out",
     "test results are reported on stdout; remove --out"
   ),

--- a/native/zero-c/src/program_graph_format.c
+++ b/native/zero-c/src/program_graph_format.c
@@ -486,7 +486,7 @@ bool z_program_graph_parse_dump(const char *text, ZProgramGraph *out, ZDiag *dia
     size_t validation_line = line_no;
     NEXT_REQUIRED_LINE();
     if (strncmp(line, "diagnostic ", 11) != 0) FAIL("expected diagnostic field after failed validation");
-    FAIL_AT(validation_line, "program graph artifact reports failed validation");
+    FAIL_AT(validation_line, "program graph input reports failed validation");
   }
   NEXT_REQUIRED_LINE();
   if (!graph_format_parse_counts_line(line, &node_count, &edge_count)) FAIL("expected node and edge counts");

--- a/native/zero-c/src/program_graph_lower.c
+++ b/native/zero-c/src/program_graph_lower.c
@@ -999,7 +999,7 @@ static void lower_init_source_from_graph(SourceInput *source, const ZProgramGrap
 static bool lower_to_program(GraphLower *lower, Program *out) {
   if (!out) return false;
   *out = (Program){0};
-  if (!lower || !lower->graph) return lower_fail(lower, NULL, "program graph is missing", "ProgramGraph artifact", "missing graph", NULL);
+  if (!lower || !lower->graph) return lower_fail(lower, NULL, "program graph is missing", "ProgramGraph input", "missing graph", NULL);
 
   size_t module_count = 0;
   for (size_t i = 0; i < lower->graph->node_len; i++) {

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -312,21 +312,21 @@ for (const [command, expected] of [
 }
 const graphHelp = zero(["graph", "--help"]).stdout;
 assert.match(graphHelp, /zero graph \[dump\|import\|validate\|roundtrip\] \[--json\] --out <program-graph-or-module\.0> <input>/);
-assert.match(graphHelp, /zero graph view \[--json\] --out <file\.0> <graph-artifact-or-package>/);
+assert.match(graphHelp, /zero graph view \[--json\] --out <file\.0> <program-graph-or-package>/);
 assert.match(graphHelp, /zero graph size \[--json\] \[--target <target>\] --out <artifact> <input>/);
 assert.match(graphHelp, /zero graph patch \[--json\] --out <program-graph-or-module\.0> <input> <patch-file>/);
-assert.match(graphHelp, /zero graph build \[--json\] \[--emit exe\|obj\].*<graph-artifact-or-package>/);
-assert.match(graphHelp, /zero graph run \[--target <host-target>\].*<graph-artifact-or-package> \[-- args\.\.\.\]/);
-assert.match(graphHelp, /zero graph test \[--json\] \[--filter <name>\] \[--target <target>\] <graph-artifact-or-package>/);
+assert.match(graphHelp, /zero graph build \[--json\] \[--emit exe\|obj\].*<program-graph-or-package>/);
+assert.match(graphHelp, /zero graph run \[--target <host-target>\].*<program-graph-or-package> \[-- args\.\.\.\]/);
+assert.match(graphHelp, /zero graph test \[--json\] \[--filter <name>\] \[--target <target>\] <program-graph-or-package>/);
 assert.doesNotMatch(graphHelp, /zero graph check[^\n]*--out/);
 const rootHelp = zero(["--help"]).stdout;
-assert.match(rootHelp, /zero graph \[dump\|import\|validate\|roundtrip\] \[--json\] --out <program-graph-or-module\.0> <file\.0\|file\.row\|project\|zero\.json\|graph-artifact>/);
-assert.match(rootHelp, /zero graph view \[--json\] --out <file\.0> <graph-artifact-or-package>/);
-assert.match(rootHelp, /zero graph size \[--json\] \[--target <target>\] --out <artifact> <graph-artifact-or-package>/);
-assert.match(rootHelp, /zero graph patch \[--json\] --out <program-graph-or-module\.0> <graph-artifact-or-package> <patch-file>/);
-assert.match(rootHelp, /zero graph build \[--json\] \[--emit exe\|obj\].*<graph-artifact-or-package>/);
-assert.match(rootHelp, /zero graph run \[--target <host-target>\].*<graph-artifact-or-package> \[-- args\.\.\.\]/);
-assert.match(rootHelp, /zero graph test \[--json\] \[--filter <name>\] \[--target <target>\] <graph-artifact-or-package>/);
+assert.match(rootHelp, /zero graph \[dump\|import\|validate\|roundtrip\] \[--json\] --out <program-graph-or-module\.0> <input>/);
+assert.match(rootHelp, /zero graph view \[--json\] --out <file\.0> <program-graph-or-package>/);
+assert.match(rootHelp, /zero graph size \[--json\] \[--target <target>\] --out <artifact> <program-graph-or-package>/);
+assert.match(rootHelp, /zero graph patch \[--json\] --out <program-graph-or-module\.0> <program-graph-or-package> <patch-file>/);
+assert.match(rootHelp, /zero graph build \[--json\] \[--emit exe\|obj\].*<program-graph-or-package>/);
+assert.match(rootHelp, /zero graph run \[--target <host-target>\].*<program-graph-or-package> \[-- args\.\.\.\]/);
+assert.match(rootHelp, /zero graph test \[--json\] \[--filter <name>\] \[--target <target>\] <program-graph-or-package>/);
 
 const graphDump = zero(["graph", "dump", "examples/hello.0"]).stdout;
 const graphDumpAgain = zero(["graph", "dump", "examples/hello.0"]).stdout;
@@ -647,7 +647,7 @@ assert.equal(directGraphSourceTestJson.sourceFile, graphTestSourceStoragePath);
 assert.equal(directGraphSourceTestJson.graph.artifact, graphTestSourceStoragePath);
 assert.equal(directGraphSourceTestJson.graph.canonicalSource, true);
 assert.equal(directGraphSourceTestJson.graph.lowering, "direct-program-graph");
-assert.equal(directGraphSourceTestJson.testDiscovery.mode, "graph-artifact");
+assert.equal(directGraphSourceTestJson.testDiscovery.mode, "program-graph");
 assert.equal(directGraphSourceTestJson.selectedTests, 1);
 assert.equal(directGraphSourceTestJson.results[0].status, "passed");
 const directGraphSourceShipJson = json(["ship", "--json", "--target", "linux-musl-x64", "--out", directGraphSourceShipPath, graphSourceStoragePath]).body;
@@ -698,7 +698,7 @@ assert.equal(graphCheckJson.view, null);
 const graphCheckOutJson = json(["graph", "check", "--json", "--out", graphCheckViewPath, graphDumpPath], { allowFailure: true });
 assert.notEqual(graphCheckOutJson.code, 0);
 assert.equal(graphCheckOutJson.body.diagnostics[0].message, "graph check does not write generated source views");
-assert.equal(graphCheckOutJson.body.diagnostics[0].expected, "zero graph view --out <file.0> <graph-artifact-or-package>");
+assert.equal(graphCheckOutJson.body.diagnostics[0].expected, "zero graph view --out <file.0> <program-graph-or-package>");
 const graphSizeJson = json(["graph", "size", "--json", "--target", "linux-musl-x64", graphDumpPath]).body;
 assert.equal(graphSizeJson.schemaVersion, 1);
 assert.equal(graphSizeJson.sourceFile, graphDumpPath);
@@ -714,7 +714,7 @@ assert.equal(graphSizeJson.sizeBreakdown.target, "linux-musl-x64");
 assert.equal(graphSizeJson.objectBackend.objectEmission.path, "direct-elf64-object");
 assert.equal(graphSizeJson.artifactPath, null);
 assert(graphSizeJson.compilerCaches.every((cache) => cache.sourceKind === "program-graph" && cache.graphHash === graphDumpJson.graphHash));
-assert.equal(graphSizeJson.compilerCaches.find((cache) => cache.name === "parseTree").invalidatesOn, "graph artifact");
+assert.equal(graphSizeJson.compilerCaches.find((cache) => cache.name === "parseTree").invalidatesOn, "ProgramGraph input");
 assert.equal(graphSizeJson.incrementalInvalidation.sourceKind, "program-graph");
 assert.equal(graphSizeJson.incrementalInvalidation.graphInput.artifact, graphDumpPath);
 assert.equal(graphSizeJson.incrementalInvalidation.graphInput.graphHash, graphDumpJson.graphHash);
@@ -769,7 +769,7 @@ assert.equal(zero(["graph", "test", graphTestDumpPath]).stdout, "1 test(s) ok\n"
 const graphTestOutJson = json(["graph", "test", "--json", "--out", graphCheckViewPath, graphTestDumpPath], { allowFailure: true });
 assert.notEqual(graphTestOutJson.code, 0);
 assert.equal(graphTestOutJson.body.diagnostics[0].message, "graph test does not support --out");
-assert.equal(graphTestOutJson.body.diagnostics[0].expected, "zero graph test [--json] [--filter <name>] [--target <target>] <graph-artifact-or-package>");
+assert.equal(graphTestOutJson.body.diagnostics[0].expected, "zero graph test [--json] [--filter <name>] [--target <target>] <program-graph-or-package>");
 const graphTestJson = json(["graph", "test", "--json", "--filter", "addition", graphTestDumpPath]).body;
 assert.equal(graphTestJson.ok, true);
 assert.equal(graphTestJson.sourceFile, graphTestDumpPath);
@@ -778,7 +778,7 @@ assert.equal(graphTestJson.graph.canonicalSource, false);
 assert.equal(graphTestJson.graph.lowering, "direct-program-graph");
 assert.match(graphTestJson.graph.graphHash, /^graph:[0-9a-f]{16}$/);
 assert.equal(graphTestJson.testBackend, "direct-frontend");
-assert.equal(graphTestJson.testDiscovery.mode, "graph-artifact");
+assert.equal(graphTestJson.testDiscovery.mode, "program-graph");
 assert.equal(graphTestJson.testDiscovery.filter, "addition");
 assert.equal(graphTestJson.selectedTests, 1);
 assert.equal(graphTestJson.results[0].status, "passed");
@@ -845,7 +845,7 @@ assert.equal(directGraphManifestCheckJson.package.name, "graph-manifest-package"
 assert.equal(directGraphManifestCheckJson.package.manifestPath, join(graphManifestPackageDir, "zero.json"));
 assert.notEqual(directGraphManifestCheckJson.package.manifestHash, "0000000000000000");
 assert(directGraphManifestCheckJson.compilerCaches.every((cache) => cache.sourceKind === "program-graph" && cache.graphHash === directGraphManifestCheckJson.graph.graphHash));
-assert.equal(directGraphManifestCheckJson.compilerCaches.find((cache) => cache.name === "parseTree").invalidatesOn, "graph artifact");
+assert.equal(directGraphManifestCheckJson.compilerCaches.find((cache) => cache.name === "parseTree").invalidatesOn, "ProgramGraph input");
 assert.equal(directGraphManifestCheckJson.interfaceFingerprints.sourceKind, "program-graph");
 assert.equal(directGraphManifestCheckJson.interfaceFingerprints.graphHash, directGraphManifestCheckJson.graph.graphHash);
 assert.equal(directGraphManifestCheckJson.incrementalInvalidation.sourceKind, "program-graph");
@@ -928,6 +928,7 @@ assert.equal(directGraphHostLeakJson.body.diagnostics[0].message, "foreign targe
 const graphManifestMissingJson = json(["graph", "check", "--json", "conformance/packages/test-app"], { allowFailure: true });
 assert.equal(graphManifestMissingJson.code, 1);
 assert.equal(graphManifestMissingJson.body.diagnostics[0].message, "zero.json is missing targets.cli.graph");
+assert.equal(graphManifestMissingJson.body.diagnostics[0].expected, "targets.cli.graph pointing at saved ProgramGraph input");
 writeFileSync(graphSizeNoisePatchPath, [
   "zero-program-graph-patch v1",
   `expect graphHash "${graphDumpJson.graphHash}"`,
@@ -1544,7 +1545,7 @@ writeFileSync(graphFailedArtifactPath, [
 ].join("\n"));
 const graphFailedArtifact = json(["graph", "validate", "--json", graphFailedArtifactPath], { allowFailure: true });
 assert(graphFailedArtifact.code);
-assert.equal(graphFailedArtifact.body.diagnostics[0].message, "program graph artifact reports failed validation");
+assert.equal(graphFailedArtifact.body.diagnostics[0].message, "program graph input reports failed validation");
 const graphTrailingArtifactPath = join(outDir, "trailing-content.program-graph");
 writeFileSync(graphTrailingArtifactPath, `${graphDump}\nextra\n`);
 const graphTrailingArtifact = json(["graph", "validate", "--json", graphTrailingArtifactPath], { allowFailure: true });


### PR DESCRIPTION
- Use ProgramGraph input wording in help, docs, and diagnostics
- Align graph command contracts and conformance expectations