### PR TITLE
evals: discrimination checks for --fixture (negative fixtures)

### DIFF
--- a/evals/src/cases.ts
+++ b/evals/src/cases.ts
@@ -18,6 +18,17 @@ export interface EvalServerCheck {
   expectedStderr?: string;
 }
 
+// A near-miss source that the case's gates MUST reject. Used by `--fixture`
+// to prove a case discriminates (rejects wrong answers), not only that the
+// golden fixture passes. `expectGate` documents which gate is expected to
+// catch it: "stdout"/"run" (run output), "pattern" (requiredSourcePatterns),
+// or "check" (compiler check).
+export interface NegativeFixture {
+  label: string;
+  source: string;
+  expectGate: "stdout" | "pattern" | "check" | "run";
+}
+
 export interface EvalCase {
   id: string;
   title: string;
@@ -33,6 +44,7 @@ export interface EvalCase {
   expectedStdout: string;
   expectedStderr?: string;
   requiredSourcePatterns: RegExp[];
+  negativeFixtures?: NegativeFixture[];
 }
 
 interface RosettaChallenge {
@@ -115,6 +127,18 @@ const baseEvalCases: EvalCase[] = [
       /world\.out\.write/,
       /hello from zero/,
     ],
+    negativeFixtures: [
+      {
+        label: "missing-trailing-newline",
+        source: [
+          "pub fn main(world: World) -> Void raises {",
+          "    check world.out.write(\"hello from zero\")",
+          "}",
+          "",
+        ].join("\n"),
+        expectGate: "stdout",
+      },
+    ],
   },
   {
     id: "fibonacci",
@@ -161,6 +185,31 @@ const baseEvalCases: EvalCase[] = [
       /World/,
       /world\.out\.write/,
       /fib sequence: 0 1 1 2 3 5 8 13 21 34 55/,
+    ],
+    negativeFixtures: [
+      {
+        // Drops the `fib(10) == 55` term from the verification guard. The run
+        // still prints the same line, so only the per-value requiredSourcePattern
+        // can catch it — proving those asserts are load-bearing.
+        label: "drops-fib10-verification",
+        source: [
+          "fn fib(n: u32) -> u32 {",
+          "    if n <= 1 {",
+          "        return n",
+          "    }",
+          "    return fib(n - 1) + fib(n - 2)",
+          "}",
+          "",
+          "pub fn main(world: World) -> Void raises {",
+          "    let ok: Bool = fib(0) == 0 && fib(1) == 1 && fib(2) == 1 && fib(3) == 2 && fib(4) == 3 && fib(5) == 5 && fib(6) == 8 && fib(7) == 13 && fib(8) == 21 && fib(9) == 34",
+          "    if ok {",
+          "        check world.out.write(\"fib sequence: 0 1 1 2 3 5 8 13 21 34 55\\n\")",
+          "    }",
+          "}",
+          "",
+        ].join("\n"),
+        expectGate: "pattern",
+      },
     ],
   },
 ];
@@ -291,6 +340,74 @@ const agentScaleEvalCases: EvalCase[] = [
       /fn\s+subtract/,
       /fn\s+multiply/,
       /usage: zero run \. -- <add\|subtract\|multiply\|help> <x> <y>/,
+    ],
+    negativeFixtures: [
+      {
+        // `multiply` returns x - y instead of x * y; help and the other
+        // commands are correct. Passes the help happy-path and every source
+        // pattern (fn multiply still exists), so only the multi-command
+        // runChecks can catch it — proving coverage isn't met by one route.
+        label: "multiply-returns-subtraction",
+        source: [
+          "fn add(x: u32, y: u32) -> u32 {",
+          "    return x + y",
+          "}",
+          "",
+          "fn subtract(x: u32, y: u32) -> u32 {",
+          "    return x - y",
+          "}",
+          "",
+          "fn multiply(x: u32, y: u32) -> u32 {",
+          "    return x - y",
+          "}",
+          "",
+          "pub fn main(world: World) -> Void raises {",
+          "    if std.cli.argEquals(1, \"help\") {",
+          `        check world.out.write(${JSON.stringify(scaleCliUsage)})`,
+          "        return",
+          "    }",
+          "    let x: Maybe<u32> = std.args.parseU32(2)",
+          "    let y: Maybe<u32> = std.args.parseU32(3)",
+          "    if !x.has || !y.has {",
+          `        check world.out.write(${JSON.stringify(scaleCliUsage)})`,
+          "        return",
+          "    }",
+          "    if std.cli.argEquals(1, \"add\") {",
+          "        let result: u32 = add(x.value, y.value)",
+          "        var out: [10]u8 = [0_u8; 10]",
+          "        let text: Maybe<Span<u8>> = std.fmt.u32(out, result)",
+          "        if text.has {",
+          "            check world.out.write(text.value)",
+          "            check world.out.write(\"\\n\")",
+          "        }",
+          "        return",
+          "    }",
+          "    if std.cli.argEquals(1, \"subtract\") {",
+          "        let result: u32 = subtract(x.value, y.value)",
+          "        var out: [10]u8 = [0_u8; 10]",
+          "        let text: Maybe<Span<u8>> = std.fmt.u32(out, result)",
+          "        if text.has {",
+          "            check world.out.write(text.value)",
+          "            check world.out.write(\"\\n\")",
+          "        }",
+          "        return",
+          "    }",
+          "    if std.cli.argEquals(1, \"multiply\") {",
+          "        let result: u32 = multiply(x.value, y.value)",
+          "        var out: [10]u8 = [0_u8; 10]",
+          "        let text: Maybe<Span<u8>> = std.fmt.u32(out, result)",
+          "        if text.has {",
+          "            check world.out.write(text.value)",
+          "            check world.out.write(\"\\n\")",
+          "        }",
+          "        return",
+          "    }",
+          `    check world.out.write(${JSON.stringify(scaleCliUsage)})`,
+          "}",
+          "",
+        ].join("\n"),
+        expectGate: "run",
+      },
     ],
   },
   {

--- a/evals/src/run.ts
+++ b/evals/src/run.ts
@@ -380,6 +380,16 @@ async function runCase(
     evalCase,
     validationDurationMs,
   );
+  const negativeFixtureResults =
+    options.fixture && !isPackageEvalCase(evalCase)
+      ? await evaluateNegativeFixtures(evalCase, caseDir)
+      : [];
+  const negativeFixtureFailures = negativeFixtureResults
+    .filter((negativeResult) => !negativeResult.rejected)
+    .map(
+      (negativeResult) =>
+        `${negativeResult.label}: not rejected by any gate (case does not discriminate)`,
+    );
   const passed =
     agentRun.error === null &&
     check.code === 0 &&
@@ -388,10 +398,14 @@ async function runCase(
     budgetFailures.length === 0 &&
     patternFailures.length === 0 &&
     responseFormatFailures.length === 0 &&
-    agentRequirementFailures.length === 0;
+    agentRequirementFailures.length === 0 &&
+    negativeFixtureFailures.length === 0;
 
   if (!passed && !error) {
-    error = failureReason({
+    error =
+      negativeFixtureFailures.length > 0
+        ? negativeFixtureFailures.join("; ")
+        : failureReason({
       run,
       build,
       runFailures,
@@ -438,6 +452,7 @@ async function runCase(
     sourcePatternFailures: patternFailures,
     responseFormatFailures,
     agentRequirementFailures,
+    negativeFixtures: negativeFixtureResults,
     error,
   };
 
@@ -671,6 +686,53 @@ async function validateSourceLocally(
     }
   }
   return { check, build, runs, remoteSourcePath: null, sourceText: source };
+}
+
+interface NegativeFixtureResult {
+  label: string;
+  expectGate: string;
+  rejected: boolean;
+  gatesFailed: string[];
+  caughtByExpectedGate: boolean;
+}
+
+// In --fixture mode, run each negative fixture through the same local
+// validation path as the golden and assert it is REJECTED by at least one
+// gate. A negative that passes every gate means the case's gates are too weak
+// to discriminate a wrong answer (a silent non-discriminating eval).
+async function evaluateNegativeFixtures(
+  evalCase: EvalCase,
+  caseDir: string,
+): Promise<NegativeFixtureResult[]> {
+  const negatives = evalCase.negativeFixtures ?? [];
+  const results: NegativeFixtureResult[] = [];
+  for (const [index, negative] of negatives.entries()) {
+    const dir = join(caseDir, `negative-${index}`);
+    await mkdir(dir, { recursive: true });
+    const sourcePath = join(dir, "candidate.0");
+    const source = extractZeroSource(negative.source);
+    await writeFile(sourcePath, source);
+    const validation = await validateSourceLocally(evalCase, sourcePath, source);
+    const gatesFailed: string[] = [];
+    if (validation.check.code !== 0) gatesFailed.push("check");
+    if ((validation.build?.code ?? 0) !== 0) gatesFailed.push("build");
+    if (
+      sourcePatternFailures(source, evalCase.requiredSourcePatterns).length > 0
+    ) {
+      gatesFailed.push("pattern");
+    }
+    if (runResultFailures(validation.runs).length > 0) gatesFailed.push("run");
+    // "stdout" mismatches surface through the run-result comparison.
+    const expectedGate = negative.expectGate === "stdout" ? "run" : negative.expectGate;
+    results.push({
+      label: negative.label,
+      expectGate: negative.expectGate,
+      rejected: gatesFailed.length > 0,
+      gatesFailed,
+      caughtByExpectedGate: gatesFailed.includes(expectedGate),
+    });
+  }
+  return results;
 }
 
 async function validateSourceInSandbox(


### PR DESCRIPTION
Implements #403.

## What

Adds an optional `negativeFixtures` field to `EvalCase`: near-miss sources the case's gates MUST reject. In `--fixture` mode each negative runs through the same local validation path as the golden; the case fails if any negative is *not* rejected by at least one gate — surfacing cases whose gates are too weak to discriminate a wrong answer.

## Three base-case negatives

- **hello-world** — drops the trailing `\n` → caught by the stdout/run comparison.
- **fibonacci** — drops the `fib(10) == 55` verification term (the run still prints the same line) → caught by `requiredSourcePatterns`, proving the per-value asserts are load-bearing.
- **scale-multi-command-cli** — `multiply` returns `x - y` with `help` and the other commands correct → caught by the `multiply 6 7 → 42` runCheck, proving multi-command coverage isn't met by the happy path.

## Verified locally

All three goldens still pass and each negative is rejected by its expected gate. A self-test (injecting a *valid* source as a negative) correctly fails the case with "not rejected by any gate", confirming the check is not a no-op.

## Direction (not in this PR)

These negatives are hand-written. A natural extension is to *generate* near-misses by mutating the golden with a few rules (mutation-testing flavor), so each case proves its own discrimination automatically. Happy to discuss whether that's wanted before building it.

Scope: TS harness + eval methodology only; no compiler changes.
