### PR TITLE
refactor(zero-c): consolidate duplicated dynamic-array grow helpers (#390)

### DIFF
--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -1061,6 +1061,31 @@ Z_RET_OWNED void *z_checked_malloc(size_t size);
 Z_RET_OWNED void *z_checked_calloc(size_t count, size_t item_size);
 Z_RET_OWNED void *z_checked_reallocarray(Z_SINK Z_OPTIONAL void *ptr, size_t count, size_t item_size);
 size_t z_grow_capacity(size_t current, size_t required, size_t initial);
+
+/* Shared dynamic-array grow helper. Ensures room for one more element, growing
+ * via z_grow_capacity + z_checked_reallocarray when the slot is full. Replaces
+ * the per-file copies that previously lived in ir.c, program_graph_lower.c, and
+ * checker.c. */
+static inline void *z_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
+  if (len + 1 > *cap) {
+    *cap = z_grow_capacity(*cap, len + 1, initial);
+    return z_checked_reallocarray(items, *cap, item_size);
+  }
+  return items;
+}
+
+/* As z_grow_items, but also accounts the new allocation against an IrProgram's
+ * mir_bytes total. Replaces the verbatim copies in ir.c and program_graph_mir.c. */
+static inline void *ir_grow_tracked_items(IrProgram *ir, void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
+  if (len + 1 > *cap) {
+    size_t next_cap = z_grow_capacity(*cap, len + 1, initial);
+    void *next_items = z_checked_reallocarray(items, next_cap, item_size);
+    if (ir) ir->mir_bytes += next_cap * item_size;
+    *cap = next_cap;
+    return next_items;
+  }
+  return items;
+}
 Z_RET_OWNED char *z_strdup(Z_IN const char *text);
 Z_RET_OWNED char *z_strndup(Z_IN const char *text, size_t len);
 Z_RET_OWNED Z_RET_OPTIONAL char *z_read_file(Z_IN const char *path, Z_OUT ZDiag *diag);

--- a/native/zero-c/src/checker.c
+++ b/native/zero-c/src/checker.c
@@ -157,14 +157,6 @@ struct MetaCache {
 static const ZTargetInfo *configured_check_target = NULL;
 static MetaCache default_meta_cache = {0};
 
-static void *checker_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
-  if (len + 1 > *cap) {
-    *cap = z_grow_capacity(*cap, len + 1, initial);
-    return z_checked_reallocarray(items, *cap, item_size);
-  }
-  return items;
-}
-
 static const char *origin_path_text(const char *path) {
   return path ? path : "";
 }
@@ -338,7 +330,7 @@ static bool value_provenance_add_full_with_index_exact(ValueProvenance *origins,
       return true;
     }
   }
-  origins->items = checker_grow_items(origins->items, origins->len, &origins->cap, 4, sizeof(ProvenanceEntry));
+  origins->items = z_grow_items(origins->items, origins->len, &origins->cap, 4, sizeof(ProvenanceEntry));
   origins->items[origins->len] = (ProvenanceEntry){
     .value_path = path && path[0] ? z_strdup(path) : NULL,
     .origin = {
@@ -458,7 +450,7 @@ static bool place_vec_add(PlaceVec *places, const char *root, Scope *root_scope,
     Place *place = &places->items[i];
     if (strcmp(place->root, root) == 0 && place->root_scope == root_scope && origin_path_equal(place->path, path)) return true;
   }
-  places->items = checker_grow_items(places->items, places->len, &places->cap, 4, sizeof(Place));
+  places->items = z_grow_items(places->items, places->len, &places->cap, 4, sizeof(Place));
   places->items[places->len++] = (Place){
     .root = z_strdup(root),
     .root_scope = root_scope,
@@ -537,7 +529,7 @@ static void place_vec_clear_for_place(PlaceVec *places, Scope *root_scope, const
 
 static bool provenance_storage_effect_vec_add(ProvenanceStorageEffectVec *effects, const char *target_root, Scope *target_scope, const char *target_path, const ValueProvenance *value, bool overwrite) {
   if (!effects || !target_root || !target_root[0] || !value || value->len == 0) return false;
-  effects->items = checker_grow_items(effects->items, effects->len, &effects->cap, 4, sizeof(ProvenanceStorageEffect));
+  effects->items = z_grow_items(effects->items, effects->len, &effects->cap, 4, sizeof(ProvenanceStorageEffect));
   ProvenanceStorageEffect *effect = &effects->items[effects->len++];
   *effect = (ProvenanceStorageEffect){
     .target = {
@@ -1345,7 +1337,7 @@ static bool split_generic_args(const char *inner, size_t inner_len, char ***out_
         free(items);
         return false;
       }
-      items = checker_grow_items(items, len, &cap, 4, sizeof(char *));
+      items = z_grow_items(items, len, &cap, 4, sizeof(char *));
       items[len++] = z_strndup(inner + start, end - start);
       start = i + 1;
     }
@@ -10366,7 +10358,7 @@ static void collect_visible_type_names(Scope *scope, ParamVec *out) {
       bool type_param = cursor->is_type_param && cursor->is_type_param[i];
       if (!cursor->names[i] || (!type_param && !static_param)) continue;
       if (param_vec_contains_name(out, cursor->names[i])) continue;
-      out->items = checker_grow_items(out->items, out->len, &out->cap, 8, sizeof(Param));
+      out->items = z_grow_items(out->items, out->len, &out->cap, 8, sizeof(Param));
       out->items[out->len++] = (Param){
         .name = cursor->names[i],
         .type = static_param ? cursor->types[i] : "Type",

--- a/native/zero-c/src/ir.c
+++ b/native/zero-c/src/ir.c
@@ -23,27 +23,8 @@ static Expr *clone_expr(const Expr *expr);
 static Stmt *clone_stmt(const Stmt *stmt);
 static void push_function_clone(FunctionVec *vec, const Function *source);
 
-static void *ir_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
-  if (len + 1 > *cap) {
-    *cap = z_grow_capacity(*cap, len + 1, initial);
-    return z_checked_reallocarray(items, *cap, item_size);
-  }
-  return items;
-}
-
-static void *ir_grow_tracked_items(IrProgram *ir, void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
-  if (len + 1 > *cap) {
-    size_t next_cap = z_grow_capacity(*cap, len + 1, initial);
-    void *next_items = z_checked_reallocarray(items, next_cap, item_size);
-    if (ir) ir->mir_bytes += next_cap * item_size;
-    *cap = next_cap;
-    return next_items;
-  }
-  return items;
-}
-
 static void push_param_clone(ParamVec *vec, const Param *param) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
   vec->items[vec->len++] = (Param){
     .name = z_strdup(param->name),
     .type = param->type ? z_strdup(param->type) : NULL,
@@ -61,12 +42,12 @@ static ParamVec clone_params(const ParamVec *params) {
 }
 
 static void push_expr_clone(ExprVec *vec, const Expr *expr) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Expr *));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Expr *));
   vec->items[vec->len++] = clone_expr(expr);
 }
 
 static void push_type_arg_clone(TypeArgVec *vec, const TypeArg *arg) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeArg));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeArg));
   vec->items[vec->len++] = (TypeArg){
     .type = arg->type ? z_strdup(arg->type) : NULL,
     .line = arg->line,
@@ -75,7 +56,7 @@ static void push_type_arg_clone(TypeArgVec *vec, const TypeArg *arg) {
 }
 
 static void push_field_clone(FieldInitVec *vec, const FieldInit *field) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(FieldInit));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(FieldInit));
   vec->items[vec->len++] = (FieldInit){
     .name = z_strdup(field->name),
     .value = clone_expr(field->value),
@@ -107,7 +88,7 @@ static Expr *clone_expr(const Expr *expr) {
 }
 
 static void push_stmt_clone(StmtVec *vec, const Stmt *stmt) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Stmt *));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Stmt *));
   vec->items[vec->len++] = clone_stmt(stmt);
 }
 
@@ -118,7 +99,7 @@ static StmtVec clone_stmts(const StmtVec *stmts) {
 }
 
 static void push_match_arm_clone(MatchArmVec *vec, const MatchArm *arm) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(MatchArm));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(MatchArm));
   vec->items[vec->len++] = (MatchArm){
     .case_name = z_strdup(arm->case_name),
     .range_end = arm->range_end ? z_strdup(arm->range_end) : NULL,
@@ -338,7 +319,7 @@ static void ir_type_arg_vec_free(TypeArgVec *args) {
 }
 
 static void ir_type_arg_vec_push_owned(TypeArgVec *args, char *type) {
-  args->items = ir_grow_items(args->items, args->len, &args->cap, 4, sizeof(TypeArg));
+  args->items = z_grow_items(args->items, args->len, &args->cap, 4, sizeof(TypeArg));
   args->items[args->len++] = (TypeArg){.type = type};
 }
 
@@ -851,7 +832,7 @@ static void ir_active_local_restore(IrProgram *ir, size_t mark) {
 
 static void ir_active_local_push(IrProgram *ir, const char *name) {
   if (!ir || !name) return;
-  ir->active_local_names = ir_grow_items(ir->active_local_names, ir->active_local_len, &ir->active_local_cap, 8, sizeof(char *));
+  ir->active_local_names = z_grow_items(ir->active_local_names, ir->active_local_len, &ir->active_local_cap, 8, sizeof(char *));
   ir->active_local_names[ir->active_local_len++] = z_strdup(name);
 }
 
@@ -5334,7 +5315,7 @@ static void ir_lower_direct_backend_subset(IrProgram *ir, const Program *program
 }
 
 static void push_function_clone(FunctionVec *vec, const Function *source) {
-  vec->items = ir_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Function));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Function));
   vec->items[vec->len++] = (Function){
     .name = z_strdup(source->name),
     .test_name = source->test_name ? z_strdup(source->test_name) : NULL,
@@ -5358,7 +5339,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   ir.target = target;
   for (size_t i = 0; i < program->c_imports.len; i++) {
     CImport *source = &program->c_imports.items[i];
-    ir.program.c_imports.items = ir_grow_items(ir.program.c_imports.items, ir.program.c_imports.len, &ir.program.c_imports.cap, 4, sizeof(CImport));
+    ir.program.c_imports.items = z_grow_items(ir.program.c_imports.items, ir.program.c_imports.len, &ir.program.c_imports.cap, 4, sizeof(CImport));
     ir.program.c_imports.items[ir.program.c_imports.len++] = (CImport){
       .header = source->header ? z_strdup(source->header) : NULL,
       .resolved_header = source->resolved_header ? z_strdup(source->resolved_header) : NULL,
@@ -5369,7 +5350,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->consts.len; i++) {
     ConstDecl *source = &program->consts.items[i];
-    ir.program.consts.items = ir_grow_items(ir.program.consts.items, ir.program.consts.len, &ir.program.consts.cap, 4, sizeof(ConstDecl));
+    ir.program.consts.items = z_grow_items(ir.program.consts.items, ir.program.consts.len, &ir.program.consts.cap, 4, sizeof(ConstDecl));
     ir.program.consts.items[ir.program.consts.len++] = (ConstDecl){
       .name = z_strdup(source->name),
       .type = source->type ? z_strdup(source->type) : NULL,
@@ -5381,7 +5362,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->aliases.len; i++) {
     TypeAlias *source = &program->aliases.items[i];
-    ir.program.aliases.items = ir_grow_items(ir.program.aliases.items, ir.program.aliases.len, &ir.program.aliases.cap, 4, sizeof(TypeAlias));
+    ir.program.aliases.items = z_grow_items(ir.program.aliases.items, ir.program.aliases.len, &ir.program.aliases.cap, 4, sizeof(TypeAlias));
     ir.program.aliases.items[ir.program.aliases.len++] = (TypeAlias){
       .name = z_strdup(source->name),
       .target = source->target ? z_strdup(source->target) : NULL,
@@ -5392,7 +5373,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->interfaces.len; i++) {
     InterfaceDecl *source = &program->interfaces.items[i];
-    ir.program.interfaces.items = ir_grow_items(ir.program.interfaces.items, ir.program.interfaces.len, &ir.program.interfaces.cap, 4, sizeof(InterfaceDecl));
+    ir.program.interfaces.items = z_grow_items(ir.program.interfaces.items, ir.program.interfaces.len, &ir.program.interfaces.cap, 4, sizeof(InterfaceDecl));
     InterfaceDecl cloned = {
       .name = z_strdup(source->name),
       .type_params = clone_params(&source->type_params),
@@ -5407,7 +5388,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->shapes.len; i++) {
     Shape *source = &program->shapes.items[i];
-    ir.program.shapes.items = ir_grow_items(ir.program.shapes.items, ir.program.shapes.len, &ir.program.shapes.cap, 4, sizeof(Shape));
+    ir.program.shapes.items = z_grow_items(ir.program.shapes.items, ir.program.shapes.len, &ir.program.shapes.cap, 4, sizeof(Shape));
     Shape cloned = {
       .name = z_strdup(source->name),
       .layout = z_strdup(source->layout),
@@ -5424,7 +5405,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->enums.len; i++) {
     EnumDecl *source = &program->enums.items[i];
-    ir.program.enums.items = ir_grow_items(ir.program.enums.items, ir.program.enums.len, &ir.program.enums.cap, 4, sizeof(EnumDecl));
+    ir.program.enums.items = z_grow_items(ir.program.enums.items, ir.program.enums.len, &ir.program.enums.cap, 4, sizeof(EnumDecl));
     ir.program.enums.items[ir.program.enums.len++] = (EnumDecl){
       .name = z_strdup(source->name),
       .type = source->type ? z_strdup(source->type) : NULL,
@@ -5436,7 +5417,7 @@ IrProgram z_lower_program_with_source(const Program *program, const SourceInput 
   }
   for (size_t i = 0; i < program->choices.len; i++) {
     Choice *source = &program->choices.items[i];
-    ir.program.choices.items = ir_grow_items(ir.program.choices.items, ir.program.choices.len, &ir.program.choices.cap, 4, sizeof(Choice));
+    ir.program.choices.items = z_grow_items(ir.program.choices.items, ir.program.choices.len, &ir.program.choices.cap, 4, sizeof(Choice));
     ir.program.choices.items[ir.program.choices.len++] = (Choice){
       .name = z_strdup(source->name),
       .cases = clone_params(&source->cases),

--- a/native/zero-c/src/program_graph_lower.c
+++ b/native/zero-c/src/program_graph_lower.c
@@ -23,86 +23,78 @@ typedef struct {
   bool preserve_graph_types;
 } GraphLower;
 
-static void *lower_grow_items(void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
-  if (len + 1 > *cap) {
-    *cap = z_grow_capacity(*cap, len + 1, initial);
-    return z_checked_reallocarray(items, *cap, item_size);
-  }
-  return items;
-}
-
 static void lower_push_function(FunctionVec *vec, Function item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Function));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Function));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_stmt(StmtVec *vec, Stmt *item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Stmt *));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 8, sizeof(Stmt *));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_expr(ExprVec *vec, Expr *item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Expr *));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Expr *));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_type_arg(TypeArgVec *vec, TypeArg item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeArg));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeArg));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_field(FieldInitVec *vec, FieldInit item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(FieldInit));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(FieldInit));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_param(ParamVec *vec, Param item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Param));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_use(UseImportVec *vec, UseImport item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(UseImport));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(UseImport));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_c_import(CImportVec *vec, CImport item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(CImport));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(CImport));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_const(ConstVec *vec, ConstDecl item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(ConstDecl));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(ConstDecl));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_alias(TypeAliasVec *vec, TypeAlias item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeAlias));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(TypeAlias));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_shape(ShapeVec *vec, Shape item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Shape));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Shape));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_interface(InterfaceVec *vec, InterfaceDecl item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(InterfaceDecl));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(InterfaceDecl));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_enum(EnumVec *vec, EnumDecl item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(EnumDecl));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(EnumDecl));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_choice(ChoiceVec *vec, Choice item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Choice));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(Choice));
   vec->items[vec->len++] = item;
 }
 
 static void lower_push_match_arm(MatchArmVec *vec, MatchArm item) {
-  vec->items = lower_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(MatchArm));
+  vec->items = z_grow_items(vec->items, vec->len, &vec->cap, 4, sizeof(MatchArm));
   vec->items[vec->len++] = item;
 }
 

--- a/native/zero-c/src/program_graph_mir.c
+++ b/native/zero-c/src/program_graph_mir.c
@@ -19,16 +19,6 @@
 #include <sys/time.h>
 enum { IR_READONLY_DATA_BASE = 1024u, IR_READONLY_DATA_LIMIT = 65536u };
 
-static void *ir_grow_tracked_items(IrProgram *ir, void *items, size_t len, size_t *cap, size_t initial, size_t item_size) {
-  if (len + 1 > *cap) {
-    size_t next_cap = z_grow_capacity(*cap, len + 1, initial);
-    void *next_items = z_checked_reallocarray(items, next_cap, item_size);
-    if (ir) ir->mir_bytes += next_cap * item_size;
-    *cap = next_cap;
-    return next_items;
-  }
-  return items;
-}
 static IrTypeKind ir_type_kind(const char *type);
 static bool ir_text_eq(const char *left, const char *right) {
   return strcmp(left ? left : "", right ? right : "") == 0;


### PR DESCRIPTION
## Summary

Fixes #390.

The same dynamic-array grow helper was duplicated across four files in
`native/zero-c/src`:

- `ir_grow_items` (`ir.c`), `lower_grow_items` (`program_graph_lower.c`), and
  `checker_grow_items` (`checker.c`) shared an **identical** body.
- `ir_grow_tracked_items` (the variant that also accounts `ir->mir_bytes`) was
  defined **verbatim** in both `ir.c` and `program_graph_mir.c`.

As the issue notes, the duplicated `mir_bytes` accounting can silently diverge
if one copy is edited without the others.

## Change

Hoist both helpers into `include/zero.h` as shared `static inline` functions
(`z_grow_items` and `ir_grow_tracked_items`), placed right after the
`IrProgram` definition so the tracked variant can reference `ir->mir_bytes`.
The five local definitions are removed and their call sites repointed at the
shared helpers.

Pure refactor — the helper bodies are byte-for-byte the originals, so there is
no behavior change. Net `+61 / -81` lines across 5 files.

## Validation

- `make -C native/zero-c` builds **clean** under `-Wall -Wextra -Wpedantic`.
- Host-target end-to-end works: `zero build --emit exe --target linux-x64`
  on `conformance/run/pass/hello.graph` produces an exe that runs and prints
  the expected output.
- All `conformance/check/pass/*.graph` fixtures pass `zero check` (this is the
  path that exercises the modified `checker.c` and `ir.c` lowering).

> Transparency per `AGENTS.md`: I developed this on Linux (Ubuntu via WSL) where
> the `linux-x64` host target is fully runnable, but `pnpm run agent:checks`
> could not complete because the `linux-musl-x64` build steps require a
> musl-capable C compiler that isn't installed in my environment. That step
> fails **identically on a clean checkout** (`BLD003: cross target
> 'linux-musl-x64' requires a target-capable C compiler ... install the
> bundled-toolchain default`), so it is pre-existing and unrelated to this
> change. CI (with the musl toolchain) should exercise the full matrix.
