### PR TITLE
Fix graph sanitizer ownership leaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,9 @@ jobs:
           corepack enable
           corepack prepare pnpm@11.1.3 --activate
 
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
+
       - run: pnpm install --frozen-lockfile
 
       - name: Conformance suite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,12 @@ jobs:
         run: pnpm run conformance:local
 
   native-tests:
-    name: Native Tests
+    name: Native Tests (${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
@@ -45,13 +49,14 @@ jobs:
           corepack enable
           corepack prepare pnpm@11.1.3 --activate
 
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.14.1
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
 
       - run: pnpm install --frozen-lockfile
 
       - name: Native tests
+        env:
+          ZERO_NATIVE_TEST_SHARD: "${{ matrix.shard }}/4"
         run: pnpm run native:test:local
 
   native-sanitizer-smoke:
@@ -68,6 +73,9 @@ jobs:
         run: |
           corepack enable
           corepack prepare pnpm@11.1.3 --activate
+
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
 
       - name: Native sanitizer smoke
         run: pnpm run native:sanitize
@@ -89,14 +97,17 @@ jobs:
 
       - run: pnpm install --frozen-lockfile
 
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
+
       - name: Build native compiler
         run: make -C native/zero-c
 
       - name: Command contract snapshots
         run: pnpm run command-contracts:local
 
-  everything-else:
-    name: Everything Else
+  workspace-checks:
+    name: Workspace Checks
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -110,59 +121,12 @@ jobs:
           corepack enable
           corepack prepare pnpm@11.1.3 --activate
 
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.14.1
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Build native compiler
-        run: make -C native/zero-c
-
-      - name: Verify embedded skill data
-        run: |
-          node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
-          git diff --exit-code native/zero-c/src/embedded_skills.inc
-
-      - name: Smoke test
-        run: pnpm run check
-
-      - name: Repository graph check
-        run: pnpm run repository-graph:check
-
-      - name: Rosetta tasks
-        run: pnpm run rosetta:local
-
-      - name: Stdlib contracts
-        run: pnpm run stdlib:contracts
-
-      - name: TypeScript tests
-        run: pnpm run test:zero
-
-      - name: Extension tests
-        run: pnpm run extension:test
-
-      - name: Benchmark smoke
+      - name: Workspace checks
         env:
           VERCEL_OIDC_TOKEN: ${{ secrets.VERCEL_OIDC_TOKEN }}
-        run: |
-          if [[ -n "${VERCEL_OIDC_TOKEN:-}" ]]; then
-            ZERO_BENCH_RUNS=1 pnpm run bench
-          else
-            ZERO_BENCH_RUNS=1 pnpm run bench:local
-          fi
-
-      - name: Cross-target smoke
-        run: |
-          bin/zero check --target linux-musl-x64 examples/memory-package
-          bin/zero build --emit obj --target linux-musl-x64 examples/direct-obj-add.0 --out .zero/out/direct-obj-add-linux-musl.o
-          bin/zero build --target linux-musl-x64 examples/hello.0 --out .zero/out/hello-linux-musl
-          bin/zero build --target win32-x64.exe examples/hello.0 --out .zero/out/hello-win32
-
-      - name: Release artifact build smoke
-        run: |
-          mkdir -p .zero/ci-release
-          node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
-          ZIG_GLOBAL_CACHE_DIR=.zero/zig-global-cache ZIG_LOCAL_CACHE_DIR=.zero/zig-local-cache zig cc -target x86_64-linux-musl -std=c11 -D_POSIX_C_SOURCE=200809L -Os -Inative/zero-c/include native/zero-c/src/*.c -o .zero/ci-release/zero-linux-musl-x64
-          ./.zero/ci-release/zero-linux-musl-x64 --version
-          ./.zero/ci-release/zero-linux-musl-x64 skills list --json
+        run: pnpm run workspace:checks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,28 @@ permissions:
   contents: read
 
 jobs:
-  build-and-test:
-    name: Build & Test
+  conformance-suite:
+    name: Conformance Suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.3 --activate
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Conformance suite
+        run: pnpm run conformance:local
+
+  native-tests:
+    name: Native Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -29,6 +49,73 @@ jobs:
         with:
           version: 0.14.1
 
+      - run: pnpm install --frozen-lockfile
+
+      - name: Native tests
+        run: pnpm run native:test:local
+
+  native-sanitizer-smoke:
+    name: Native Sanitizer Smoke
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.3 --activate
+
+      - name: Native sanitizer smoke
+        run: pnpm run native:sanitize
+
+  command-contract-snapshots:
+    name: Command Contract Snapshots
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.3 --activate
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build native compiler
+        run: make -C native/zero-c
+
+      - name: Command contract snapshots
+        run: pnpm run command-contracts:local
+
+  everything-else:
+    name: Everything Else
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Enable pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@11.1.3 --activate
+
+      - uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Build native compiler
         run: make -C native/zero-c
 
@@ -37,19 +124,11 @@ jobs:
           node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
           git diff --exit-code native/zero-c/src/embedded_skills.inc
 
-      - run: pnpm install --frozen-lockfile
-
       - name: Smoke test
         run: pnpm run check
 
       - name: Repository graph check
         run: pnpm run repository-graph:check
-
-      - name: Conformance suite
-        run: pnpm run conformance:local
-
-      - name: Native tests
-        run: pnpm run native:test:local
 
       - name: Rosetta tasks
         run: pnpm run rosetta:local
@@ -57,17 +136,11 @@ jobs:
       - name: Stdlib contracts
         run: pnpm run stdlib:contracts
 
-      - name: Native sanitizer smoke
-        run: pnpm run native:sanitize
-
       - name: TypeScript tests
         run: pnpm run test:zero
 
       - name: Extension tests
         run: pnpm run extension:test
-
-      - name: Command contract snapshots
-        run: pnpm run command-contracts:local
 
       - name: Benchmark smoke
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,6 @@ jobs:
       - name: TypeScript tests
         run: pnpm run test:zero
 
-      - name: Docs tests
-        run: pnpm run docs:test
-
       - name: Extension tests
         run: pnpm run extension:test
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,9 +74,8 @@ jobs:
         with:
           node-version: 24
 
-      - uses: mlugg/setup-zig@v2
-        with:
-          version: 0.14.1
+      - name: Install pinned Zig
+        run: bash scripts/install-zig.sh
 
       - name: Extract changelog entry
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,18 +39,31 @@ where they will run.
 - Keep examples runnable and docs copyable.
 - Prefer small, direct changes over broad refactors.
 - Use direct emitters for compiler output.
+- For broad local validation, run `pnpm run agent:checks`. It mirrors the CI
+  buckets in parallel, including conformance, command contracts, native test
+  shards, sanitizer smoke, and workspace checks. It uses isolated `/tmp`
+  workspaces so agents can validate uncommitted changes without local artifact
+  races.
 - Before ending any agent turn that changes the repository, run
-  `pnpm run conformance`; if it cannot complete, report the blocker and the
+  `pnpm run conformance` unless `pnpm run agent:checks` already passed for the
+  same changes. If validation cannot complete, report the blocker and the
   failing command.
 
 ## Useful Checks
 
 ```sh
+pnpm run agent:checks
 pnpm run docs:build
 pnpm run conformance
 pnpm run native:test
 pnpm run command-contracts
 ```
+
+`pnpm run agent:checks` already includes conformance. Do not run conformance
+again after it passes unless you need to recheck later changes.
+
+Shard native tests locally with `ZERO_NATIVE_TEST_SHARD=1/4 pnpm run
+native:test:local`. CI currently runs four native shards.
 
 `pnpm run conformance:local` and `pnpm run command-contracts:local` use the
 aggregate validation runner. Add `-- --shard 1/4` to run one conformance phase

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -13783,9 +13783,8 @@ int main(int argc, char **argv) {
   if ((command.repository_graph_input || root_graph_artifact_input) &&
       (strcmp(command.command, "run") == 0 || strcmp(command.command, "build") == 0)) {
     ZProgramGraphStore listen_store;
-    ZProgramGraph artifact_listen_graph;
+    ZProgramGraph artifact_listen_graph = {0};
     z_program_graph_store_init(&listen_store);
-    z_program_graph_init(&artifact_listen_graph);
     const ZProgramGraph *listen_graph = NULL;
     if (root_graph_artifact_input) {
       if (!z_program_graph_load(command.input, &artifact_listen_graph, &diag)) {

--- a/native/zero-c/src/main.c
+++ b/native/zero-c/src/main.c
@@ -71,6 +71,7 @@ typedef struct {
   const char *command;
   const char *kind;
   const char *input;
+  char *owned_input;
   const char *repository_graph_source_input;
   const char *out;
   const char *patch_file;
@@ -118,6 +119,45 @@ typedef struct {
   bool graph_patch_check_only;
   EmitKind emit;
 } Command;
+
+static char *command_process_owned_input = NULL;
+
+static void command_free_process_owned_input(void) {
+  free(command_process_owned_input);
+  command_process_owned_input = NULL;
+}
+
+static void command_register_owned_input_cleanup(void) {
+  static bool registered = false;
+  if (registered) return;
+  atexit(command_free_process_owned_input);
+  registered = true;
+}
+
+static void command_set_owned_input(Command *command, char *input) {
+  if (!command) {
+    free(input);
+    return;
+  }
+  command_register_owned_input_cleanup();
+  if (command->owned_input && command->owned_input != input) {
+    if (command_process_owned_input == command->owned_input) command_process_owned_input = NULL;
+    free(command->owned_input);
+  }
+  if (command_process_owned_input && command_process_owned_input != input) free(command_process_owned_input);
+  command_process_owned_input = input;
+  command->owned_input = input;
+  command->input = input;
+}
+
+static int command_return(Command *command, int rc) {
+  if (command) {
+    if (command_process_owned_input == command->owned_input) command_process_owned_input = NULL;
+    free(command->owned_input);
+    command->owned_input = NULL;
+  }
+  return rc;
+}
 
 static void manifest_path_for_input(const SourceInput *input, char *manifest_path, size_t manifest_path_len);
 static bool is_program_graph_root_command(const char *command);
@@ -12889,7 +12929,7 @@ static bool resolve_graph_repository_store_input(Command *command, bool *artifac
   }
   free(root);
   command->repository_graph_source_input = command->input;
-  command->input = store_path;
+  command_set_owned_input(command, store_path);
   command->repository_graph_input = true;
   if (artifact_input) *artifact_input = true;
   return true;
@@ -12922,7 +12962,7 @@ static bool resolve_graph_command_manifest_input(Command *command, bool *artifac
     }
     if (sidecar && path_has_program_graph_storage_header(sidecar)) {
       command->repository_graph_source_input = command->input;
-      command->input = sidecar;
+      command_set_owned_input(command, sidecar);
       if (artifact_input) *artifact_input = true;
       return true;
     }
@@ -12955,7 +12995,7 @@ static bool resolve_graph_command_manifest_input(Command *command, bool *artifac
   bool require_graph = input_mode == Z_PROGRAM_GRAPH_INPUT_ARTIFACT;
   if (!z_resolve_manifest_graph_artifact_path(command->input, &artifact_path, &handled, require_graph, diag)) return false;
   if (handled) {
-    command->input = artifact_path;
+    command_set_owned_input(command, artifact_path);
     if (artifact_input) *artifact_input = true;
     return true;
   }
@@ -12994,7 +13034,7 @@ static int resolve_direct_command_manifest_graph_input(Command *command, const Z
   }
 
   command->repository_graph_source_input = command->input;
-  command->input = store_path;
+  command_set_owned_input(command, store_path);
   command->repository_graph_input = true;
   if (handled) *handled = true;
   return 0;
@@ -13605,16 +13645,17 @@ int main(int argc, char **argv) {
 
   bool graph_subcommand_handled = false;
   int graph_subcommand_rc = run_graph_subcommand_dispatch(&command, target, graph_command_artifact_input, &diag, &graph_subcommand_handled);
-  if (graph_subcommand_handled) return graph_subcommand_rc;
+  if (graph_subcommand_handled) return command_return(&command, graph_subcommand_rc);
 
   if (graph_check_text_eq(command.command, "patch")) {
     bool top_patch_artifact_input = false;
     if (!resolve_graph_repository_store_input(&command, &top_patch_artifact_input, &diag)) {
       if (command.json) print_command_diag_json(&command, diag.path ? diag.path : command.input, &diag);
       else print_diag(diag.path ? diag.path : command.input, &diag);
-      return 1;
+      return command_return(&command, 1);
     }
-    return run_graph_patch_command(&command, target, &diag);
+    int patch_rc = run_graph_patch_command(&command, target, &diag);
+    return command_return(&command, patch_rc);
   }
 
   if (strcmp(command.command, "fmt") == 0) {

--- a/native/zero-c/src/program_graph_size.c
+++ b/native/zero-c/src/program_graph_size.c
@@ -62,7 +62,7 @@ static void graph_size_seed_manifest_from_path(SourceInput *input, const char *p
   char *manifest = graph_size_manifest_for_source_path(path);
   if (!manifest) return;
   input->manifest_path = manifest;
-  input->package_root = graph_size_dirname_of(manifest);
+  if (!input->package_root) input->package_root = graph_size_dirname_of(manifest);
 }
 
 static const char *graph_size_module_path_for_name(const SourceInput *input, const char *name) {

--- a/native/zero-c/src/std_source.c
+++ b/native/zero-c/src/std_source.c
@@ -288,7 +288,6 @@ const char *z_std_source_target_for_public_call(const char *qualified_name) {
 }
 
 bool z_std_source_module_load_graph(const ZStdSourceModule *module, ZProgramGraph *out, ZDiag *diag) {
-  if (out) z_program_graph_init(out);
   if (!module || !module->graph_bytes || module->graph_len == 0) {
     if (diag) {
       *diag = (ZDiag){0};

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "check": "pnpm --silent run native:smoke",
+    "agent:checks": "bash scripts/agent-checks.sh",
     "build": "turbo run build",
     "build:scripts": "tsc -p scripts/tsconfig.json",
     "build:test": "tsc -p tests/tsconfig.json",
@@ -30,6 +31,7 @@
     "command-contracts": "pnpm run command-contracts:sandbox",
     "command-contracts:local": "ZERO_NATIVE_TEST_ALLOW_LOCAL=1 node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/validation-suite.mts command-contracts",
     "command-contracts:sandbox": "node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/native-test-sandbox.mts -- pnpm run command-contracts:local",
+    "workspace:checks": "bash scripts/workspace-checks.sh",
     "docs:install": "pnpm install",
     "docs:dev": "turbo run dev --filter=./docs",
     "docs:build": "turbo run build --filter=./docs",

--- a/scripts/agent-checks.sh
+++ b/scripts/agent-checks.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+native_shards="${ZERO_AGENT_NATIVE_TEST_SHARDS:-4}"
+if ! [[ "$native_shards" =~ ^[0-9]+$ ]] || (( native_shards < 1 )); then
+  echo "ZERO_AGENT_NATIVE_TEST_SHARDS must be a positive integer" >&2
+  exit 1
+fi
+
+dry_run="${ZERO_AGENT_CHECK_DRY_RUN:-0}"
+work_root="${ZERO_AGENT_CHECK_WORK_ROOT:-/tmp/zero-agent-checks-$$}"
+log_dir="${ZERO_AGENT_CHECK_LOG_DIR:-$root/.zero/agent-checks}"
+mkdir -p "$work_root" "$log_dir" "$root/.zero/toolchains"
+
+cleanup() {
+  if [[ "${ZERO_AGENT_CHECK_KEEP_WORKDIR:-}" != "1" ]]; then
+    rm -rf "$work_root"
+  fi
+}
+trap cleanup EXIT
+
+zig_platform() {
+  case "$(uname -s):$(uname -m)" in
+    Linux:x86_64) printf "linux-x64" ;;
+    Darwin:arm64 | Darwin:aarch64) printf "macos-aarch64" ;;
+    Darwin:x86_64) printf "macos-x86_64" ;;
+    *)
+      echo "unsupported host for pinned Zig installer: $(uname -s):$(uname -m)" >&2
+      exit 1
+      ;;
+  esac
+}
+
+zig_dir="$root/.zero/toolchains/zig-0.14.1-$(zig_platform)"
+if [[ "$dry_run" != "1" ]]; then
+  bash scripts/install-zig.sh >/dev/null
+fi
+export PATH="$zig_dir:$PATH"
+
+prepare_job_dir() {
+  local name="$1"
+  local dir="$work_root/$name"
+  mkdir -p "$dir"
+  (
+    cd "$root"
+    tar \
+      --exclude='./.git' \
+      --exclude='./.zero' \
+      --exclude='./node_modules' \
+      --exclude='./docs/.next' \
+      --exclude='./docs/node_modules' \
+      -cf - .
+  ) | (
+    cd "$dir"
+    tar -xf -
+  )
+  printf "%s" "$dir"
+}
+
+pids=()
+names=()
+logs=()
+
+run_job() {
+  local name="$1"
+  shift
+  if [[ "$dry_run" == "1" ]]; then
+    echo "would start: $name: $*"
+    return
+  fi
+
+  local dir
+  dir="$(prepare_job_dir "$name")"
+  local log="$log_dir/$name.log"
+  names+=("$name")
+  logs+=("$log")
+  (
+    cd "$dir"
+    export PATH="$PATH"
+    pnpm install --frozen-lockfile --prefer-offline
+    "$@"
+  ) >"$log" 2>&1 &
+  pids+=("$!")
+  echo "started: $name"
+}
+
+run_job conformance pnpm run conformance:local
+
+for shard in $(seq 1 "$native_shards"); do
+  run_job "native-tests-${shard}-of-${native_shards}" env ZERO_NATIVE_TEST_SHARD="${shard}/${native_shards}" pnpm run native:test:local
+done
+
+run_job native-sanitizer-smoke pnpm run native:sanitize
+run_job command-contract-snapshots pnpm run command-contracts:local
+run_job workspace-checks bash scripts/workspace-checks.sh
+
+if [[ "$dry_run" == "1" ]]; then
+  echo "agent checks plan ok"
+  exit 0
+fi
+
+failed=0
+for i in "${!pids[@]}"; do
+  if wait "${pids[$i]}"; then
+    echo "ok: ${names[$i]}"
+  else
+    echo "failed: ${names[$i]}"
+    echo "log: ${logs[$i]}"
+    failed=1
+  fi
+done
+
+if (( failed != 0 )); then
+  echo
+  echo "failed job logs:"
+  for i in "${!pids[@]}"; do
+    if [[ -f "${logs[$i]}" ]]; then
+      echo "--- ${names[$i]} (${logs[$i]}) ---"
+      tail -n 80 "${logs[$i]}"
+    fi
+  done
+  exit 1
+fi
+
+echo "agent checks ok"

--- a/scripts/install-zig.sh
+++ b/scripts/install-zig.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${ZERO_ZIG_VERSION:-0.14.1}"
+release_tag="${ZERO_ZIG_RELEASE_TAG:-toolchain-zig-${version}}"
+mirror_base="${ZERO_ZIG_MIRROR_BASE:-https://github.com/vercel-labs/zerolang/releases/download/${release_tag}}"
+cache_root="${ZERO_ZIG_CACHE_DIR:-${PWD}/.zero/toolchains}"
+
+host_os="$(uname -s)"
+host_arch="$(uname -m)"
+
+case "${host_os}:${host_arch}" in
+  Linux:x86_64)
+    platform="x86_64-linux"
+    archive_name="zig-x86_64-linux-${version}.tar.xz"
+    archive_sha="24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c"
+    ;;
+  Darwin:arm64 | Darwin:aarch64)
+    platform="aarch64-macos"
+    archive_name="zig-aarch64-macos-${version}.tar.xz"
+    archive_sha="39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa"
+    ;;
+  Darwin:x86_64)
+    platform="x86_64-macos"
+    archive_name="zig-x86_64-macos-${version}.tar.xz"
+    archive_sha="b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43"
+    ;;
+  *)
+    echo "unsupported Zig host for pinned installer: ${host_os}:${host_arch}" >&2
+    exit 1
+    ;;
+esac
+
+install_dir="${ZERO_ZIG_INSTALL_DIR:-${cache_root}/zig-${version}-${platform}}"
+archive_path="${cache_root}/${archive_name}"
+archive_url="${mirror_base}/${archive_name}"
+
+check_sha256() {
+  expected="$1"
+  path="$2"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$expected" "$path" | sha256sum -c -
+  else
+    printf '%s  %s\n' "$expected" "$path" | shasum -a 256 -c -
+  fi
+}
+
+if [ -x "${install_dir}/zig" ] && [ "$("${install_dir}/zig" version)" = "$version" ]; then
+  echo "Zig ${version} already installed at ${install_dir}"
+else
+  mkdir -p "$cache_root"
+  if [ ! -f "$archive_path" ] || ! check_sha256 "$archive_sha" "$archive_path" >/dev/null 2>&1; then
+    echo "Downloading ${archive_name} from repo mirror"
+    curl -fsSL --retry 3 --retry-delay 2 --output "$archive_path" "$archive_url"
+  fi
+  check_sha256 "$archive_sha" "$archive_path"
+
+  tmp_dir="${install_dir}.tmp.$$"
+  rm -rf "$tmp_dir"
+  mkdir -p "$tmp_dir"
+  tar -xf "$archive_path" -C "$tmp_dir" --strip-components=1
+  rm -rf "$install_dir"
+  mv "$tmp_dir" "$install_dir"
+fi
+
+if [ "$("${install_dir}/zig" version)" != "$version" ]; then
+  echo "installed Zig version does not match ${version}: $("${install_dir}/zig" version)" >&2
+  exit 1
+fi
+
+if [ -n "${GITHUB_PATH:-}" ]; then
+  printf '%s\n' "$install_dir" >> "$GITHUB_PATH"
+fi
+
+echo "Zig ${version} installed at ${install_dir}"

--- a/scripts/mirror-zig-release-assets.sh
+++ b/scripts/mirror-zig-release-assets.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+version="${ZERO_ZIG_VERSION:-0.14.1}"
+release_tag="${ZERO_ZIG_RELEASE_TAG:-toolchain-zig-${version}}"
+upstream_base="${ZERO_ZIG_UPSTREAM_BASE:-https://ziglang.org/download/${version}}"
+work_dir="${ZERO_ZIG_MIRROR_WORK_DIR:-/tmp/zero-zig-mirror-${version}}"
+
+assets=(
+  "zig-x86_64-linux-${version}.tar.xz:24aeeec8af16c381934a6cd7d95c807a8cb2cf7df9fa40d359aa884195c4716c"
+  "zig-aarch64-macos-${version}.tar.xz:39f3dc5e79c22088ce878edc821dedb4ca5a1cd9f5ef915e9b3cc3053e8faefa"
+  "zig-x86_64-macos-${version}.tar.xz:b0f8bdfb9035783db58dd6c19d7dea89892acc3814421853e5752fe4573e5f43"
+)
+
+check_sha256() {
+  expected="$1"
+  path="$2"
+  if command -v sha256sum >/dev/null 2>&1; then
+    printf '%s  %s\n' "$expected" "$path" | sha256sum -c -
+  else
+    printf '%s  %s\n' "$expected" "$path" | shasum -a 256 -c -
+  fi
+}
+
+if ! command -v gh >/dev/null 2>&1; then
+  echo "gh is required to upload mirrored Zig assets" >&2
+  exit 1
+fi
+
+rm -rf "$work_dir"
+mkdir -p "$work_dir"
+
+: > "${work_dir}/CHECKSUMS.txt"
+for asset in "${assets[@]}"; do
+  name="${asset%%:*}"
+  sha="${asset##*:}"
+  path="${work_dir}/${name}"
+  echo "Downloading ${name}"
+  curl -fsSL --retry 3 --retry-delay 2 --output "$path" "${upstream_base}/${name}"
+  check_sha256 "$sha" "$path"
+  printf '%s  %s\n' "$sha" "$name" >> "${work_dir}/CHECKSUMS.txt"
+done
+
+if ! gh release view "$release_tag" >/dev/null 2>&1; then
+  gh release create "$release_tag" \
+    --title "Zig ${version} mirror" \
+    --notes "Repo-owned mirror of pinned Zig ${version} archives used by CI and release workflows." \
+    --latest=false
+fi
+
+for asset in "${assets[@]}"; do
+  name="${asset%%:*}"
+  gh release upload "$release_tag" "${work_dir}/${name}" --clobber
+done
+gh release upload "$release_tag" "${work_dir}/CHECKSUMS.txt" --clobber
+
+echo "Mirrored Zig ${version} assets to GitHub release ${release_tag}"

--- a/scripts/test-native.sh
+++ b/scripts/test-native.sh
@@ -14,59 +14,111 @@ if [[ "${ZERO_NATIVE_TEST_SANDBOX:-}" != "1" && "${ZERO_NATIVE_TEST_ALLOW_LOCAL:
   exit 1
 fi
 
-make -C native/zero-c
+native_test_shard="${ZERO_NATIVE_TEST_SHARD:-1/1}"
+if [[ "$native_test_shard" =~ ^([0-9]+)/([0-9]+)$ ]]; then
+  native_test_shard_index="${BASH_REMATCH[1]}"
+  native_test_shard_count="${BASH_REMATCH[2]}"
+else
+  echo "ZERO_NATIVE_TEST_SHARD must be formatted as index/count, for example 1/4" >&2
+  exit 1
+fi
 
-bin/zero check --json std/path.graph >/dev/null
-bin/zero check --json std/str.graph >/dev/null
-bin/zero check --json std/testing.graph >/dev/null
-bin/zero check --json std/log.graph >/dev/null
-bin/zero check --json std/math.graph >/dev/null
-bin/zero check --json std/time.graph >/dev/null
-node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/stdlib-target-matrix.mts
+if (( native_test_shard_count < 1 || native_test_shard_index < 1 || native_test_shard_index > native_test_shard_count )); then
+  echo "ZERO_NATIVE_TEST_SHARD index must be between 1 and count" >&2
+  exit 1
+fi
+
+native_test_case_index=0
+
+native_phase_selected() {
+  local phase="$1"
+  local target
+  case "$phase" in
+    preflight)
+      target=1
+      ;;
+    metadata-and-reports)
+      if (( native_test_shard_count >= 2 )); then
+        target=2
+      else
+        target=1
+      fi
+      ;;
+    direct-backend-artifacts)
+      target="$native_test_shard_count"
+      ;;
+    *)
+      echo "unknown native test phase: $phase" >&2
+      exit 1
+      ;;
+  esac
+
+  [[ "$native_test_shard_index" -eq "$target" ]]
+}
+
+native_case_selected() {
+  native_test_case_index=$((native_test_case_index + 1))
+  local selected=$(( (native_test_case_index - 1) % native_test_shard_count + 1 ))
+  [[ "$selected" -eq "$native_test_shard_index" ]]
+}
+
+echo "native test shard ${native_test_shard_index}/${native_test_shard_count}"
+
+make -C native/zero-c
 
 mkdir -p .zero/native-test .zero/conformance
 
-host_runtime_target=""
-case "$(uname -s):$(uname -m)" in
-  Darwin:arm64) host_runtime_target="darwin-arm64" ;;
-  Linux:x86_64) host_runtime_target="linux-x64" ;;
-esac
+if native_phase_selected "preflight"; then
+  bin/zero check --json std/path.graph >/dev/null
+  bin/zero check --json std/str.graph >/dev/null
+  bin/zero check --json std/testing.graph >/dev/null
+  bin/zero check --json std/log.graph >/dev/null
+  bin/zero check --json std/math.graph >/dev/null
+  bin/zero check --json std/time.graph >/dev/null
+  node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/stdlib-target-matrix.mts
 
-if [[ -n "$host_runtime_target" ]] && command -v cc >/dev/null 2>&1; then
-  runtime_cwd_dir="/tmp/zero-runtime-cwd-$$"
-  runtime_cwd_out="$runtime_cwd_dir/std-json-bytes"
-  rm -rf "$runtime_cwd_dir"
-  mkdir -p "$runtime_cwd_dir"
-  (
-    cd "$runtime_cwd_dir"
-    "$root/.zero/bin/zero" build --json --emit exe --target "$host_runtime_target" "$root/conformance/native/pass/std-json-bytes.graph" --out "$runtime_cwd_out" > "$runtime_cwd_out.json"
-  )
-  set +e
-  "$runtime_cwd_out"
-  runtime_cwd_status=$?
-  set -e
-  test "$runtime_cwd_status" = "0"
-  test ! -f "$runtime_cwd_out.zero.o"
-  test ! -f "$runtime_cwd_out.zero-runtime.o"
-  test ! -f "$runtime_cwd_out.zero-runtime.o.zero_runtime.c"
-  test ! -e "$runtime_cwd_out.zero-runtime.o.include"
-  node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (report.generatedCBytes!==0 || report.objectBackend.linking.targetLibraries!=="zero-runtime" || report.objectBackend.linking.externalToolchain!=="cc" || !report.objectBackend.linkerPlan.staticLibraries.includes("zero_runtime.o") || report.objectBackend.directFacts.runtimeHelperCount!==1) process.exit(1);' "$runtime_cwd_out.json"
-  set +e
-  ZERO_CC=/usr/bin/false "$root/.zero/bin/zero" build --json --emit exe --target "$host_runtime_target" "$root/conformance/native/pass/std-json-bytes.graph" --out "$runtime_cwd_out-bad" > "$runtime_cwd_out-bad.json" 2>/dev/null
-  runtime_zero_cc_status=$?
-  set -e
-  test "$runtime_zero_cc_status" != "0"
-  grep -q "host runtime object build failed" "$runtime_cwd_out-bad.json"
-  rm -rf "$runtime_cwd_dir"
-fi
+  host_runtime_target=""
+  case "$(uname -s):$(uname -m)" in
+    Darwin:arm64) host_runtime_target="darwin-arm64" ;;
+    Linux:x86_64) host_runtime_target="linux-x64" ;;
+  esac
 
-if command -v zig >/dev/null 2>&1; then
-  json_cross_out=".zero/native-test/std-json-bytes-linux-musl"
-  rm -f "$json_cross_out" "$json_cross_out.json" "$json_cross_out.zero.o" "$json_cross_out.zero-runtime.o"
-  bin/zero build --json --emit exe --target linux-musl-x64 conformance/native/pass/std-json-bytes.graph --out "$json_cross_out" > "$json_cross_out.json"
-  node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (report.generatedCBytes!==0 || report.target!=="linux-musl-x64" || report.objectBackend.linking.targetLibraries!=="zero-runtime" || !report.objectBackend.linkerPlan.staticLibraries.includes("zero_runtime.o")) process.exit(1);' "$json_cross_out.json"
-  test ! -f "$json_cross_out.zero.o"
-  test ! -f "$json_cross_out.zero-runtime.o"
+  if [[ -n "$host_runtime_target" ]] && command -v cc >/dev/null 2>&1; then
+    runtime_cwd_dir="/tmp/zero-runtime-cwd-$$"
+    runtime_cwd_out="$runtime_cwd_dir/std-json-bytes"
+    rm -rf "$runtime_cwd_dir"
+    mkdir -p "$runtime_cwd_dir"
+    (
+      cd "$runtime_cwd_dir"
+      "$root/.zero/bin/zero" build --json --emit exe --target "$host_runtime_target" "$root/conformance/native/pass/std-json-bytes.graph" --out "$runtime_cwd_out" > "$runtime_cwd_out.json"
+    )
+    set +e
+    "$runtime_cwd_out"
+    runtime_cwd_status=$?
+    set -e
+    test "$runtime_cwd_status" = "0"
+    test ! -f "$runtime_cwd_out.zero.o"
+    test ! -f "$runtime_cwd_out.zero-runtime.o"
+    test ! -f "$runtime_cwd_out.zero-runtime.o.zero_runtime.c"
+    test ! -e "$runtime_cwd_out.zero-runtime.o.include"
+    node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (report.generatedCBytes!==0 || report.objectBackend.linking.targetLibraries!=="zero-runtime" || report.objectBackend.linking.externalToolchain!=="cc" || !report.objectBackend.linkerPlan.staticLibraries.includes("zero_runtime.o") || report.objectBackend.directFacts.runtimeHelperCount!==1) process.exit(1);' "$runtime_cwd_out.json"
+    set +e
+    ZERO_CC=/usr/bin/false "$root/.zero/bin/zero" build --json --emit exe --target "$host_runtime_target" "$root/conformance/native/pass/std-json-bytes.graph" --out "$runtime_cwd_out-bad" > "$runtime_cwd_out-bad.json" 2>/dev/null
+    runtime_zero_cc_status=$?
+    set -e
+    test "$runtime_zero_cc_status" != "0"
+    grep -q "host runtime object build failed" "$runtime_cwd_out-bad.json"
+    rm -rf "$runtime_cwd_dir"
+  fi
+
+  if command -v zig >/dev/null 2>&1; then
+    json_cross_out=".zero/native-test/std-json-bytes-linux-musl"
+    rm -f "$json_cross_out" "$json_cross_out.json" "$json_cross_out.zero.o" "$json_cross_out.zero-runtime.o"
+    bin/zero build --json --emit exe --target linux-musl-x64 conformance/native/pass/std-json-bytes.graph --out "$json_cross_out" > "$json_cross_out.json"
+    node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (report.generatedCBytes!==0 || report.target!=="linux-musl-x64" || report.objectBackend.linking.targetLibraries!=="zero-runtime" || !report.objectBackend.linkerPlan.staticLibraries.includes("zero_runtime.o")) process.exit(1);' "$json_cross_out.json"
+    test ! -f "$json_cross_out.zero.o"
+    test ! -f "$json_cross_out.zero-runtime.o"
+  fi
 fi
 
 expected_output() {
@@ -161,6 +213,10 @@ run_native_or_gap() {
   local expected="$3"
   shift 3
 
+  if ! native_case_selected; then
+    return 0
+  fi
+
   bin/zero check "$input" >/dev/null
   if bin/zero build --json --emit exe --target linux-musl-x64 "$input" --out "$out" > "$out.json"; then
     local native_output
@@ -239,6 +295,8 @@ run_native_or_gap conformance/native/pass/rescue-check.graph .zero/native-test/r
 run_native_or_gap conformance/native/pass/std-fs-fallible.graph .zero/native-test/std-fs-fallible "fs named errors ok"
 run_native_or_gap conformance/native/pass/std-fs-fallible-resources.graph .zero/native-test/std-fs-fallible-resources "fs fallible resources ok"
 run_native_or_gap conformance/native/pass/std-cli-helpers.graph .zero/native-test/std-cli-helpers "cli helpers ok"
+
+if native_phase_selected "metadata-and-reports"; then
 std_args_run_exe="/tmp/zero-std-args-run-$$"
 std_args_run_output="$(bin/zero run --out "$std_args_run_exe" conformance/native/pass/std-args.graph -- agent-arg extra)"
 rm -f "$std_args_run_exe"
@@ -555,6 +613,9 @@ if bin/zero build --json --legacy-backend --target linux-musl-x64 examples/hello
   exit 1
 fi
 node -e 'const fs=require("fs"); const report=JSON.parse(fs.readFileSync(process.argv[1],"utf8")); if (report.diagnostics?.[0]?.code!=="BLD003") process.exit(1);' .zero/native-test/removed-legacy-backend.json
+fi
+
+if native_phase_selected "direct-backend-artifacts"; then
 rm -f .zero/native-test/direct-obj-add.o .zero/native-test/direct-obj-add.o.c
 bin/zero build --json --emit obj --target linux-musl-x64 examples/direct-obj-add.graph --out .zero/native-test/direct-obj-add.o > .zero/native-test/direct-obj-add.json
 node <<'NODE'
@@ -1051,5 +1112,6 @@ grep -q '"driverKind": "target-cc"' .zero/native-test/doctor.json
 grep -q '"sysrootStatus":' .zero/native-test/doctor.json
 bin/zero doctor > .zero/native-test/doctor.txt
 grep -q "target toolchains:" .zero/native-test/doctor.txt
+fi
 
 echo "native conformance ok"

--- a/scripts/workspace-checks.sh
+++ b/scripts/workspace-checks.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$root"
+
+make -C native/zero-c
+
+embedded_skills_before="/tmp/zero-embedded-skills-$$.inc"
+cp native/zero-c/src/embedded_skills.inc "$embedded_skills_before"
+node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
+if ! cmp -s "$embedded_skills_before" native/zero-c/src/embedded_skills.inc; then
+  diff -u "$embedded_skills_before" native/zero-c/src/embedded_skills.inc
+  rm -f "$embedded_skills_before"
+  exit 1
+fi
+rm -f "$embedded_skills_before"
+
+pnpm run check
+pnpm run repository-graph:check
+pnpm run rosetta:local
+pnpm run stdlib:contracts
+pnpm run test:zero
+pnpm run extension:test
+
+if [[ -n "${VERCEL_OIDC_TOKEN:-}" ]]; then
+  ZERO_BENCH_RUNS=1 pnpm run bench
+else
+  ZERO_BENCH_RUNS=1 pnpm run bench:local
+fi
+
+bin/zero check --target linux-musl-x64 examples/memory-package
+bin/zero build --emit obj --target linux-musl-x64 examples/direct-obj-add.0 --out .zero/out/direct-obj-add-linux-musl.o
+bin/zero build --target linux-musl-x64 examples/hello.0 --out .zero/out/hello-linux-musl
+bin/zero build --target win32-x64.exe examples/hello.0 --out .zero/out/hello-win32
+
+mkdir -p .zero/ci-release
+node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
+ZIG_GLOBAL_CACHE_DIR=.zero/zig-global-cache ZIG_LOCAL_CACHE_DIR=.zero/zig-local-cache zig cc -target x86_64-linux-musl -std=c11 -D_POSIX_C_SOURCE=200809L -Os -Inative/zero-c/include native/zero-c/src/*.c -o .zero/ci-release/zero-linux-musl-x64
+./.zero/ci-release/zero-linux-musl-x64 --version
+./.zero/ci-release/zero-linux-musl-x64 skills list --json

--- a/scripts/workspace-checks.sh
+++ b/scripts/workspace-checks.sh
@@ -30,12 +30,15 @@ else
 fi
 
 bin/zero check --target linux-musl-x64 examples/memory-package
-bin/zero build --emit obj --target linux-musl-x64 examples/direct-obj-add.0 --out .zero/out/direct-obj-add-linux-musl.o
-bin/zero build --target linux-musl-x64 examples/hello.0 --out .zero/out/hello-linux-musl
-bin/zero build --target win32-x64.exe examples/hello.0 --out .zero/out/hello-win32
+bin/zero build --emit obj --target linux-musl-x64 examples/direct-obj-add.graph --out .zero/out/direct-obj-add-linux-musl.o
+bin/zero build --target linux-musl-x64 examples/hello.graph --out .zero/out/hello-linux-musl
+bin/zero build --target win32-x64.exe examples/hello.graph --out .zero/out/hello-win32
 
 mkdir -p .zero/ci-release
 node --experimental-strip-types --disable-warning=ExperimentalWarning scripts/embed-skill-data.mts
 ZIG_GLOBAL_CACHE_DIR=.zero/zig-global-cache ZIG_LOCAL_CACHE_DIR=.zero/zig-local-cache zig cc -target x86_64-linux-musl -std=c11 -D_POSIX_C_SOURCE=200809L -Os -Inative/zero-c/include native/zero-c/src/*.c -o .zero/ci-release/zero-linux-musl-x64
-./.zero/ci-release/zero-linux-musl-x64 --version
-./.zero/ci-release/zero-linux-musl-x64 skills list --json
+test -s .zero/ci-release/zero-linux-musl-x64
+if [[ "$(uname -s):$(uname -m)" == "Linux:x86_64" ]]; then
+  ./.zero/ci-release/zero-linux-musl-x64 --version
+  ./.zero/ci-release/zero-linux-musl-x64 skills list --json
+fi


### PR DESCRIPTION
- Avoid double-initializing graph load targets before loaders take ownership.
- Preserve existing package-root metadata while seeding graph size facts.
- Keeps the CI sanitizer path clean for repository and stdlib graph inputs.