### PR TITLE
Prepare v0.3.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,19 @@
 # Changelog
 
-## 0.3.1
+## 0.3.2
 
 <!-- release:start -->
+
+- Adds `break` and `continue` support to the direct backend and `zero test`, lowering both through typed MIR and all direct emitters with conformance coverage and required runtime checks.
+- Speeds up graph validation with indexed node-hash tables, a reusable adjacency index, and deduplicated store validation, making `zero import` on large programs roughly 12x faster.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.3.1
 
 - Hardens compiler, runtime, and toolchain I/O boundaries with checked file reads and writes, directory rejection, atomic output staging, safer executable finalization, mapped-MIR and binary graph parser validation, and regular-file checks for generated compiler/linker outputs.
 - Removes remaining shell-based native execution surfaces in favor of argv-based process helpers, safer tool resolution, guarded child setup, validated compiler overrides, and explicit metrics coverage for process and shell-call regressions.
@@ -14,8 +25,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.3.0
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -4681,7 +4681,7 @@ assert.equal(depGraphBody.package.resolver.deterministic, true);
 assert.match(depGraphBody.package.lockfile.path, /\.zero\/package-locks\/[0-9a-f]+\.lock\.json/);
 assert(depGraphBody.package.dependencies.some((item) => item.name === "dep-lib" && item.status === "path-resolved" && item.targetCompatible === true));
 assert(depGraphBody.package.dependencies.some((item) => item.name === "remote-tools" && item.status === "registry-reference" && item.version === "1.2.3"));
-assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.3.1");
+assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.3.2");
 assert.equal(depGraphBody.packageCache.cacheKeyInputs.packageVersion, "0.1.0");
 assert.match(depGraphBody.packageCache.cacheKeyInputs.dependencyGraphHash, /^[0-9a-f]{16}$/);
 const depDoc = await execFileAsync(zero, ["doc", "--json", "conformance/packages/dep-app"]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-docs",
   "private": true,
-  "version": "0.3.1",
+  "version": "0.3.2",
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zero Language",
   "description": "Syntax highlighting for the Zero programming language.",
   "publisher": "zero-lang",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "type": "module",
   "categories": [

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -6,7 +6,7 @@
 
 #include "zero_contracts.h"
 
-#define ZERO_VERSION "0.3.1"
+#define ZERO_VERSION "0.3.2"
 
 typedef struct ZTargetInfo ZTargetInfo;
 typedef struct ZProgramGraph ZProgramGraph;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-lang-workspace",
   "description": "Workspace for the Zero language docs, native compiler, examples, and editor tooling.",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.1.3",

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -876,11 +876,11 @@ function directExeEmitterForTarget(target: string) {
 
 const generatedCBytesBeforeReadOnlyCommands = json(["size", "--json", "examples/memory-package"]).body.generatedCBytes;
 
-assert.equal(zero(["--version"]).stdout, "zero 0.3.1\n");
+assert.equal(zero(["--version"]).stdout, "zero 0.3.2\n");
 
 const version = json(["--version", "--json"]).body;
 assert.equal(version.schemaVersion, 1);
-assert.equal(version.version, "0.3.1");
+assert.equal(version.version, "0.3.2");
 assert.equal(version.backend, "zero-c");
 assert.equal(typeof version.host, "string");
 assert(version.targets.includes("darwin-arm64"));
@@ -6114,7 +6114,7 @@ assert.equal(depDoc.package.name, "dep-app");
 assert.equal(depDoc.publicationGate.requiresExamplesForPublicApi, true);
 const depBuild = json(["build", "--json", "--target", "linux-musl-x64", "conformance/packages/dep-app", "--out", join(outDir, "dep-app")]).body;
 assert.equal(depBuild.packageCache.invalidationReasons.includes("dependency graph changed"), true);
-assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.3.1" && item.packageVersion === "0.1.0"), true);
+assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.3.2" && item.packageVersion === "0.1.0"), true);
 const depDevTrace = json(["dev", "--json", "--trace", "--target", "linux-musl-x64", "conformance/packages/dep-app"]).body;
 assert.equal(depDevTrace.trace.requested, true);
 assert.equal(depDevTrace.partialDiagnostics.stable, true);

--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -62,8 +62,8 @@ async function collectSkillMdFiles(dir: string): Promise<string[]> {
 
 describe("native zero CLI", () => {
   it("prints a terse plain version", async () => {
-    assert.equal((await runZero(["--version"])).stdout, "zero 0.3.1\n");
-    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.3.1\n");
+    assert.equal((await runZero(["--version"])).stdout, "zero 0.3.2\n");
+    assert.equal((await runNativeZero(["--version"])).stdout, "zero 0.3.2\n");
   });
 
   it("checks directly and rejects removed legacy build flags", async () => {


### PR DESCRIPTION
## Summary

- Bump workspace, docs, extension, compiler, and contract version strings from 0.3.1 to 0.3.2.
- Add the marked 0.3.2 changelog entry covering direct backend break/continue support and the graph validation indexing speedup, moving release markers from 0.3.1.
- Align CLI, command-contract, and conformance version assertions with the new version.