### PR TITLE
Prepare v0.3.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,23 @@
 # Changelog
 
-## 0.3.2
+## 0.3.3
 
 <!-- release:start -->
+
+- Makes package graph stores refresh from edited projections across compiler commands, classifies source/store sync by content instead of mtimes, and gives stale, diverged, and ambiguous reconcile states deterministic diagnostics and repairs.
+- Improves agent-facing inspection and edit loops with scoped `zero query` output, `zero view --fn`, `zero diff --fn`, `zero patch --replace-fn --body-file`, focused command help, and smaller version-matched skill topics with section-scoped stdlib fetches.
+- Expands standard-library coverage with `std.regex`, `std.inet`, `std.unicode`, and RFC 3339 helpers in `std.time`, including docs, skill references, and runtime conformance fixtures.
+- Hardens direct backend correctness for shape references, large stack frames, fallible `Void` mains, file reads, trap stderr, top-level consts, null `Maybe` locals, fixed-array lengths, and untyped integer literal adoption.
+- Speeds up large graph workflows with indexed reconciliation, stdlib merges, projection validation caches, graph lowering indexes, and borrow-contract scans while preserving deterministic graph hashes and artifacts.
+- Adds graph-store diagnostic codes and complete `zero explain` coverage, buildability gating for unsupported checked constructs, example package gates, sanitizer smoke, package build determinism contracts, and git build hashes in `zero --version`.
+
+### Contributors
+
+- @ctate
+
+<!-- release:end -->
+
+## 0.3.2
 
 - Adds `break` and `continue` support to the direct backend and `zero test`, lowering both through typed MIR and all direct emitters with conformance coverage and required runtime checks.
 - Speeds up graph validation with indexed node-hash tables, a reusable adjacency index, and deduplicated store validation, making `zero import` on large programs roughly 12x faster.
@@ -10,8 +25,6 @@
 ### Contributors
 
 - @ctate
-
-<!-- release:end -->
 
 ## 0.3.1
 

--- a/conformance/run.mjs
+++ b/conformance/run.mjs
@@ -4749,7 +4749,7 @@ assert.equal(depGraphBody.package.resolver.deterministic, true);
 assert.match(depGraphBody.package.lockfile.path, /\.zero\/package-locks\/[0-9a-f]+\.lock\.json/);
 assert(depGraphBody.package.dependencies.some((item) => item.name === "dep-lib" && item.status === "path-resolved" && item.targetCompatible === true));
 assert(depGraphBody.package.dependencies.some((item) => item.name === "remote-tools" && item.status === "registry-reference" && item.version === "1.2.3"));
-assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.3.2");
+assert.equal(depGraphBody.packageCache.cacheKeyInputs.compilerVersion, "0.3.3");
 assert.equal(depGraphBody.packageCache.cacheKeyInputs.packageVersion, "0.1.0");
 assert.match(depGraphBody.packageCache.cacheKeyInputs.dependencyGraphHash, /^[0-9a-f]{16}$/);
 const depDoc = await execFileAsync(zero, ["doc", "--json", "conformance/packages/dep-app"]);

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-docs",
   "private": true,
-  "version": "0.3.2",
+  "version": "0.3.3",
   "type": "module",
   "packageManager": "pnpm@11.1.3",
   "engines": {

--- a/extensions/vscode/package.json
+++ b/extensions/vscode/package.json
@@ -3,7 +3,7 @@
   "displayName": "Zero Language",
   "description": "Syntax highlighting for the Zero programming language.",
   "publisher": "zero-lang",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "type": "module",
   "categories": [

--- a/native/zero-c/include/zero.h
+++ b/native/zero-c/include/zero.h
@@ -6,7 +6,7 @@
 
 #include "zero_contracts.h"
 
-#define ZERO_VERSION "0.3.2"
+#define ZERO_VERSION "0.3.3"
 
 #ifndef ZERO_BUILD_HASH
 #define ZERO_BUILD_HASH "unknown"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "zero-lang-workspace",
   "description": "Workspace for the Zero language docs, native compiler, examples, and editor tooling.",
-  "version": "0.3.2",
+  "version": "0.3.3",
   "private": true,
   "license": "Apache-2.0",
   "packageManager": "pnpm@11.1.3",

--- a/scripts/snapshot-command-contracts.mts
+++ b/scripts/snapshot-command-contracts.mts
@@ -884,11 +884,11 @@ function directExeEmitterForTarget(target: string) {
 
 const generatedCBytesBeforeReadOnlyCommands = json(["size", "--json", "examples/memory-package"]).body.generatedCBytes;
 
-assert.match(zero(["--version"]).stdout, /^zero 0\.3\.2 \(build (?:[0-9a-f]{7,40}|unknown)\)\n$/);
+assert.match(zero(["--version"]).stdout, /^zero 0\.3\.3 \(build (?:[0-9a-f]{7,40}|unknown)\)\n$/);
 
 const version = json(["--version", "--json"]).body;
 assert.equal(version.schemaVersion, 1);
-assert.equal(version.version, "0.3.2");
+assert.equal(version.version, "0.3.3");
 assert.match(version.commit, /^(?:[0-9a-f]{7,40}|unknown)$/);
 assert.equal(version.backend, "zero-c");
 assert.equal(typeof version.host, "string");
@@ -6977,7 +6977,7 @@ assert.equal(depDoc.package.name, "dep-app");
 assert.equal(depDoc.publicationGate.requiresExamplesForPublicApi, true);
 const depBuild = json(["build", "--json", "--target", "linux-musl-x64", "conformance/packages/dep-app", "--out", join(outDir, "dep-app")]).body;
 assert.equal(depBuild.packageCache.invalidationReasons.includes("dependency graph changed"), true);
-assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.3.2" && item.packageVersion === "0.1.0"), true);
+assert.equal(depBuild.compilerCaches.every((item) => item.compilerVersion === "0.3.3" && item.packageVersion === "0.1.0"), true);
 const depDevTrace = json(["dev", "--json", "--trace", "--target", "linux-musl-x64", "conformance/packages/dep-app"]).body;
 assert.equal(depDevTrace.trace.requested, true);
 assert.equal(depDevTrace.partialDiagnostics.stable, true);

--- a/tests/zero-cli.test.ts
+++ b/tests/zero-cli.test.ts
@@ -62,7 +62,7 @@ async function collectSkillMdFiles(dir: string): Promise<string[]> {
 
 describe("native zero CLI", () => {
   it("prints a terse plain version with the build hash", async () => {
-    const versionPattern = /^zero 0\.3\.2 \(build (?:[0-9a-f]{7,40}|unknown)\)\n$/;
+    const versionPattern = /^zero 0\.3\.3 \(build (?:[0-9a-f]{7,40}|unknown)\)\n$/;
     assert.match((await runZero(["--version"])).stdout, versionPattern);
     assert.match((await runNativeZero(["--version"])).stdout, versionPattern);
   });


### PR DESCRIPTION
- Bump package, extension, and native compiler versions to 0.3.3.
- Move release markers to the v0.3.3 changelog entry.
- Align command-contract, conformance, and CLI test version expectations.