### PR TITLE
Support direct checksum helpers

### DIFF
--- a/conformance/native/pass/direct-checksum-helpers.0
+++ b/conformance/native/pass/direct-checksum-helpers.0
@@ -1,0 +1,9 @@
+export c fn main() -> i32 {
+    let crc_text: u32 = std.codec.crc32("zero")
+    let crc_bytes: u32 = std.codec.crc32Bytes(std.mem.span("zero hash payload\n"))
+    let hash: u32 = std.crypto.hash32(std.mem.span("message"))
+    if crc_text == 2883514770_u32 && crc_bytes == 1120241454_u32 && hash == 3065852031_u32 {
+        return 0
+    }
+    return 1
+}

--- a/native/zero-c/src/aarch64_direct.c
+++ b/native/zero-c/src/aarch64_direct.c
@@ -532,6 +532,13 @@ static bool a64_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun, c
   return true;
 }
 
+static bool a64_emit_crc32_bytes_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
+  if (!value->left) return a64_diag(diag, "direct AArch64 CRC32 requires a byte view", value->line, value->column, "missing byte view");
+  if (!a64_emit_byte_view_pair_at(text, fun, value->left, 11, 10, frame_size, scratch_slot, ctx, diag)) return false;
+  z_aarch64_emit_crc32_bytes_loop(text, reg);
+  return true;
+}
+
 static bool a64_emit_byte_view_index_load_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, ZAArch64DirectContext *ctx, ZDiag *diag) {
   if (!value->index || !a64_emit_value_to_reg_at(text, fun, value->index, 8, frame_size, scratch_slot, ctx, diag)) return false;
   if (!a64_emit_store_scratch(text, 8, value->index ? value->index->type : IR_TYPE_U32, scratch_slot, value->index, diag)) return false;
@@ -679,6 +686,7 @@ static bool a64_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const Ir
     case IR_VALUE_BYTE_COPY: return a64_emit_byte_copy_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_FILL: return a64_emit_byte_fill_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_VIEW_EQ: return a64_emit_byte_view_eq_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_CRC32_BYTES: return a64_emit_crc32_bytes_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return a64_emit_byte_view_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_INDEX_LOAD: return a64_emit_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     default:

--- a/native/zero-c/src/aarch64_emit.c
+++ b/native/zero-c/src/aarch64_emit.c
@@ -218,8 +218,24 @@ void z_aarch64_emit_add_x_reg_lsl(ZBuf *text, unsigned dst, unsigned lhs, unsign
   z_aarch64_append_u32(text, 0x8b000000u | ((rhs & 31u) << 16) | ((shift & 0x3fu) << 10) | ((lhs & 31u) << 5) | (dst & 31u));
 }
 
+void z_aarch64_emit_and_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs) {
+  z_aarch64_append_u32(text, 0x0a000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+}
+
+void z_aarch64_emit_eor_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs) {
+  z_aarch64_append_u32(text, 0x4a000000u | ((rhs & 31u) << 16) | ((lhs & 31u) << 5) | (dst & 31u));
+}
+
 void z_aarch64_emit_lsr_x_imm(ZBuf *text, unsigned dst, unsigned src, unsigned shift) {
   z_aarch64_append_u32(text, 0xd340fc00u | ((shift & 0x3fu) << 16) | ((src & 31u) << 5) | (dst & 31u));
+}
+
+void z_aarch64_emit_lsr_w_imm(ZBuf *text, unsigned dst, unsigned src, unsigned shift) {
+  z_aarch64_append_u32(text, 0x53007c00u | ((shift & 0x1fu) << 16) | ((src & 31u) << 5) | (dst & 31u));
+}
+
+void z_aarch64_emit_neg_w(ZBuf *text, unsigned dst, unsigned src) {
+  z_aarch64_append_u32(text, 0x4b0003e0u | ((src & 31u) << 16) | (dst & 31u));
 }
 
 void z_aarch64_emit_sub_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs) {
@@ -324,6 +340,39 @@ void z_aarch64_emit_byte_eq_loop(ZBuf *text, unsigned result_reg) {
   z_aarch64_patch_cond19(text, equal, text->len);
   z_aarch64_emit_movz_w(text, result_reg, 1);
   z_aarch64_patch_branch26(text, after_false, text->len);
+}
+
+void z_aarch64_emit_crc32_bytes_loop(ZBuf *text, unsigned result_reg) {
+  z_aarch64_emit_movz_w(text, 8, 0xffffffffu);
+  z_aarch64_emit_movz_w(text, 9, 0);
+  size_t byte_loop = text->len;
+  z_aarch64_emit_cmp_w(text, 9, 10);
+  size_t done = z_aarch64_emit_b_cond_placeholder(text, 2);
+  z_aarch64_emit_add_x_reg(text, 12, 11, 9);
+  z_aarch64_emit_load_b_imm(text, 12, 12, 0);
+  z_aarch64_emit_eor_w_reg(text, 8, 8, 12);
+  z_aarch64_emit_movz_w(text, 13, 8);
+  size_t bit_loop = text->len;
+  z_aarch64_emit_mov_w(text, 14, 8);
+  z_aarch64_emit_movz_w(text, 15, 1);
+  z_aarch64_emit_and_w_reg(text, 14, 14, 15);
+  z_aarch64_emit_neg_w(text, 14, 14);
+  z_aarch64_emit_movz_w(text, 15, 0xedb88320u);
+  z_aarch64_emit_and_w_reg(text, 14, 14, 15);
+  z_aarch64_emit_lsr_w_imm(text, 8, 8, 1);
+  z_aarch64_emit_eor_w_reg(text, 8, 8, 14);
+  z_aarch64_emit_sub_w_imm(text, 13, 13, 1);
+  size_t byte_next = z_aarch64_emit_cbz_w_placeholder(text, 13);
+  size_t bit_back = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_branch26(text, bit_back, bit_loop);
+  z_aarch64_patch_cond19(text, byte_next, text->len);
+  z_aarch64_emit_add_w_imm(text, 9, 9, 1);
+  size_t byte_back = z_aarch64_emit_b_placeholder(text);
+  z_aarch64_patch_branch26(text, byte_back, byte_loop);
+  z_aarch64_patch_cond19(text, done, text->len);
+  z_aarch64_emit_movz_w(text, 14, 0xffffffffu);
+  z_aarch64_emit_eor_w_reg(text, 8, 8, 14);
+  if (result_reg != 8) z_aarch64_emit_mov_w(text, result_reg, 8);
 }
 
 size_t z_aarch64_emit_bl_placeholder(ZBuf *text) {

--- a/native/zero-c/src/aarch64_emit.h
+++ b/native/zero-c/src/aarch64_emit.h
@@ -55,7 +55,11 @@ void z_aarch64_emit_store_h_imm(ZBuf *text, unsigned src, unsigned base, unsigne
 void z_aarch64_emit_add_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_add_x_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_add_x_reg_lsl(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs, unsigned shift);
+void z_aarch64_emit_and_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
+void z_aarch64_emit_eor_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_lsr_x_imm(ZBuf *text, unsigned dst, unsigned src, unsigned shift);
+void z_aarch64_emit_lsr_w_imm(ZBuf *text, unsigned dst, unsigned src, unsigned shift);
+void z_aarch64_emit_neg_w(ZBuf *text, unsigned dst, unsigned src);
 void z_aarch64_emit_sub_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_sub_x_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
 void z_aarch64_emit_mul_w_reg(ZBuf *text, unsigned dst, unsigned lhs, unsigned rhs);
@@ -70,6 +74,7 @@ void z_aarch64_emit_b_offset_words(ZBuf *text, int32_t words);
 void z_aarch64_emit_byte_copy_min_loop(ZBuf *text, unsigned result_reg);
 void z_aarch64_emit_byte_fill_loop(ZBuf *text, unsigned result_reg);
 void z_aarch64_emit_byte_eq_loop(ZBuf *text, unsigned result_reg);
+void z_aarch64_emit_crc32_bytes_loop(ZBuf *text, unsigned result_reg);
 
 size_t z_aarch64_emit_bl_placeholder(ZBuf *text);
 size_t z_aarch64_emit_b_placeholder(ZBuf *text);

--- a/native/zero-c/src/buildability.c
+++ b/native/zero-c/src/buildability.c
@@ -10,7 +10,7 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
       case IR_VALUE_STRING_LITERAL: case IR_VALUE_ARRAY_BYTE_VIEW: case IR_VALUE_BYTE_SLICE: case IR_VALUE_BYTE_VIEW_LEN:
       case IR_VALUE_BYTE_VIEW_INDEX_LOAD: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL: case IR_VALUE_BYTE_VIEW_EQ:
       case IR_VALUE_INDEX_LOAD: case IR_VALUE_MAYBE_HAS: case IR_VALUE_MAYBE_VALUE: case IR_VALUE_MAYBE_BYTE_VIEW_LITERAL:
-      case IR_VALUE_MAYBE_SCALAR_LITERAL: case IR_VALUE_RAND_NEXT_U32:
+      case IR_VALUE_MAYBE_SCALAR_LITERAL: case IR_VALUE_RAND_NEXT_U32: case IR_VALUE_CRC32_BYTES:
         (void)local_set_value;
         return true;
       default:
@@ -25,7 +25,7 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
       case IR_VALUE_BYTE_VIEW_INDEX_LOAD: case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL: case IR_VALUE_BYTE_VIEW_EQ:
       case IR_VALUE_INDEX_LOAD: case IR_VALUE_FIELD_LOAD: case IR_VALUE_CHECK:
       case IR_VALUE_MAYBE_HAS: case IR_VALUE_MAYBE_VALUE: case IR_VALUE_MAYBE_BYTE_VIEW_LITERAL: case IR_VALUE_MAYBE_SCALAR_LITERAL:
-      case IR_VALUE_RAND_NEXT_U32:
+      case IR_VALUE_RAND_NEXT_U32: case IR_VALUE_CRC32_BYTES:
         return true;
       default:
         (void)local_set_value;
@@ -63,8 +63,11 @@ static bool build_value_supported(const ZBuildability *ctx, const IrValue *value
     case IR_VALUE_FS_CLOSE_FILE: case IR_VALUE_FS_EXISTS: case IR_VALUE_FS_REMOVE: case IR_VALUE_FS_RENAME:
     case IR_VALUE_FS_FILE_LEN: case IR_VALUE_FS_MAKE_DIR: case IR_VALUE_FS_REMOVE_DIR: case IR_VALUE_FS_IS_DIR:
     case IR_VALUE_FS_DIR_ENTRY_COUNT: case IR_VALUE_FS_TEMP_NAME: case IR_VALUE_FS_ATOMIC_WRITE:
-    case IR_VALUE_CRC32_BYTES:
       return ctx->backend == Z_DIRECT_BACKEND_ELF64;
+    case IR_VALUE_CRC32_BYTES:
+      return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 ||
+             ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 || ctx->backend == Z_DIRECT_BACKEND_COFF_X64 ||
+             z_build_backend_is_aarch64_direct(ctx->backend);
     case IR_VALUE_BYTE_COPY: case IR_VALUE_BYTE_FILL:
       return ctx->backend == Z_DIRECT_BACKEND_ELF64 || ctx->backend == Z_DIRECT_BACKEND_MACHO64 ||
              ctx->backend == Z_DIRECT_BACKEND_MACHO_X64 || ctx->backend == Z_DIRECT_BACKEND_COFF_X64;

--- a/native/zero-c/src/buildability_value_targets.c
+++ b/native/zero-c/src/buildability_value_targets.c
@@ -176,6 +176,14 @@ static bool build_aarch64_byte_operation(const ZBuildability *ctx, const IrFunct
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
   if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
+  if (value->kind == IR_VALUE_CRC32_BYTES) {
+    if (scratch_slot + 3 >= BUILD_AARCH64_SCRATCH_SLOT_COUNT) {
+      return z_build_diag(ctx, diag, "direct AArch64 CRC32 exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+    }
+    if (!z_build_check_aarch64_byte_view(ctx, fun, value->left, diag)) return false;
+    if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 CRC32 exceeds scratch register spill capacity", diag)) return false;
+    if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_AARCH64_SCRATCH_SLOT_COUNT, "direct AArch64 CRC32 exceeds scratch register spill capacity", diag)) return false;
+  }
   if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
   return true;
 }
@@ -250,6 +258,7 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
       if (!z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_coff_byte_view(ctx, fun, value->right, diag)) return false;
     }
+    if (value->kind == IR_VALUE_CRC32_BYTES && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_coff_byte_view_len(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_coff_byte_view(ctx, fun, value->left, diag)) return false;
@@ -266,6 +275,7 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
       if (!z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
       if (!z_build_check_macho_x64_byte_view(ctx, fun, value->right, diag)) return false;
     }
+    if (value->kind == IR_VALUE_CRC32_BYTES && !z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN && !z_build_check_macho_x64_byte_view_len(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_x64_byte_view(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_LEN || value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD) *skip_left = true;
@@ -301,6 +311,12 @@ bool z_build_check_target_value(const ZBuildability *ctx, const IrFunction *fun,
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && scratch_slot >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O byte-view indexed load exceeds scratch register spill capacity", diag)) return false;
     if (value->kind == IR_VALUE_BYTE_VIEW_INDEX_LOAD && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+    if (value->kind == IR_VALUE_CRC32_BYTES) {
+      if (scratch_slot + 3 >= BUILD_MACHO_SCRATCH_SLOT_COUNT) return z_build_diag(ctx, diag, "direct AArch64 Mach-O CRC32 exceeds scratch register spill capacity", value->line, value->column, "expression too deep");
+      if (!z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
+      if (!build_check_aarch64_byte_view_ptr_spill(ctx, fun, value->left, scratch_slot, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O CRC32 exceeds scratch register spill capacity", diag)) return false;
+      if (!build_check_aarch64_byte_view_len_spill(ctx, fun, value->left, scratch_slot + 1, BUILD_MACHO_SCRATCH_SLOT_COUNT, "direct AArch64 Mach-O CRC32 exceeds scratch register spill capacity", diag)) return false;
+    }
     if ((value->kind == IR_VALUE_FIXED_BUF_ALLOC || value->kind == IR_VALUE_VEC_INIT) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if ((value->kind == IR_VALUE_JSON_PARSE_BYTES || value->kind == IR_VALUE_JSON_VALIDATE_BYTES || value->kind == IR_VALUE_JSON_STREAM_TOKENS_BYTES) && !z_build_check_macho_byte_view(ctx, fun, value->left, diag)) return false;
     if (value->kind == IR_VALUE_HTTP_FETCH) {

--- a/native/zero-c/src/emit_coff.c
+++ b/native/zero-c/src/emit_coff.c
@@ -580,6 +580,13 @@ static bool coff_emit_byte_view_eq_value(ZBuf *text, const IrFunction *fun, cons
   return true;
 }
 
+static bool coff_emit_crc32_bytes_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
+  if (!value->left) return coff_diag_at(diag, "direct COFF CRC32 requires a byte view", value->line, value->column, "missing byte view");
+  if (!coff_emit_byte_view_pair(text, fun, value->left, 11, 9, ctx, diag)) return false;
+  z_x64_emit_crc32_bytes_loop(text, 11, 9);
+  return true;
+}
+
 static bool coff_emit_index_load_value(ZBuf *text, const IrFunction *fun, const IrValue *value, CoffEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return coff_diag_at(diag, "direct COFF indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -655,6 +662,7 @@ static bool coff_emit_value(ZBuf *text, const IrFunction *fun, const IrValue *va
     case IR_VALUE_BYTE_COPY: return coff_emit_byte_copy_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_FILL: return coff_emit_byte_fill_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_EQ: return coff_emit_byte_view_eq_value(text, fun, value, ctx, diag);
+    case IR_VALUE_CRC32_BYTES: return coff_emit_crc32_bytes_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return coff_emit_byte_view_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_INDEX_LOAD: return coff_emit_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_FIELD_LOAD: return coff_emit_field_load_value(text, fun, value, diag);

--- a/native/zero-c/src/emit_elf64.c
+++ b/native/zero-c/src/emit_elf64.c
@@ -1222,30 +1222,7 @@ static bool elf_emit_byte_bulk_value(ZBuf *code, const IrFunction *fun, const Ir
     case IR_VALUE_CRC32_BYTES: {
       if (!value->left) return elf_diag(diag, "direct ELF64 CRC32 requires a byte view", value->line, value->column, "missing byte view");
       if (!elf_emit_byte_view_pair(code, fun, value->left, 6, 9, ctx, diag)) return false;
-      z_x64_emit_mov_eax_u32(code, 0xffffffffu);
-      z_x64_emit_xor_ecx_ecx(code);
-      size_t byte_loop = code->len;
-      z_x64_emit_cmp_reg_reg(code, 1, 9, true);
-      size_t done = z_x64_emit_jcc32_placeholder(code, 0x83);
-      z_x64_emit_movzx_reg32_base_index_u8(code, 2, 6, 1);
-      z_x64_emit_xor_reg_from_reg(code, 0, 2, false);
-      z_x64_emit_mov_reg_u32(code, 8, 8);
-      size_t bit_loop = code->len;
-      z_x64_emit_mov_reg_from_reg(code, 2, 0, false);
-      z_x64_emit_and_reg_i8(code, 2, 1, false);
-      z_x64_emit_neg_reg(code, 2, false);
-      z_x64_emit_and_reg_u32(code, 2, 0xedb88320u, false);
-      z_x64_emit_shr_reg_one(code, 0, false);
-      z_x64_emit_xor_reg_from_reg(code, 0, 2, false);
-      z_x64_emit_dec_r8d(code);
-      size_t bit_back = z_x64_emit_jcc32_placeholder(code, 0x85);
-      z_x64_patch_rel32(code, bit_back, bit_loop);
-      z_x64_emit_inc_rcx(code);
-      size_t byte_back = z_x64_emit_jmp32_placeholder(code, 0xe9);
-      z_x64_patch_rel32(code, byte_back, byte_loop);
-      z_x64_patch_rel32(code, done, code->len);
-      z_x64_append_u8(code, 0x35);
-      z_x64_append_u32(code, 0xffffffffu);
+      z_x64_emit_crc32_bytes_loop(code, 6, 9);
       return true;
     }
     case IR_VALUE_BYTE_COPY: {

--- a/native/zero-c/src/emit_macho64.c
+++ b/native/zero-c/src/emit_macho64.c
@@ -707,6 +707,13 @@ static bool macho_emit_byte_view_eq_to_reg_at(ZBuf *text, const IrFunction *fun,
   return true;
 }
 
+static bool macho_emit_crc32_bytes_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left) return macho_diag_at(diag, "direct AArch64 Mach-O CRC32 requires a byte view", value->line, value->column, "missing byte view");
+  if (!macho_emit_byte_view_pair_at(text, fun, value->left, 11, 10, frame_size, scratch_slot, ctx, diag)) return false;
+  z_aarch64_emit_crc32_bytes_loop(text, reg);
+  return true;
+}
+
 static bool macho_emit_index_load_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return macho_diag_at(diag, "direct AArch64 Mach-O indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -964,6 +971,8 @@ static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const 
       return macho_emit_byte_fill_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_VIEW_EQ:
       return macho_emit_byte_view_eq_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
+    case IR_VALUE_CRC32_BYTES:
+      return macho_emit_crc32_bytes_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD:
       return macho_emit_byte_view_index_load_to_reg_at(text, fun, value, reg, frame_size, scratch_slot, ctx, diag);
     case IR_VALUE_INDEX_LOAD:

--- a/native/zero-c/src/emit_macho_x64.c
+++ b/native/zero-c/src/emit_macho_x64.c
@@ -634,6 +634,13 @@ static bool machx64_emit_byte_view_eq_value(ZBuf *text, const IrFunction *fun, c
   return true;
 }
 
+static bool machx64_emit_crc32_bytes_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
+  if (!value->left) return machx64_diag_at(diag, "direct x86_64 Mach-O CRC32 requires a byte view", value->line, value->column, "missing byte view");
+  if (!machx64_emit_byte_view_pair(text, fun, value->left, 11, 9, ctx, diag)) return false;
+  z_x64_emit_crc32_bytes_loop(text, 11, 9);
+  return true;
+}
+
 static bool machx64_emit_index_load_value(ZBuf *text, const IrFunction *fun, const IrValue *value, MachOEmitContext *ctx, ZDiag *diag) {
   if (value->array_index >= fun->local_len) return machx64_diag_at(diag, "direct x86_64 Mach-O indexed load array is out of range", value->line, value->column, "invalid array local");
   const IrLocal *local = &fun->locals[value->array_index];
@@ -703,6 +710,7 @@ static bool machx64_emit_value(ZBuf *text, const IrFunction *fun, const IrValue 
     case IR_VALUE_BYTE_COPY: return machx64_emit_byte_copy_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_FILL: return machx64_emit_byte_fill_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_EQ: return machx64_emit_byte_view_eq_value(text, fun, value, ctx, diag);
+    case IR_VALUE_CRC32_BYTES: return machx64_emit_crc32_bytes_value(text, fun, value, ctx, diag);
     case IR_VALUE_BYTE_VIEW_INDEX_LOAD: return machx64_emit_byte_view_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_INDEX_LOAD: return machx64_emit_index_load_value(text, fun, value, ctx, diag);
     case IR_VALUE_FIELD_LOAD: return machx64_emit_field_load_value(text, fun, value, diag);

--- a/native/zero-c/src/x64_emit.c
+++ b/native/zero-c/src/x64_emit.c
@@ -479,6 +479,33 @@ void z_x64_emit_byte_eq_loop(ZBuf *buf) {
   z_x64_patch_rel32(buf, after_false, buf->len);
 }
 
+void z_x64_emit_crc32_bytes_loop(ZBuf *buf, unsigned ptr_reg, unsigned len_reg) {
+  z_x64_emit_mov_eax_u32(buf, 0xffffffffu);
+  z_x64_emit_xor_ecx_ecx(buf);
+  size_t byte_loop = buf->len;
+  z_x64_emit_cmp_reg_reg(buf, 1, len_reg, false);
+  size_t done = z_x64_emit_jcc32_placeholder(buf, 0x83);
+  z_x64_emit_movzx_reg32_base_index_u8(buf, 2, ptr_reg, 1);
+  z_x64_emit_xor_reg_from_reg(buf, 0, 2, false);
+  z_x64_emit_mov_reg_u32(buf, 8, 8);
+  size_t bit_loop = buf->len;
+  z_x64_emit_mov_reg_from_reg(buf, 2, 0, false);
+  z_x64_emit_and_reg_i8(buf, 2, 1, false);
+  z_x64_emit_neg_reg(buf, 2, false);
+  z_x64_emit_and_reg_u32(buf, 2, 0xedb88320u, false);
+  z_x64_emit_shr_reg_one(buf, 0, false);
+  z_x64_emit_xor_reg_from_reg(buf, 0, 2, false);
+  z_x64_emit_dec_r8d(buf);
+  size_t bit_back = z_x64_emit_jcc32_placeholder(buf, 0x85);
+  z_x64_patch_rel32(buf, bit_back, bit_loop);
+  z_x64_emit_inc_ecx(buf);
+  size_t byte_back = z_x64_emit_jmp32_placeholder(buf, 0xe9);
+  z_x64_patch_rel32(buf, byte_back, byte_loop);
+  z_x64_patch_rel32(buf, done, buf->len);
+  z_x64_append_u8(buf, 0x35);
+  z_x64_append_u32(buf, 0xffffffffu);
+}
+
 void z_x64_emit_load_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp, bool wide) {
   z_x64_emit_base_index_scale_disp_op(buf, 0x8b, dst_reg, base_reg, index_reg, scale, disp, wide, false);
 }

--- a/native/zero-c/src/x64_emit.h
+++ b/native/zero-c/src/x64_emit.h
@@ -53,6 +53,7 @@ void z_x64_emit_cmp_base_index_u8(ZBuf *buf, unsigned base_reg, unsigned index_r
 void z_x64_emit_byte_copy_min_loop(ZBuf *buf);
 void z_x64_emit_byte_fill_loop(ZBuf *buf);
 void z_x64_emit_byte_eq_loop(ZBuf *buf);
+void z_x64_emit_crc32_bytes_loop(ZBuf *buf, unsigned ptr_reg, unsigned len_reg);
 void z_x64_emit_load_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp, bool wide);
 void z_x64_emit_lea_base_index_scale_disp_reg(ZBuf *buf, unsigned dst_reg, unsigned base_reg, unsigned index_reg, unsigned scale, unsigned disp);
 void z_x64_emit_xor_r8d_r8d(ZBuf *buf);

--- a/scripts/compiler-metrics.mts
+++ b/scripts/compiler-metrics.mts
@@ -26,7 +26,7 @@ const fileBudgets = {
   "native/zero-c/src/buildability_internal.h": { maxLines: 40, maxStrcmpCalls: 0 },
   "native/zero-c/src/buildability_context.c": { maxLines: 185, maxStrcmpCalls: 1 },
   "native/zero-c/src/buildability_targets.c": { maxLines: 190, maxStrcmpCalls: 0 },
-  "native/zero-c/src/buildability_value_targets.c": { maxLines: 355, maxStrcmpCalls: 0 },
+  "native/zero-c/src/buildability_value_targets.c": { maxLines: 371, maxStrcmpCalls: 0 },
   "native/zero-c/src/call_resolve.c": { maxLines: 200, maxStrcmpCalls: 2 },
   "native/zero-c/src/call_resolve.h": { maxLines: 100, maxStrcmpCalls: 0 },
   "native/zero-c/src/canonical_text.c": { maxLines: 1508, maxStrcmpCalls: 0 },
@@ -46,17 +46,17 @@ const fileBudgets = {
   "native/zero-c/src/elf_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.c": { maxLines: 470, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_format.h": { maxLines: 90, maxStrcmpCalls: 0 },
-  "native/zero-c/src/aarch64_direct.c": { maxLines: 1057, maxStrcmpCalls: 1 },
+  "native/zero-c/src/aarch64_direct.c": { maxLines: 1065, maxStrcmpCalls: 1 },
   "native/zero-c/src/aarch64_direct.h": { maxLines: 40, maxStrcmpCalls: 0 },
-  "native/zero-c/src/aarch64_emit.c": { maxLines: 388, maxStrcmpCalls: 0 },
-  "native/zero-c/src/aarch64_emit.h": { maxLines: 82, maxStrcmpCalls: 0 },
-  "native/zero-c/src/emit_macho64.c": { maxLines: 1817, maxStrcmpCalls: 2 },
-  "native/zero-c/src/emit_macho_x64.c": { maxLines: 1426, maxStrcmpCalls: 1 },
+  "native/zero-c/src/aarch64_emit.c": { maxLines: 437, maxStrcmpCalls: 0 },
+  "native/zero-c/src/aarch64_emit.h": { maxLines: 87, maxStrcmpCalls: 0 },
+  "native/zero-c/src/emit_macho64.c": { maxLines: 1826, maxStrcmpCalls: 2 },
+  "native/zero-c/src/emit_macho_x64.c": { maxLines: 1434, maxStrcmpCalls: 1 },
   "native/zero-c/src/macho_emit_state.c": { maxLines: 210, maxStrcmpCalls: 0 },
   "native/zero-c/src/macho_emit_state.h": { maxLines: 90, maxStrcmpCalls: 0 },
   "native/zero-c/src/emit_elf64.c": { maxLines: 2308, maxStrcmpCalls: 3 },
   "native/zero-c/src/emit_elf_aarch64.c": { maxLines: 330, maxStrcmpCalls: 1 },
-  "native/zero-c/src/emit_coff.c": { maxLines: 1290, maxStrcmpCalls: 1 },
+  "native/zero-c/src/emit_coff.c": { maxLines: 1298, maxStrcmpCalls: 1 },
   "native/zero-c/src/emit_coff_aarch64.c": { maxLines: 380, maxStrcmpCalls: 0 },
   "native/zero-c/src/fs.c": { maxLines: 1255, maxStrcmpCalls: 33 },
   "native/zero-c/src/mir_verify.c": { maxLines: 1391, maxStrcmpCalls: 0 },
@@ -99,8 +99,8 @@ const fileBudgets = {
   "native/zero-c/src/type_core.h": { maxLines: 150, maxStrcmpCalls: 0 },
   "native/zero-c/src/unify.c": { maxLines: 500, maxStrcmpCalls: 14 },
   "native/zero-c/src/unify.h": { maxLines: 75, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.c": { maxLines: 825, maxStrcmpCalls: 0 },
-  "native/zero-c/src/x64_emit.h": { maxLines: 115, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.c": { maxLines: 850, maxStrcmpCalls: 0 },
+  "native/zero-c/src/x64_emit.h": { maxLines: 116, maxStrcmpCalls: 0 },
 };
 
 const knownLargeFunctionLimits = new Map([
@@ -116,7 +116,7 @@ const knownLargeFunctionLimits = new Map([
   ["native/zero-c/src/checker.c|static bool expr_reference_provenance(CheckContext *ctx, const Program *program, const Expr *expr, Scope *scope, ValueProvenance *origins) {", 175],
   ["native/zero-c/src/main.c|static int run_tests_direct(const Command *command, const SourceInput *input, const Program *program, const ZTargetInfo *target) {", 151],
   ["native/zero-c/src/checker.c|static bool check_scalar_match(CheckContext *ctx, const Program *program, const Function *fun, const Stmt *stmt, Scope *scope, ZDiag *diag, int loop_depth, const char *match_type) {", 127],
-  ["native/zero-c/src/emit_macho64.c|static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {", 127],
+  ["native/zero-c/src/emit_macho64.c|static bool macho_emit_value_to_reg_at(ZBuf *text, const IrFunction *fun, const IrValue *value, unsigned reg, unsigned frame_size, unsigned scratch_slot, MachOEmitContext *ctx, ZDiag *diag) {", 129],
 ]);
 
 const knownReturnTypeDivergences = new Map();

--- a/scripts/stdlib-target-matrix.mts
+++ b/scripts/stdlib-target-matrix.mts
@@ -8,7 +8,10 @@ import { promisify } from "node:util";
 const execFileAsync = promisify(execFile);
 const zero = "bin/zero";
 const outDir = ".zero/stdlib-target-matrix";
-const fixture = "conformance/native/pass/stdlib-target-neutral.0";
+const fixtures = [
+  "conformance/native/pass/stdlib-target-neutral.0",
+  "conformance/native/pass/direct-checksum-helpers.0",
+];
 const artifactBudgetBytes = 120_000;
 const targets = [
   "darwin-arm64",
@@ -22,6 +25,7 @@ const targets = [
 ];
 
 type MatrixRow = {
+  fixture: string;
   target: string;
   ok: boolean;
   artifactPath: string;
@@ -55,34 +59,40 @@ async function json(args: string[]) {
 }
 
 const rows: MatrixRow[] = [];
-for (const target of targets) {
-  const ext = target.includes("win32") ? ".obj" : ".o";
-  const artifactPath = join(outDir, `stdlib-target-neutral-${target}${ext}`);
-  const result = await json(["build", "--json", "--emit", "obj", "--target", target, fixture, "--out", artifactPath]);
-  const diagnostic = result.body?.diagnostics?.[0];
-  const row: MatrixRow = {
-    target,
-    ok: result.code === 0 && result.body?.ok !== false,
-    artifactPath,
-    artifactBytes: result.body?.artifactBytes ?? 0,
-    generatedCBytes: result.body?.generatedCBytes ?? -1,
-    directObjectEmitter: result.body?.releaseTargetContract?.directObjectEmitter,
-    diagnostic: diagnostic ? `${diagnostic.code}: ${diagnostic.message}` : undefined,
-  };
-  rows.push(row);
-  assert.equal(row.ok, true, `${target} failed: ${row.diagnostic ?? result.stderr}`);
-  assert.equal(row.generatedCBytes, 0, `${target} used generated C fallback`);
-  assert.ok(row.artifactBytes > 0, `${target} did not produce an object artifact`);
-  assert.ok(row.artifactBytes <= artifactBudgetBytes, `${target} object artifact exceeded ${artifactBudgetBytes} bytes`);
+for (const fixture of fixtures) {
+  const stem = fixture.split("/").pop()?.replace(/\.0$/, "") ?? "fixture";
+  for (const target of targets) {
+    const ext = target.includes("win32") ? ".obj" : ".o";
+    const artifactPath = join(outDir, `${stem}-${target}${ext}`);
+    const result = await json(["build", "--json", "--emit", "obj", "--target", target, fixture, "--out", artifactPath]);
+    const diagnostic = result.body?.diagnostics?.[0];
+    const row: MatrixRow = {
+      fixture,
+      target,
+      ok: result.code === 0 && result.body?.ok !== false,
+      artifactPath,
+      artifactBytes: result.body?.artifactBytes ?? 0,
+      generatedCBytes: result.body?.generatedCBytes ?? -1,
+      directObjectEmitter: result.body?.releaseTargetContract?.directObjectEmitter,
+      diagnostic: diagnostic ? `${diagnostic.code}: ${diagnostic.message}` : undefined,
+    };
+    rows.push(row);
+    assert.equal(row.ok, true, `${fixture} ${target} failed: ${row.diagnostic ?? result.stderr}`);
+    assert.equal(row.generatedCBytes, 0, `${fixture} ${target} used generated C fallback`);
+    assert.ok(row.artifactBytes > 0, `${fixture} ${target} did not produce an object artifact`);
+    assert.ok(row.artifactBytes <= artifactBudgetBytes, `${fixture} ${target} object artifact exceeded ${artifactBudgetBytes} bytes`);
+  }
 }
 
-const hostRun = await execFileAsync(zero, ["run", fixture]);
-assert.equal(hostRun.stdout, "", "target-neutral stdlib fixture should run silently");
+for (const fixture of fixtures) {
+  const hostRun = await execFileAsync(zero, ["run", fixture]);
+  assert.equal(hostRun.stdout, "", `${fixture} should run silently`);
+}
 
 const report = {
   schemaVersion: 1,
   ok: rows.every((row) => row.ok),
-  fixture,
+  fixtures,
   artifactBudgetBytes,
   targets: rows,
 };


### PR DESCRIPTION
- Add CRC32 byte-loop emission for AArch64 and x64 direct backends
- Mark public checksum helpers buildable across supported targets
- Add conformance and target-matrix coverage