### PR TITLE
Prepare v0.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Changelog
 
-## 0.1.4
+## 0.2.0
 
 <!-- release:start -->
+
+- Makes canonical `.0` text the native source surface, with a parser, formatter, Program import path, diagnostics, docs, examples, stdlib sources, benchmarks, conformance fixtures, and command snapshots aligned around that format.
+- Promotes ProgramGraph from inspection output into an editable artifact workflow with deterministic dump, validate, view, check, roundtrip, import, patch, build, run, test, size, and package entrypoint support.
+- Adds source-backed graph edits so checked graph patches can rewrite canonical `.0` files while preserving package/import context, std helper context, metadata, and stable graph identities.
+- Expands direct backend coverage with darwin-x64 Mach-O executable support, shared AArch64 ELF/COFF emission, target-readiness reporting, byte-view ABI fixes, and stronger cross-target buildability checks.
+- Adds source-backed `std.path`, `std.str`, and `std.math` modules with docs, examples, Rosetta coverage, and direct target validation.
+- Exposes resolved call-resolution and stdlib helper facts in graph JSON, tightening generic return typing, member call facts, std helper validation, and package cache metadata.
+- Grows Rosetta and compiler smoke coverage, graph command contracts, metrics budgets, CLI docs, skills, and docs tests around the current agent edit loop.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.1.4
 
 - Adopts canonical `.0` text as the current Zero source surface across parsing, import resolution, package manifests, command workflows, docs, fixtures, formatting, and artifact contracts.
 - Rebuilds checker internals around TypeCore, binder-aware unification, generic inference, static interface validation, provenance substitution, and shared call-resolution facts.
@@ -15,8 +31,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.1.3
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -3116,7 +3116,7 @@ assert.equal(depGraphBody.package.resolver.deterministic, true);
 assert.match(depGraphBody.package.lockfile.path, /\.zero\/package-locks\/[0-9a-f]+\.lock\.json/);
 assert(depGraphBody.package.dependencies.some((item) => item.name === "dep-lib" && item.status === "path-resolved" && item.targetCompatible === true));
 assert(depGraphBody.package.dependencies.some((item) => item.name === "remote-tools" && item.status === "registry-reference" && item.version === "1.2.3"));
-assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.1.4");
+assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.2.0");
 assert.equal(depGraphBody.packageCache.cacheKeyInputs.packageVersion, "0.1.0");
 assert.match(depGraphBody.packageCache.cacheKeyInputs.dependencyGraphHash, /^[0-9a-f]{16}$/);
 const depDoc = await execFileAsync(zero, ["doc", "--json", "conformance/packages/dep-app"]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-docs",
   "private": true,
-  "version": "0.1.4",
+  "version": "0.2.0",
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zero Language",
   "description": "Syntax highlighting for the Zero programming language.",
   "publisher": "zero-lang",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "categories": [

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -35,7 +35,7 @@
 #endif
 #include <unistd.h>
 
-#define ZERO_VERSION "0.1.4"
+#define ZERO_VERSION "0.2.0"
 
 #include "embedded_runtime_sources.inc"
 #include "embedded_skills.inc"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-lang-workspace",
   "description": "Workspace for the Zero language docs, native compiler, examples, and editor tooling.",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.1.3",

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -495,11 +495,11 @@ function assertReleaseTargetContract(report, expected) {
 
 const generatedCBytesBeforeReadOnlyCommands = json(["size", "--json", "examples/memory-package"]).body.generatedCBytes;
 
-assert.equal(zero(["--version"]).stdout, "zero 0.1.4\n");
+assert.equal(zero(["--version"]).stdout, "zero 0.2.0\n");
 
 const version = json(["--version", "--json"]).body;
 assert.equal(version.schemaVersion, 1);
-assert.equal(version.version, "0.1.4");
+assert.equal(version.version, "0.2.0");
 assert.equal(version.backend, "zero-c");
 assert.equal(typeof version.host, "string");
 assert(version.targets.includes("darwin-arm64"));
@@ -3711,7 +3711,7 @@ assert.equal(depDoc.package.name, "dep-app");
 assert.equal(depDoc.publicationGate.requiresExamplesForPublicApi, true);
 const depBuild = json(["build", "--json", "--target", "linux-musl-x64", "conformance/packages/dep-app", "--out", join(outDir, "dep-app")]).body;
 assert.equal(depBuild.packageCache.invalidationReasons.includes("dependency graph changed"), true);
-assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.1.4" && item.packageVersion === "0.1.0"), true);
+assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.2.0" && item.packageVersion === "0.1.0"), true);
 const depDevTrace = json(["dev", "--json", "--trace", "--target", "linux-musl-x64", "conformance/packages/dep-app"]).body;
 assert.equal(depDevTrace.trace.requested, true);
 assert.equal(depDevTrace.partialDiagnostics.stable, true);

--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -62,8 +62,8 @@ async function collectSkillMdFiles(dir: string): Promise<string[]> {
 
 describe("native zero CLI", () => {
   it("prints a terse plain version", async () => {
-    assert.equal((await runZero(["--version"])).stdout, "zero 0.1.4\n");
-    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.1.4\n");
+    assert.equal((await runZero(["--version"])).stdout, "zero 0.2.0\n");
+    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.2.0\n");
   });
 
   it("checks directly and rejects removed legacy build flags", async () => {


### PR DESCRIPTION
- Bump workspace, docs, extension, and native compiler versions to 0.2.0.
- Add marked 0.2.0 changelog entry and clear previous release markers.
- Update version-sensitive CLI, conformance, and command-contract expectations.