### PR TITLE
fix(security): use rightmost X-Forwarded-For hop for docs-chat rate limiting

### DIFF
--- a/docs/app/api/docs-chat/route.ts
+++ b/docs/app/api/docs-chat/route.ts
@@ -9,6 +9,7 @@ import {
   docsChatMinuteRateLimit,
   isDocsChatRateLimitConfigured,
 } from "@/lib/rate-limit";
+import { getRateLimitIdentifier } from "@/lib/rate-limit-identifier";
 
 export const maxDuration = 60;
 
@@ -71,12 +72,6 @@ function addCacheControl(messages: ModelMessage[]): ModelMessage[] {
     }
     return message;
   });
-}
-
-function getRateLimitIdentifier(req: Request): string {
-  const forwardedFor = req.headers.get("x-forwarded-for");
-  const realIp = req.headers.get("x-real-ip");
-  return forwardedFor?.split(",")[0]?.trim() || realIp?.trim() || "anonymous";
 }
 
 async function rateLimitRequest(req: Request): Promise<NextResponse | null> {

--- a/docs/lib/rate-limit-identifier.ts
+++ b/docs/lib/rate-limit-identifier.ts
@@ -1,0 +1,35 @@
+/**
+ * Picks a stable identifier for per-client rate limiting.
+ *
+ * `x-forwarded-for` is *appended* by trusted proxies (Vercel, most reverse
+ * proxies) rather than overwritten, so its leftmost value is whatever the
+ * client supplied and the rightmost is the most-recently-appended trusted
+ * hop. Taking the leftmost lets any client send
+ * `X-Forwarded-For: <random>` per request and bypass per-IP rate limits.
+ *
+ * Order of preference:
+ *   1. `x-vercel-forwarded-for` — Vercel-edge-set, single client IP, not
+ *      forwardable by clients.
+ *   2. `x-real-ip` — typically stripped/overwritten by reverse proxies.
+ *   3. `x-forwarded-for` last value — the most-recently-appended hop. The
+ *      leftmost is client-supplied; the rightmost was added by the trusted
+ *      proxy in front of this app, so a client cannot inject past it.
+ *   4. `"anonymous"` — share a quota across unidentified callers rather than
+ *      give each one a private bucket.
+ */
+export function getRateLimitIdentifier(req: Pick<Request, "headers">): string {
+  const vercelForwarded = req.headers.get("x-vercel-forwarded-for")?.trim();
+  if (vercelForwarded) return vercelForwarded;
+
+  const realIp = req.headers.get("x-real-ip")?.trim();
+  if (realIp) return realIp;
+
+  const forwardedFor = req.headers.get("x-forwarded-for");
+  if (forwardedFor) {
+    const parts = forwardedFor.split(",").map((s) => s.trim()).filter(Boolean);
+    const last = parts[parts.length - 1];
+    if (last) return last;
+  }
+
+  return "anonymous";
+}

--- a/docs/src/tests/rate-limit-identifier.test.mjs
+++ b/docs/src/tests/rate-limit-identifier.test.mjs
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+import { describe, it } from "node:test";
+import ts from "typescript";
+
+const docsSiteRoot = resolve(import.meta.dirname, "../..");
+
+function loadModule(relativePath) {
+  const sourcePath = join(docsSiteRoot, relativePath);
+  const source = readFileSync(sourcePath, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2022,
+    },
+    fileName: sourcePath,
+  });
+  const module = { exports: {} };
+  new Function("exports", "module", outputText)(module.exports, module);
+  return module.exports;
+}
+
+function makeReq(headers) {
+  const map = new Map(Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]));
+  return {
+    headers: {
+      get(name) {
+        const value = map.get(name.toLowerCase());
+        return value == null ? null : value;
+      },
+    },
+  };
+}
+
+const { getRateLimitIdentifier } = loadModule("lib/rate-limit-identifier.ts");
+
+describe("getRateLimitIdentifier", () => {
+  it("prefers x-vercel-forwarded-for over everything else", () => {
+    const req = makeReq({
+      "x-vercel-forwarded-for": "203.0.113.10",
+      "x-real-ip": "10.0.0.5",
+      "x-forwarded-for": "1.1.1.1, 198.51.100.1",
+    });
+    assert.equal(getRateLimitIdentifier(req), "203.0.113.10");
+  });
+
+  it("falls back to x-real-ip when vercel header is absent", () => {
+    const req = makeReq({
+      "x-real-ip": "203.0.113.20",
+      "x-forwarded-for": "1.1.1.1, 198.51.100.1",
+    });
+    assert.equal(getRateLimitIdentifier(req), "203.0.113.20");
+  });
+
+  it("uses the LAST x-forwarded-for hop, not the first", () => {
+    // Vercel and most reverse proxies APPEND to X-Forwarded-For; the
+    // rightmost value is what the trusted proxy added, the leftmost is
+    // client-supplied and trivially spoofable. The legacy implementation
+    // took split(',')[0], which let an attacker pick their own bucket
+    // by sending `X-Forwarded-For: <anything>` per request.
+    const req = makeReq({
+      "x-forwarded-for": "1.1.1.1, 198.51.100.1, 203.0.113.30",
+    });
+    assert.equal(getRateLimitIdentifier(req), "203.0.113.30");
+  });
+
+  it("ignores empty entries in x-forwarded-for", () => {
+    const req = makeReq({
+      "x-forwarded-for": "1.1.1.1, ,",
+    });
+    assert.equal(getRateLimitIdentifier(req), "1.1.1.1");
+  });
+
+  it("returns 'anonymous' when no header is set", () => {
+    const req = makeReq({});
+    assert.equal(getRateLimitIdentifier(req), "anonymous");
+  });
+
+  it("returns 'anonymous' when every candidate header is blank", () => {
+    const req = makeReq({
+      "x-vercel-forwarded-for": "  ",
+      "x-real-ip": "",
+      "x-forwarded-for": ", , ",
+    });
+    assert.equal(getRateLimitIdentifier(req), "anonymous");
+  });
+
+  it("regression: a client-supplied X-Forwarded-For does NOT change the bucket", () => {
+    // Same trusted-proxy IP, attacker sends two different leftmost spoofs.
+    // Pre-fix, these produced two different identifiers (bypass). Post-fix,
+    // both resolve to the trusted-proxy-appended rightmost value.
+    const trustedHop = "203.0.113.40";
+
+    const reqA = makeReq({
+      "x-forwarded-for": `1.1.1.1, ${trustedHop}`,
+    });
+    const reqB = makeReq({
+      "x-forwarded-for": `9.9.9.9, ${trustedHop}`,
+    });
+
+    assert.equal(getRateLimitIdentifier(reqA), trustedHop);
+    assert.equal(getRateLimitIdentifier(reqB), trustedHop);
+    assert.equal(getRateLimitIdentifier(reqA), getRateLimitIdentifier(reqB));
+  });
+
+  it("regression: same client cannot rotate buckets via x-vercel-forwarded-for absence", () => {
+    // If somehow x-vercel-forwarded-for and x-real-ip are stripped, the
+    // attacker can still only rotate the LEFTMOST of XFF, never the RIGHTMOST
+    // (which the trusted proxy added). Two requests from the same trusted
+    // proxy with different attacker-leftmost values must collide.
+    const idA = getRateLimitIdentifier(
+      makeReq({ "x-forwarded-for": "attacker-A, trusted-proxy" }),
+    );
+    const idB = getRateLimitIdentifier(
+      makeReq({ "x-forwarded-for": "attacker-B, trusted-proxy" }),
+    );
+    assert.equal(idA, "trusted-proxy");
+    assert.equal(idB, "trusted-proxy");
+  });
+});


### PR DESCRIPTION
## Summary

The docs-chat rate-limit identifier reads the leftmost value of `X-Forwarded-For`, which on Vercel (and most reverse-proxy setups) is the client-supplied portion of the header rather than what the trusted proxy appended. Any client can send `X-Forwarded-For: <random>` on each request to land in a fresh per-minute / per-day rate-limit bucket and bypass the limit entirely — turning the docs-chat AI Gateway / Anthropic spend into a free-token sink for anyone with a script and a list of IPs.

The fix prefers Vercel's `x-vercel-forwarded-for` header (set by the edge with only the original client IP, not client-forwardable), then `x-real-ip`, then falls back to the *rightmost* value in `x-forwarded-for` so the trusted-proxy hop is always the identifier and a client can't inject past it.

## Impact

`docs/app/api/docs-chat/route.ts` enforces per-IP rate limits (`RATE_LIMIT_PER_MINUTE`, default 10; `RATE_LIMIT_PER_DAY`, default 100) via Upstash sliding/fixed windows. The identifier was built from:

```ts
function getRateLimitIdentifier(req: Request): string {
  const forwardedFor = req.headers.get("x-forwarded-for");
  const realIp = req.headers.get("x-real-ip");
  return forwardedFor?.split(",")[0]?.trim() || realIp?.trim() || "anonymous";
}
```

Per [Vercel's edge documentation](https://vercel.com/docs/concepts/edge-network/headers), `X-Forwarded-For` is appended: a request reaching the function with `X-Forwarded-For: 1.1.1.1` from the client arrives as `X-Forwarded-For: 1.1.1.1, <real-client-ip>`. `split(",")[0]` therefore reads the client-supplied portion, so any caller can rotate the leftmost value per request and never hit a limit. Each chat call streams through Vercel AI Gateway → `anthropic/claude-haiku-4.5` with `stepCountIs(5)` and the bash + readFile tools — a sustained sweep would translate directly into API spend on the deployment's account.

There is no auth/data exposure beyond the rate-limit bypass; this is a financial / availability concern.

## Location

`docs/app/api/docs-chat/route.ts:76` (legacy `getRateLimitIdentifier`) → moved to `docs/lib/rate-limit-identifier.ts`.

## Fix

`docs/lib/rate-limit-identifier.ts` extracts a pure identifier picker so it can be unit-tested without pulling in Upstash:

1. `x-vercel-forwarded-for` — Vercel-edge-set, single IP, not forwardable by clients.
2. `x-real-ip` — typically stripped/overwritten by reverse proxies.
3. `x-forwarded-for` *last* value — the most-recently-appended hop. The leftmost is client-supplied; the rightmost is what the trusted proxy in front of this app added, so a client cannot inject past it.
4. `"anonymous"` — share a quota when nothing identifies the caller.

`docs/app/api/docs-chat/route.ts` imports the new helper and drops the inline implementation.

## Verification

```
$ node --test docs/src/tests/rate-limit-identifier.test.mjs docs/src/tests/docs.test.mjs
# tests 16
# suites 3
# pass 16
# fail 0
```

```
$ docs/node_modules/.bin/tsc --noEmit
# exit 0
```

8 new tests cover the spoofing scenarios:
- `x-vercel-forwarded-for` wins over everything else.
- `x-real-ip` fallback when the Vercel header is absent.
- `x-forwarded-for` resolves to the rightmost hop (not the leftmost, the legacy behavior).
- Empty / blank-only entries collapse to `"anonymous"`.
- Two requests from the same trusted proxy with different attacker-leftmost XFF values produce the *same* identifier — the bucket cannot be rotated.

## Detected by

Aeon + manual review (semgrep / trufflehog / osv all clean on this path).
- Severity: medium
- CWE-348 (Use of Less Trusted Source)
- CWE-290 (Authentication Bypass by Spoofing)
- CWE-770 (Allocation of Resources Without Limits)

If you'd prefer a different layout (e.g. inline the helper, drop the test scaffolding, or use a different header order), happy to revise — close this freely.

---
Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
