### PR TITLE
Cover chained `as` casts in the canonical parser

### DIFF
--- a/conformance/native/pass/explicit-casts.0
+++ b/conformance/native/pass/explicit-casts.0
@@ -25,8 +25,9 @@ pub fn main(world: World) -> Void raises {
     let size: usize = count as usize
     let offset: isize = small as isize
     let sum: u16 = small as u16 + 1 as u16
+    let chained: i32 = big as u8 as i32
     let bag: CastBag = CastBag { byte: big as u8, count: small as u32, size: count as usize, signed: small as isize }
-    if byte == 44 && count == 42 && size == 42 && offset == 42 && sum == 43 && narrow(big) == 44 && widen(small) == 42 && toSize(7) == 7 && bag.byte == 44 {
+    if byte == 44 && count == 42 && size == 42 && offset == 42 && sum == 43 && chained == 44 && narrow(big) == 44 && widen(small) == 42 && toSize(7) == 7 && bag.byte == 44 {
         check world.out.write("explicit casts ok\n")
     }
 }

--- a/native/zero-c/tests/canonical_text_smoke.c
+++ b/native/zero-c/tests/canonical_text_smoke.c
@@ -907,6 +907,22 @@ static void imports_cast_comparisons_without_parentheses(void) {
   z_free_program(&program);
 }
 
+static void parses_chained_as_casts(void) {
+  const char *source =
+    "fn narrow(value: u32) -> i32 {\n"
+    "    return value as u8 as i32\n"
+    "}\n";
+  ZDiag diag = {0};
+  Program program = {0};
+  expect(z_parse_canonical_text_program_source(source, &program, &diag), diag.message);
+  Expr *outer = program.functions.items[0].body.items[0]->expr;
+  expect(outer && outer->kind == EXPR_CAST && strcmp(outer->text, "i32") == 0, "expected outer chained cast to i32");
+  Expr *inner = outer->left;
+  expect(inner && inner->kind == EXPR_CAST && strcmp(inner->text, "u8") == 0, "expected inner chained cast to u8");
+  expect(inner->left && inner->left->kind == EXPR_IDENT && strcmp(inner->left->text, "value") == 0, "expected chained cast to wrap the source operand");
+  z_free_program(&program);
+}
+
 static void expect_program_checks_and_roundtrips(const char *source, const char *label, bool library) {
   ZDiag diag = {0};
   Program program = {0};
@@ -1196,6 +1212,7 @@ int main(int argc, char **argv) {
   imports_decoded_literals_and_prefix_forms();
   imports_call_arguments_with_casts();
   imports_cast_comparisons_without_parentheses();
+  parses_chained_as_casts();
   parses_checks_and_graph_roundtrips_core_program();
   parses_checks_and_graph_roundtrips_library_program();
   parses_checks_and_graph_roundtrips_generic_shape_literal();


### PR DESCRIPTION
## Summary

This PR started as a fix for flat-chained `as` casts (`5 as u8 as i32`) in the **row source parser**. That parser has since been removed in #332 ("Remove row source parser"), which routes all source through the canonical `.0` parser.

I verified that the canonical parser (`canon_parse_expr_prec` in `canonical_text_program.c`) already parses chained casts correctly — its precedence-climbing loop folds each `as` into the previous expression by construction. So rather than fixing a bug, this PR **pins that behavior with the test coverage that the migration dropped**: the deleted row parser had a chained-cast smoke test, the canonical parser inherited the behavior but not the test.

## What's added

- **`canonical_text_smoke.c` → `parses_chained_as_casts`**: asserts the nested AST for `value as u8 as i32` — outer `EXPR_CAST{i32}` wrapping inner `EXPR_CAST{u8}` wrapping the operand. Sits alongside `imports_cast_comparisons_without_parentheses`.
- **`conformance/native/pass/explicit-casts.0`**: a chained `big as u8 as i32` (→ `44`), extending coverage from parsing into typecheck, codegen, and runtime truncation.

## Why it's worth keeping

Single casts and cast-comparisons are tested; flat-chained casts were only ever covered by the deleted row parser's smoke test. This restores that coverage against the parser that's actually shipping, so a future parser refactor can't silently regress it. No production code is touched.

## Test plan

- [x] `npm run canonical-text:test`
- [x] `make -C native/zero-c` clean
- [x] `node conformance/run.mjs` — "conformance ok"
- [x] compiler-metrics ratchet — no violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)
