### PR TITLE
Use local zero wrapper in install docs

### DIFF
--- a/docs/articles/install.md
+++ b/docs/articles/install.md
@@ -51,7 +51,7 @@ then use the checkout's `zero` binary for experiments:
 ```sh
 pnpm install
 make -C native/zero-c
-zero --version
+bin/zero --version
 ```
 
 The repository contributor notes cover checkout-specific wrapper commands.


### PR DESCRIPTION
## Summary

- Update the repository checkout install docs to use `bin/zero --version` after building the local compiler.
- Keep the command aligned with the README and contributor notes so checkout users verify the compiler from the repo instead of any `zero` already on `PATH`.

## Validation

- `pnpm run docs:build`
